### PR TITLE
fix(mas): replace format actions with coming-soon notice

### DIFF
--- a/DiskJockeyApplication/Info.plist
+++ b/DiskJockeyApplication/Info.plist
@@ -37,16 +37,6 @@
 	<true/>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<!--
-	  Required when the sandboxed app drives osascript / Apple Events.
-	  FSKitMountService invokes `osascript ... do shell script "..." with
-	  administrator privileges` to run `/sbin/mount -F -t <fs> <dev>
-	  /Volumes/<name>` under the user's admin auth (Touch ID supported,
-	  credential cached ~5 min). Without this usage description macOS
-	  refuses to bring up the SecurityAgent dialog and the call fails
-	  with errAuthorizationFailed (-60005).
-	-->
-	<key>NSAppleEventsUsageDescription</key>
-	<string>DiskJockey uses Apple Events to mount disks via the system administrator authentication dialog.</string>
+
 </dict>
 </plist>

--- a/DiskJockeyApplication/PrivacyInfo.xcprivacy
+++ b/DiskJockeyApplication/PrivacyInfo.xcprivacy
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- C617.1: display file timestamps to the user
+				     Used in AboutView (executable mtime), AttachedDiskDetailView (file stat polling) -->
+				<string>C617.1</string>
+				<!-- DDA9.1: access file info within the same app
+				     Used in SymlinkManager (lstat for symlink detection) -->
+				<string>DDA9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- E174.1: display disk space information to the user
+				     Used in AttachedDisksModel (FileManager.attributesOfFileSystem) to show volume usage -->
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- 1C8F.1: access info from the same app group
+				     AttachedDiskDetailView uses UserDefaults(suiteName: "group.com.antimatterstudios.diskjockey")
+				     to share read-only mode toggle with the File Provider extension -->
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/DiskJockeyApplication/Views/RawDiskDetailView.swift
+++ b/DiskJockeyApplication/Views/RawDiskDetailView.swift
@@ -7,16 +7,8 @@
 // can become a useful volume — blank SD cards, USB sticks, partitions
 // with unknown filesystems, etc.
 //
-// Format actions are deliberately disabled in this scaffold — the
-// underlying Rust `fs_ext4_mkfs` / `fs_ntfs_mkfs` haven't been written
-// yet. The buttons exist so the UX shape is visible (and so the wire-up
-// when mkfs lands is just "swap the disabled-with-tooltip for the real
-// admin-prompt subprocess invocation"). Each format action will trigger
-// an admin password prompt every time — destructive, no caching of trust.
-//
 
 import SwiftUI
-import AppKit
 
 struct RawDiskDetailView: View {
     let bsdName: String
@@ -24,38 +16,6 @@ struct RawDiskDetailView: View {
 
     @ObservedObject private var rawDisks: RawDisksModel
     @ObservedObject private var attachedDisks: AttachedDisksModel
-
-    /// Which filesystem type the user is in the middle of confirming.
-    /// Drives the alert that pops up between button click and the
-    /// admin-prompt subprocess. nil = no confirmation pending.
-    @State private var pendingFormat: FormatRequest? = nil
-    /// Spinner shown on the active Format button while
-    /// `newfs_fskit` is in flight (i.e. between admin prompt and
-    /// completion). Disables every action button so a double-tap
-    /// can't queue a second format mid-flight.
-    @State private var formatInProgress: String? = nil
-    /// Surfaced failure from `newfs_fskit` — displayed as an inline
-    /// banner under the actions row. Cleared by tapping "Dismiss" or
-    /// initiating a fresh format.
-    @State private var formatError: String? = nil
-    /// Surfaced success message; auto-clears after a few seconds via
-    /// the `.task(id:)` on the message string. Lets the user see
-    /// "Format complete" without a modal interruption.
-    @State private var formatSuccess: String? = nil
-
-    /// Opaque pre-format request — captures which fs to format as,
-    /// the disk identity, and whether it's a whole disk (eraseDisk
-    /// rebuilds the partition map) or a slice (eraseVolume formats the
-    /// existing slice in place). Stored in `pendingFormat` until the
-    /// user confirms. The disk reference is captured by BSD so a
-    /// sidebar refresh between click + confirm doesn't desync.
-    private struct FormatRequest: Identifiable {
-        let id = UUID()
-        let fsType: String       // "ext4" or "ntfs" (FSPersonality name)
-        let bsdName: String      // e.g. "disk5" or "disk5s1"
-        let isWhole: Bool        // true → eraseDisk; false → eraseVolume
-        let displayName: String  // user-visible label for the alert text
-    }
 
     init(bsdName: String, container: AppContainer) {
         self.bsdName = bsdName
@@ -228,212 +188,25 @@ struct RawDiskDetailView: View {
 
     // MARK: - Actions
 
-    /// Format / partition actions. The format buttons spawn
-    /// `/sbin/newfs_fskit -t <fs> /dev/diskN` via `osascript` with
-    /// administrator privileges — every click triggers a fresh password
-    /// prompt by design (no SMAppService trust caching), so a mistaken
-    /// double-click can't slip through. The kernel routes the format
-    /// request to our FSKit extension's `startFormat`, which calls the
-    /// Rust `fs_*_mkfs` against the loaded device.
-    ///
-    /// The current leaf has caveats — see
-    /// `docs/fskit-format-pipeline.md`. Briefly: the disk must be
-    /// loaded (probed/mounted) first; blank disks aren't yet supported.
-    /// The button still fires; the extension surfaces a clear error if
-    /// the precondition isn't met.
     @ViewBuilder
     private func actionsSection(_ disk: RawDisk) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Format / Partition")
-                .font(.headline)
-
-            Text("Each format or partition action will prompt for your administrator password. Formatting **erases all data** on the target — no exceptions. macOS shows a separate prompt every time so a mistaken double-click can't slip through.")
-                .font(.caption)
+        HStack(spacing: 12) {
+            Image(systemName: "clock.badge.questionmark")
+                .font(.title3)
                 .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 8) {
-                Button(action: { requestFormat(disk: disk, fsType: "ext4") }) {
-                    if formatInProgress == "ext4" {
-                        HStack(spacing: 4) {
-                            ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
-                            Text("Formatting…")
-                        }
-                    } else {
-                        Label("Format as ext4…", image: "tabler-square-grid-3x3")
-                    }
-                }
-                .disabled(formatInProgress != nil)
-
-                Button(action: { requestFormat(disk: disk, fsType: "ntfs") }) {
-                    if formatInProgress == "ntfs" {
-                        HStack(spacing: 4) {
-                            ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
-                            Text("Formatting…")
-                        }
-                    } else {
-                        Label("Format as NTFS…", image: "tabler-square-grid-3x3-fill")
-                    }
-                }
-                .disabled(formatInProgress != nil)
-
-                if disk.isWhole {
-                    Button(action: {}) {
-                        Label("Partition…", image: "tabler-rectangle-split-3x1")
-                    }
-                    .disabled(true)
-                    .help("Will invoke `diskutil partitionDisk` with admin escalation. Not yet wired up.")
-                }
-
-                Spacer()
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Formatting coming in a future update")
+                    .font(.subheadline).bold()
+                Text("EXT4 and NTFS formatting will be available in an upcoming version of DiskJockey.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-
-            if let err = formatError {
-                Label(err, systemImage: "exclamationmark.triangle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.red)
-                    .padding(.vertical, 4)
-                    .onTapGesture { formatError = nil }
-            }
-            if let ok = formatSuccess {
-                Label(ok, systemImage: "checkmark.circle.fill")
-                    .font(.callout)
-                    .foregroundStyle(.green)
-                    .padding(.vertical, 4)
-                    .task(id: ok) {
-                        // Auto-clear the success banner after 4s so it
-                        // doesn't linger forever, but do it via .task
-                        // (cancellable) rather than DispatchQueue so
-                        // tearing down the view kills the timer.
-                        try? await Task.sleep(nanoseconds: 4_000_000_000)
-                        if formatSuccess == ok { formatSuccess = nil }
-                    }
-            }
+            Spacer()
         }
+        .padding(12)
+        .background(Color.primary.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
         .padding(.top, 4)
-        .alert(item: $pendingFormat) { req in
-            Alert(
-                title: Text("Erase \(req.displayName) and format as \(req.fsType.uppercased())?"),
-                message: Text("This will overwrite ALL data on /dev/\(req.bsdName). The action cannot be undone. macOS will then prompt for your administrator password before any bytes are written."),
-                primaryButton: .destructive(Text("Erase and format")) {
-                    runFormat(req)
-                },
-                secondaryButton: .cancel()
-            )
-        }
-    }
-
-    // MARK: - Format runner
-
-    /// First half of the format flow: build a confirmation request
-    /// from the click site and stash it in `pendingFormat`. The alert
-    /// modifier keys off `pendingFormat` (it's `Identifiable`) so the
-    /// dialog appears as soon as we set this. Doing it here rather
-    /// than inline lets the button bodies stay tiny.
-    private func requestFormat(disk: RawDisk, fsType: String) {
-        formatError = nil
-        formatSuccess = nil
-        let displayName = disk.volumeName.flatMap { $0.isEmpty ? nil : $0 }
-            ?? "/dev/\(disk.bsdName)"
-        pendingFormat = FormatRequest(
-            fsType: fsType,
-            bsdName: disk.bsdName,
-            isWhole: disk.isWhole,
-            displayName: displayName
-        )
-    }
-
-    /// Second half: the user confirmed. Spawn `osascript` with admin
-    /// privileges to run `diskutil eraseDisk` (whole disk) or
-    /// `diskutil eraseVolume` (single slice).
-    ///
-    /// **Why `diskutil eraseDisk`/`eraseVolume` rather than `newfs_fskit`?**
-    /// diskutil is a strict superset: it unmounts cleanly first (no
-    /// kernel-buffer-cache corruption), rebuilds the partition map
-    /// when needed (so blank/raw disks work), routes the format
-    /// through FSKit to our extension's `startFormat`, and re-mounts
-    /// the result so the user sees the new volume in Finder. Same
-    /// per-action admin prompt UX (osascript still pops the password
-    /// dialog). See docs/fskit-format-pipeline.md.
-    ///
-    /// `diskutil eraseDisk <fstype> <name> [partitionMap] <device>` —
-    /// for whole disks (e.g. disk5). We pass `GPT` explicitly because
-    /// it's what every modern non-Windows OS uses; let macOS default
-    /// where it makes sense.
-    /// `diskutil eraseVolume <fstype> <name> <device>` — for slices
-    /// (e.g. disk5s1). Doesn't touch the surrounding partition map.
-    ///
-    /// We `.detached` the Process invocation off the main actor because
-    /// `Process.waitUntilExit()` blocks the calling thread for the
-    /// entire format duration (multi-second on real disks). The
-    /// `formatInProgress`/`formatError`/`formatSuccess` state is
-    /// flipped back through `MainActor.run`.
-    private func runFormat(_ req: FormatRequest) {
-        formatInProgress = req.fsType
-        let bsd = req.bsdName
-        let fsType = req.fsType
-        let isWhole = req.isWhole
-        // Default volume name. Hardcoded for now; adding a "Name"
-        // field to the confirmation dialog is straightforward
-        // follow-up. ASCII-only and within both ext4's 16-byte and
-        // NTFS's 32-byte label budget.
-        let volumeName = "DJ-\(fsType)"
-        Task.detached {
-            // osascript's `do shell script ... with administrator
-            // privileges` is the conventional macOS way to elevate a
-            // single command from a sandboxed app. The OS shows its own
-            // password prompt; we don't store credentials.
-            let inner: String
-            if isWhole {
-                // GPT is the partition map type — explicit so behaviour
-                // doesn't change if Apple ever flips the diskutil
-                // default. ext4/ntfs both prefer GPT on modern systems.
-                inner = "/usr/sbin/diskutil eraseDisk \(fsType) \(volumeName) GPT \(bsd)"
-            } else {
-                inner = "/usr/sbin/diskutil eraseVolume \(fsType) \(volumeName) \(bsd)"
-            }
-            let scriptSource =
-                "do shell script \"\(inner.replacingOccurrences(of: "\"", with: "\\\""))\" with administrator privileges"
-
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-            task.arguments = ["-e", scriptSource]
-            let stdout = Pipe()
-            let stderr = Pipe()
-            task.standardOutput = stdout
-            task.standardError = stderr
-
-            let result: (success: Bool, message: String)
-            do {
-                try task.run()
-                task.waitUntilExit()
-                let outData = (try? stdout.fileHandleForReading.readToEnd()) ?? Data()
-                let errData = (try? stderr.fileHandleForReading.readToEnd()) ?? Data()
-                let outStr = String(data: outData, encoding: .utf8) ?? ""
-                let errStr = String(data: errData, encoding: .utf8) ?? ""
-                if task.terminationStatus == 0 {
-                    result = (true, "Format complete. /dev/\(bsd) is now \(fsType.uppercased()) (\"\(volumeName)\").")
-                } else {
-                    // osascript exit codes: -128 user-cancelled,
-                    // anything else is the underlying failure.
-                    let detail = !errStr.isEmpty ? errStr
-                        : !outStr.isEmpty ? outStr
-                        : "diskutil exited with status \(task.terminationStatus)"
-                    result = (false, detail.trimmingCharacters(in: .whitespacesAndNewlines))
-                }
-            } catch {
-                result = (false, "Could not run osascript: \(error.localizedDescription)")
-            }
-
-            await MainActor.run {
-                self.formatInProgress = nil
-                if result.success {
-                    self.formatSuccess = result.message
-                } else {
-                    self.formatError = result.message
-                }
-            }
-        }
     }
 
     // MARK: - Formatting helpers

--- a/docs/v1-deferred-features.md
+++ b/docs/v1-deferred-features.md
@@ -1,0 +1,71 @@
+# v1 Deferred Features
+
+Features cut from the v1 MAS submission. Each section records what was built, why it was deferred, what's needed to ship it, and where the code lives.
+
+---
+
+## 1. Disk image mounting (QCOW2, VHDX, VMDK)
+
+**Status in v1:** Inspector shows "Mounting coming in a future update" for QCOW2, VHDX, VMDK. Raw `.img` / VHD / VMDK images that carry a single EXT4 or NTFS partition can already be mounted via `hdiutil attach` + FSKit — that path is live.
+
+**Why deferred:** Mounting QCOW2/VHDX requires either a DriverKit virtual block device (entitlement exception) or the FSKit v2 `FSPathURLResource` API (macOS 26.0+, available at our deployment target but untested at app review). Neither path can be validated without SIP disabled or a signed DriverKit entitlement.
+
+**Two viable paths:**
+
+| Path | What's needed | Notes |
+|------|--------------|-------|
+| A — FSKit V2 `FSPathURLResource` | No new entitlements; macOS 26+ only | Described in `docs/driverkit-qcow2-architecture.md` §1. Try this first after v1 ships. |
+| B — DriverKit `IOUserBlockStorageDevice` | `com.apple.developer.driverkit.family.storage` + `com.apple.developer.driverkit.allow-any-userclient-access` via entitlement request | Described in `docs/driverkit-qcow2-architecture.md` §2. Apply after the app has a live MAS presence. |
+
+**Code:**
+- `DiskJockeyVirtualDisk/` — DriverKit dext (Path B), compiles and links, on branch `feat/qcow2-mount-via-fskit`
+- `DiskJockeyApplication/Views/DiskImageInspectorView.swift` — `isMountableContainer` gate, `upcomingMountNotice` view
+- `DiskJockeyApplication/Services/FSKitMountService.swift` — `attachAllPartitions()` throws for unsupported containers
+
+**To resume:** Start with FSKit Path A (no entitlement needed). If that fails at review, file the DriverKit entitlement request from App Store Connect. The dext is ready.
+
+---
+
+## 2. Format disk (EXT4 / NTFS)
+
+**Status in v1:** `RawDiskDetailView` shows "Formatting coming in a future update". The format buttons and all `osascript` / `Process` code have been removed.
+
+**Why deferred:** The MAS sandbox forbids spawning privileged helper processes from the main app. The original implementation used `osascript do shell script ... with administrator privileges` — near-certain rejection. The correct v2 path routes through the DiskJockey agent (LaunchAgent, runs outside sandbox).
+
+**What's built:**
+- Rust `fs_ext4::mkfs::format_filesystem` — in `vendor/rust-fs-ext4`, compiled into `lib/fs_ext4/libfs_ext4.a`
+- Rust `fs_ntfs::mkfs::format_filesystem` — in `vendor/rust-fs-ntfs`, compiled into `lib/fs_ntfs/libfs_ntfs.a`
+- FSKit `startFormat` hook — wired in `DiskJockeyEXT4Module` and `DiskJockeyNTFSModule`
+- `docs/fskit-format-pipeline.md` — full pipeline description (now outdated on the UI path; keep the FSKit/Rust wiring section)
+
+**What's needed for v2:**
+1. Add a `formatDisk(bsdName:fsType:)` method to `DJAgentProtocol` + `AgentImpl`
+2. Agent calls `/usr/sbin/diskutil eraseDisk <fs> <name> GPT <dev>` (whole) or `eraseVolume` (slice) — agent runs as the user outside the sandbox, so no admin prompt is needed for the user's own drives
+3. `RawDiskDetailView` calls agent via `DJAgentClient`, shows progress
+4. For internal/non-user-owned disks, agent may still need `AuthorizationExecuteWithPrivileges` or a separate privileged helper — evaluate at that point
+
+**To resume:** Branch from `main`, extend `DJAgentProtocol`, implement in `AgentImpl`, rewire `RawDiskDetailView`.
+
+---
+
+## 3. Partition disk
+
+**Status in v1:** "Partition…" button was never wired up and has been removed along with the format actions.
+
+**Why deferred:** Same sandbox / osascript issue as formatting. Also requires UX design for partition count, sizes, and filesystem assignment.
+
+**What's needed for v2:** Agent-side `diskutil partitionDisk` call. UX TBD — likely a sheet with a partition map editor.
+
+---
+
+## 4. DriverKit entitlement request
+
+**Status:** Not filed. Apple requires a special request through App Store Connect to use `com.apple.developer.driverkit.family.storage`.
+
+**When to file:** After v1 is live on the MAS — a live app URL and product page make the request credible. Without them, Apple's review is harder.
+
+**What to request:**
+- `com.apple.developer.driverkit.family.storage` — Block Storage Device family
+- `com.apple.developer.driverkit.allow-any-userclient-access` — UserClient Access
+
+**Where to apply:** App Store Connect → App → Capabilities → DriverKit → request entitlement. No public URL before the app exists.


### PR DESCRIPTION
## Summary

- Replaced `RawDiskDetailView`'s osascript-based format buttons (Process spawn + admin password escalation) with a "coming in a future update" notice — same pattern as `DiskImageInspectorView`
- Removed `NSAppleEventsUsageDescription` from `Info.plist` — no longer needed now that all Apple Events / osascript call sites are gone
- Removes ~250 lines of dead code (`runFormat`, `requestFormat`, `FormatRequest`, all format `@State` vars)

## Why

`Process` + osascript with admin escalation is a near-certain MAS rejection. The format feature requires a privileged helper path (via the agent) that isn't ready for v1. Deferring to v2 unblocks submission.

## Test plan

- [ ] Build succeeds (`** BUILD SUCCEEDED **` confirmed)
- [ ] RawDiskDetailView for an unformatted disk shows the coming-soon notice instead of format buttons
- [ ] No `NSAppleEventsUsageDescription` key in Info.plist
- [ ] All other views unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)