### PR TITLE
feat(ext4): stuck-progress watchdog (Fix D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The README carries an abbreviated tail of this file (last ten dated sections).
 
 ---
 
+## 2026-05-31
+
+- **EXT4 stuck-progress watchdog (Fix D).** `DetachedOperationWatchdog` gains a per-op heartbeat layer on top of the existing deactivate-side trigger from Fix A. While a fsck / repair / format op is in flight, a background timer wakes once per `stuckCheckInterval` and checks whether `heartbeat()` has fired within `stuckDeadline` (default 60 s); if not, the same `onExpire` callback runs as Fix A's deactivate path — production exits the appex so `storagekitd` respawns. `EXT4FileSystem.startCheck` and `RepairXPCService.runRepair` call `watchdog.heartbeat()` from each Rust `onProgress` callback (unthrottled — log emission stays throttled separately, but the watchdog must see every tick). Catches the case where a verify/repair wedges mid-walk on a corrupted inode loop with no progress callbacks and the volume's still mounted — Fix A's deactivate-only trigger wouldn't fire there. Four new unit tests cover heartbeat-resets-clock, fires-when-silent, stays-quiet-while-beating, and stops-on-counter-zero.
+
 ## 2026-05-20
 
 - **EXT4 quiesce during verify / repair (Fix C).** While `fsck_fskit -t ext4` (verify) or `RepairXPCService` (repair) holds the volume's `OperationLock`, every user-facing FS op in `EXT4Volume` (attributes, setAttributes, lookup, enumerateDirectory, read, write, readSymbolicLink, createItem, createSymbolicLink, createLink, removeItem, renameItem, synchronize) checks `opLock.current` as its first instruction and throws `POSIXError(.EBUSY)` immediately if non-idle. Finder, Spotlight, `cp` and other callers get a fast recognisable "disk in use" error instead of blocking on the backend lock for the entire verify duration. Verify itself doesn't traverse these gates — its dispatch goes `startCheck` → `backend.runFsck` → `fs_ext4_fsck_run` and reads the device internally via the Rust crate's private methods, so the quiesce never locks the holder out of its own work.

--- a/DiskJockeyEXT4/EXT4FileSystem.swift
+++ b/DiskJockeyEXT4/EXT4FileSystem.swift
@@ -252,7 +252,14 @@ final class EXT4FileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
     static let watchdog: DetachedOperationWatchdog = {
         DetachedOperationWatchdog(
             label: "ext4",
-            defaultDeadline: 30
+            defaultDeadline: 30,
+            // Fix D — stuck-progress monitor. If `heartbeat()`
+            // doesn't fire for 60 s while at least one op is in
+            // flight, the op is presumed wedged (e.g. fsck stuck on
+            // a corrupted inode loop) and the appex `exit`s the
+            // same way deactivate-watchdog does. Overridable via
+            // App Group default `ext4StuckDeadlineSeconds`.
+            stuckDeadline: 60
         ) { pending, deadline in
             log.error(
                 "watchdog: \(pending) op(s) still pending after \(Int(deadline))s — exiting (EX_TEMPFAIL) so storagekitd respawns",
@@ -1177,6 +1184,12 @@ extension EXT4FileSystem: FSManageableResourceMaintenanceOperations {
             let result = backend.runFsck(
                 repair: repairRequested,
                 onProgress: { phase, done, total in
+                    // Stuck-progress heartbeat. Tells the watchdog
+                    // the op is still alive — must be unthrottled
+                    // (called on every Rust progress callback) so a
+                    // long quiet phase doesn't accidentally trip
+                    // `stuckDeadline`.
+                    Self.watchdog.heartbeat()
                     // Throttle. Phase change always emits (so the user
                     // sees the pipeline advance) and the first emit
                     // bypasses the time gate (so the progress bar

--- a/DiskJockeyEXT4/EXT4FileSystem.swift
+++ b/DiskJockeyEXT4/EXT4FileSystem.swift
@@ -250,16 +250,22 @@ final class EXT4FileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
     /// closure logs + exits the process so `storagekitd` respawns the
     /// appex cleanly.
     static let watchdog: DetachedOperationWatchdog = {
-        DetachedOperationWatchdog(
+        // Fix D — stuck-progress monitor. If `heartbeat()` doesn't
+        // fire for `stuckDeadline` seconds while at least one op
+        // is in flight, the op is presumed wedged (e.g. fsck stuck
+        // on a corrupted inode loop) and the appex `exit`s the
+        // same way deactivate-watchdog does. Default 60 s,
+        // overridable via the App Group default
+        // `ext4StuckDeadlineSeconds` (read once at static-let init
+        // time, same one-shot pattern as the deactivate side's
+        // `ext4WatchdogDeadlineSeconds` override).
+        let defaults = UserDefaults(suiteName: AppLog.groupIdentifier)
+        let configuredStuck = defaults?.double(forKey: "ext4StuckDeadlineSeconds") ?? 0
+        let stuckDeadline: TimeInterval = configuredStuck > 0 ? configuredStuck : 60
+        return DetachedOperationWatchdog(
             label: "ext4",
             defaultDeadline: 30,
-            // Fix D — stuck-progress monitor. If `heartbeat()`
-            // doesn't fire for 60 s while at least one op is in
-            // flight, the op is presumed wedged (e.g. fsck stuck on
-            // a corrupted inode loop) and the appex `exit`s the
-            // same way deactivate-watchdog does. Overridable via
-            // App Group default `ext4StuckDeadlineSeconds`.
-            stuckDeadline: 60
+            stuckDeadline: stuckDeadline
         ) { pending, deadline in
             log.error(
                 "watchdog: \(pending) op(s) still pending after \(Int(deadline))s — exiting (EX_TEMPFAIL) so storagekitd respawns",

--- a/DiskJockeyEXT4/RepairXPCService.swift
+++ b/DiskJockeyEXT4/RepairXPCService.swift
@@ -274,6 +274,11 @@ final class RepairXPCService: NSObject {
         let runResult = resolved.backend.runFsck(
             repair: true,
             onProgress: { phase, done, total in
+                // Stuck-progress heartbeat (Fix D). Refreshes the
+                // watchdog clock so a repair that's still making
+                // forward progress can't trip the stuck-deadline
+                // even though the log emission below is throttled.
+                EXT4FileSystem.watchdog.heartbeat()
                 // Throttle. Only two carve-outs that bypass the time
                 // gate: a phase CHANGE (so the user sees the
                 // pipeline advance) and the FIRST emit (so the

--- a/DiskJockeyLibrary/DetachedOperationWatchdog.swift
+++ b/DiskJockeyLibrary/DetachedOperationWatchdog.swift
@@ -57,14 +57,34 @@ public final class DetachedOperationWatchdog: @unchecked Sendable {
     /// window for slow-disk diagnostics without recompiling.
     public let defaultDeadline: TimeInterval
 
+    /// Maximum gap allowed between `heartbeat()` calls while any op
+    /// is pending. When `> 0`, a background timer wakes once per
+    /// `stuckCheckInterval` seconds and fires `onExpire` if the gap
+    /// has exceeded this deadline. `0` disables the stuck-progress
+    /// monitor entirely — the watchdog then behaves identically to
+    /// pre-Fix-D (only the `scheduleExpiryIfNeeded` deactivate-side
+    /// trigger fires).
+    public let stuckDeadline: TimeInterval
+
+    /// How often the background stuck-progress timer wakes to check
+    /// `now - lastHeartbeat`. Tighter than `stuckDeadline` so the
+    /// effective fire latency is at most one tick past the deadline.
+    public let stuckCheckInterval: TimeInterval
+
     private let onExpire: ExpireHandler
     private let counter = OSAllocatedUnfairLock<Int>(initialState: 0)
+    private let lastHeartbeatNs = OSAllocatedUnfairLock<UInt64>(initialState: 0)
+    private let stuckTimer = OSAllocatedUnfairLock<DispatchSourceTimer?>(initialState: nil)
 
     public init(label: String,
                 defaultDeadline: TimeInterval,
+                stuckDeadline: TimeInterval = 0,
+                stuckCheckInterval: TimeInterval = 1.0,
                 onExpire: @escaping ExpireHandler) {
         self.label = label
         self.defaultDeadline = defaultDeadline
+        self.stuckDeadline = stuckDeadline
+        self.stuckCheckInterval = stuckCheckInterval
         self.onExpire = onExpire
     }
 
@@ -76,15 +96,84 @@ public final class DetachedOperationWatchdog: @unchecked Sendable {
 
     /// Increment the counter. Pair with `leave()` in a `defer` so the
     /// counter still decrements on early return / thrown error.
+    ///
+    /// When `stuckDeadline > 0` and this transitions the counter
+    /// from 0 → 1, the stuck-progress monitor arms — a background
+    /// timer that fires `onExpire` if `heartbeat()` hasn't been
+    /// called for longer than `stuckDeadline` while ops are pending.
     public func enter() {
-        counter.withLock { $0 += 1 }
+        let became1 = counter.withLock { c -> Bool in
+            c += 1
+            return c == 1
+        }
+        // Reset the heartbeat clock on first entry so a slow-to-start
+        // op gets a full `stuckDeadline` window before being judged
+        // stuck. Subsequent `enter()` calls don't disturb the clock —
+        // an in-flight op's heartbeat protection shouldn't be reset
+        // by a sibling op starting up.
+        if became1 && stuckDeadline > 0 {
+            lastHeartbeatNs.withLock { $0 = monotonicNanos() }
+            armStuckTimer()
+        }
     }
 
     /// Decrement the counter, clamped to zero. Clamping is defensive
     /// against accidental double-`leave`; the alternative (wrap to
     /// `Int.max`) would silently break the scheduler's guard.
+    ///
+    /// When this transitions the counter from 1 → 0, the
+    /// stuck-progress monitor is cancelled.
     public func leave() {
-        counter.withLock { $0 = max(0, $0 - 1) }
+        let became0 = counter.withLock { c -> Bool in
+            c = max(0, c - 1)
+            return c == 0
+        }
+        if became0 {
+            cancelStuckTimer()
+        }
+    }
+
+    /// Refresh the "last heartbeat" timestamp. Detached ops should
+    /// call this from their `onProgress` (or equivalent) callback so
+    /// the stuck-progress monitor knows the op is still making
+    /// forward progress. Safe to call from any thread.
+    ///
+    /// No-op when `stuckDeadline == 0` (Fix D disabled).
+    public func heartbeat() {
+        guard stuckDeadline > 0 else { return }
+        lastHeartbeatNs.withLock { $0 = monotonicNanos() }
+    }
+
+    // MARK: - Stuck-progress monitor (Fix D)
+
+    private func armStuckTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        let intervalNs = UInt64(stuckCheckInterval * 1_000_000_000)
+        timer.schedule(
+            deadline: .now() + stuckCheckInterval,
+            repeating: .nanoseconds(Int(intervalNs))
+        )
+        timer.setEventHandler { [weak self] in self?.stuckTick() }
+        stuckTimer.withLock { $0 = timer }
+        timer.resume()
+    }
+
+    private func cancelStuckTimer() {
+        stuckTimer.withLock { current in
+            current?.cancel()
+            current = nil
+        }
+    }
+
+    private func stuckTick() {
+        let pending = self.pending
+        guard pending > 0 else { return }
+        let last = lastHeartbeatNs.withLock { $0 }
+        guard last > 0 else { return }
+        let elapsedNs = monotonicNanos() &- last
+        let deadlineNs = UInt64(stuckDeadline * 1_000_000_000)
+        guard elapsedNs >= deadlineNs else { return }
+        onExpire(pending, stuckDeadline)
     }
 
     /// Schedule a one-shot timer that re-checks the counter at the

--- a/DiskJockeyLibrary/DetachedOperationWatchdog.swift
+++ b/DiskJockeyLibrary/DetachedOperationWatchdog.swift
@@ -173,6 +173,16 @@ public final class DetachedOperationWatchdog: @unchecked Sendable {
         let elapsedNs = monotonicNanos() &- last
         let deadlineNs = UInt64(stuckDeadline * 1_000_000_000)
         guard elapsedNs >= deadlineNs else { return }
+        // One-shot fire. Cancel the timer BEFORE invoking onExpire
+        // so subsequent ticks can't re-enter — `lastHeartbeatNs` is
+        // never refreshed here, so without this cancel every
+        // following tick would also satisfy the deadline guard and
+        // re-call onExpire. In production that's masked because
+        // onExpire calls `exit()` and the process is gone before
+        // the next tick lands, but the contract should be explicit
+        // and robust against an onExpire that doesn't terminate
+        // (e.g. test spies that just flip a counter).
+        cancelStuckTimer()
         onExpire(pending, stuckDeadline)
     }
 

--- a/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
+++ b/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
@@ -166,6 +166,29 @@ struct DetachedOperationWatchdogTests {
         #expect(reportedDeadline.get() == 0.1)
     }
 
+    @Test func stuckMonitorFiresOnceNotOncePerTick() async throws {
+        // Regression: an earlier version fired `onExpire` on every
+        // timer tick after the deadline. Masked in production because
+        // `exit()` terminates before the next tick, but the contract
+        // is one-shot — verify with a counter spy that several check
+        // intervals don't accumulate fires.
+        let fireCount = LockBox(0)
+        let w = DetachedOperationWatchdog(
+            label: "test",
+            defaultDeadline: 100,
+            stuckDeadline: 0.05,
+            stuckCheckInterval: 0.02
+        ) { _, _ in
+            fireCount.set(fireCount.get() + 1)
+        }
+        w.enter()
+        // 250 ms with 20 ms check interval = ~12 potential ticks past
+        // the 50 ms deadline. Without one-shot cancellation we'd see
+        // double-digit fires. With it, exactly 1.
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(fireCount.get() == 1)
+    }
+
     @Test func stuckMonitorDoesNotFireWhileHeartbeatsArrive() async throws {
         let fireCount = LockBox(0)
         let w = DetachedOperationWatchdog(

--- a/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
+++ b/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
@@ -130,4 +130,79 @@ struct DetachedOperationWatchdogTests {
         try await Task.sleep(nanoseconds: 250_000_000)
         #expect(fireCount.get() == 0)
     }
+
+    // ----- Stuck-progress monitor (Fix D) -----
+
+    @Test func stuckMonitorDisabledByDefaultStuckDeadlineZero() async throws {
+        let fired = LockBox(false)
+        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 100) { _, _ in
+            fired.set(true)
+        }
+        // stuckDeadline defaults to 0 ⇒ disabled
+        w.enter()
+        // No heartbeats. With Fix D off, this should NOT fire even
+        // though we sit silent indefinitely (within the test window).
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(fired.get() == false)
+    }
+
+    @Test func stuckMonitorFiresWhenNoHeartbeatPastDeadline() async throws {
+        let fired = LockBox(false)
+        let reportedDeadline = LockBox(0.0)
+        let w = DetachedOperationWatchdog(
+            label: "test",
+            defaultDeadline: 100,
+            stuckDeadline: 0.1,
+            stuckCheckInterval: 0.03
+        ) { _, deadline in
+            reportedDeadline.set(deadline)
+            fired.set(true)
+        }
+        w.enter()
+        // No heartbeat() calls. After ~0.1s the stuck-progress monitor
+        // should observe `now - lastHeartbeat > stuckDeadline` and fire.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(fired.get() == true)
+        #expect(reportedDeadline.get() == 0.1)
+    }
+
+    @Test func stuckMonitorDoesNotFireWhileHeartbeatsArrive() async throws {
+        let fireCount = LockBox(0)
+        let w = DetachedOperationWatchdog(
+            label: "test",
+            defaultDeadline: 100,
+            stuckDeadline: 0.1,
+            stuckCheckInterval: 0.03
+        ) { _, _ in
+            fireCount.set(fireCount.get() + 1)
+        }
+        w.enter()
+        // Beat every 30ms for 250ms. Each heartbeat resets the clock,
+        // so we should never exceed the 100ms stuckDeadline.
+        for _ in 0..<8 {
+            w.heartbeat()
+            try await Task.sleep(nanoseconds: 30_000_000)
+        }
+        #expect(fireCount.get() == 0)
+    }
+
+    @Test func stuckMonitorStopsAfterLeaveTransitionsCounterToZero() async throws {
+        let fired = LockBox(false)
+        let w = DetachedOperationWatchdog(
+            label: "test",
+            defaultDeadline: 100,
+            stuckDeadline: 0.05,
+            stuckCheckInterval: 0.02
+        ) { _, _ in
+            fired.set(true)
+        }
+        w.enter()
+        w.leave()  // immediately drop counter to 0 — monitor should cancel
+        // Sleep well past the stuckDeadline. If the monitor weren't
+        // cancelled it would still tick and find pending==0, so
+        // wouldn't fire — but more importantly: no timer should be
+        // around to consume resources after `leave`.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(fired.get() == false)
+    }
 }


### PR DESCRIPTION
## Summary

Defense-in-depth on top of Fix A's parent-death watchdog. While that one fires when `Volume.deactivate` runs with detached ops still in flight, this catches the orthogonal failure mode: an op wedged mid-walk (Rust crate stuck on a corrupted inode loop, say) with no `onProgress` callbacks but the volume still mounted — Fix A's trigger never sees that.

## Mechanism

`DetachedOperationWatchdog` (in DiskJockeyLibrary) gains:

- New `stuckDeadline` + `stuckCheckInterval` init parameters (both `0`/disabled by default — existing call sites are untouched semantically)
- `heartbeat()` method that refreshes the last-progress timestamp
- Background `DispatchSourceTimer` that arms on the `0 → 1` counter transition (via `enter()`), fires `onExpire` if the heartbeat clock exceeds `stuckDeadline` while any op is pending, cancels on the `1 → 0` transition (via `leave()`)

`EXT4FileSystem.watchdog` now passes `stuckDeadline: 60`. The fsck/repair `onProgress` closures in both `EXT4FileSystem.startCheck` and `RepairXPCService.runRepair` call `Self.watchdog.heartbeat()` unthrottled (log emission and `Progress` updates stay throttled separately, but the watchdog needs every tick).

## Tests

Four new unit tests in `DetachedOperationWatchdogTests`:
- `stuckMonitorDisabledByDefaultStuckDeadlineZero` — no false fires when Fix D is off
- `stuckMonitorFiresWhenNoHeartbeatPastDeadline` — fires after silent op exceeds deadline
- `stuckMonitorDoesNotFireWhileHeartbeatsArrive` — stays quiet while heartbeats keep arriving
- `stuckMonitorStopsAfterLeaveTransitionsCounterToZero` — timer cancels cleanly on counter drop

Full suite: 80 tests pass (67 DiskJockeyTests + 13 DiskJockeyLibraryTests).

## Test plan

- [x] `xcodebuild test` — 80/80 passing
- [ ] Runtime: trigger a verify on a real ext4 volume, confirm normal completion (no false-positive stuck fire)
- [ ] Runtime: artificially extend a verify (or run on a deliberately-slow corrupted image) past 60 s of no progress callbacks, confirm watchdog fires + appex exits cleanly + `storagekitd` respawns

## Stacks with

- [Fix A — parent-death watchdog](https://github.com/antimatter-studios/diskjockey/pull/12) — same watchdog instance, different trigger