### PR TITLE
refactor(ui): swap sidebar — Local Drives above Network Drives

### DIFF
--- a/DiskJockeyApplication/Views/ContentView.swift
+++ b/DiskJockeyApplication/Views/ContentView.swift
@@ -164,28 +164,6 @@ private struct SidebarView: View {
         VStack(spacing: 0) {
             // Mount list + logs
             List(selection: $sidebarModel.selectedItem) {
-                Section("Network Drives") {
-                    if directMountRegistry.mounts.isEmpty {
-                        Text("No mounts configured")
-                            .foregroundStyle(.secondary)
-                            .font(.caption)
-                    } else {
-                        ForEach(directMountRegistry.mounts, id: \.id) { mount in
-                            DirectMountSidebarRow(
-                                mount: mount,
-                                registry: directMountRegistry
-                            )
-                            .tag(SidebarItem.directMount(mount.id))
-                        }
-                    }
-
-                    Button(action: { showingAddMount = true }) {
-                        Label("Add Network Drive", image: "tabler-plus")
-                            .foregroundStyle(Color.accentColor)
-                    }
-                    .buttonStyle(.plain)
-                }
-
                 Section("Local Drives") {
                     if attachedDisks.disks.isEmpty {
                         Text("No local volumes mounted")
@@ -203,6 +181,28 @@ private struct SidebarView: View {
                             logRepository: container.logRepository)
                     }) {
                         Label("Add Disk Image", image: "tabler-plus")
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Section("Network Drives") {
+                    if directMountRegistry.mounts.isEmpty {
+                        Text("No mounts configured")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    } else {
+                        ForEach(directMountRegistry.mounts, id: \.id) { mount in
+                            DirectMountSidebarRow(
+                                mount: mount,
+                                registry: directMountRegistry
+                            )
+                            .tag(SidebarItem.directMount(mount.id))
+                        }
+                    }
+
+                    Button(action: { showingAddMount = true }) {
+                        Label("Add Network Drive", image: "tabler-plus")
                             .foregroundStyle(Color.accentColor)
                     }
                     .buttonStyle(.plain)


### PR DESCRIPTION
## Summary

One-line user preference: in `ContentView.swift`'s sidebar `List`, the **Local Drives** section now appears above **Network Drives**. Matches the physical-first / remote-second mental model.

Pure reorder — no logic, no behavior, no test changes.

## Test plan

- [x] `xcodebuild build` — clean Debug build
- [ ] Launch the app, confirm sidebar order is now: Local Drives → Network Drives → (Empty Drives, conditional) → System