### PR TITLE
fix(ext4): atomically replace existing rename target

### DIFF
--- a/DiskJockeyEXT4/EXT4Backend.swift
+++ b/DiskJockeyEXT4/EXT4Backend.swift
@@ -237,7 +237,12 @@ final class EXT4Backend: FileSystemBackend {
     func rename(src: String, dst: String) -> Bool {
         state.withLock { fs in
             guard let fs = fs else { return false }
-            return fs_ext4_rename(fs, src, dst) == 0
+            // Use the replace variant so an existing destination is
+            // atomically overwritten (POSIX rename(2) semantics). The
+            // plain fs_ext4_rename rejects an existing dst with EEXIST,
+            // which breaks in-place editors (e.g. `sed -i`) that write a
+            // temp file then rename it over the original.
+            return fs_ext4_rename2(fs, src, dst, FS_EXT4_RENAME_REPLACE) == 0
         }
     }
 

--- a/DiskJockeyEXT4/EXT4Volume.swift
+++ b/DiskJockeyEXT4/EXT4Volume.swift
@@ -784,27 +784,18 @@ final class EXT4Volume: FSVolume,
         let srcPath = Self.joinPath(srcDir.path, srcNameStr)
         let dstPath = Self.joinPath(dstDir.path, dstNameStr)
 
-        // The fs_ext4 rename does not allow renaming onto an existing
-        // entry, so when `overItem` is non-nil we have to remove the
-        // destination first. POSIX semantics require that an existing
-        // directory target be empty; we honour that by routing through
-        // rmdir / unlink based on the destination's actual type, not the
-        // source's.
-        if overItem != nil {
-            if let dstAttr = backend.stat(path: dstPath) {
-                let removed: Bool
-                switch dstAttr.fileType {
-                case .directory:
-                    removed = backend.rmdir(path: dstPath)
-                default:
-                    removed = backend.unlink(path: dstPath)
-                }
-                if !removed {
-                    throw Self.posixError(from: backend)
-                }
-            }
-        }
-
+        // backend.rename() atomically replaces an existing destination
+        // (FS_EXT4_RENAME_REPLACE), enforcing POSIX semantics in the
+        // crate: file→file overwrites and frees the old inode, empty-dir
+        // → empty-dir overwrites the dropped subdir, and crossing the
+        // file/directory boundary or a non-empty dir target fails with
+        // EISDIR / ENOTDIR / ENOTEMPTY. We no longer unlink the
+        // destination ourselves — doing so was non-atomic and lost the
+        // original file if the rename then failed. We also can't rely on
+        // `overItem` being populated: FSKit only passes it when the kernel
+        // had already resolved the destination, so an unguarded
+        // rename-over (e.g. `sed -i`) would otherwise slip through with a
+        // nil overItem.
         guard backend.rename(src: srcPath, dst: dstPath) else {
             throw Self.posixError(from: backend)
         }


### PR DESCRIPTION
## Problem
A bug report: `sed -i ''` fails on a mounted ext4 volume, while `awk … > tmp; mv` works. Misattributed to FUSE — it's our FSKit ext4 driver.

`sed -i` writes a temp file then `rename(temp, original)` onto the existing target. The ext4 backend's `rename()` called `fs_ext4_rename`, which rejects an existing destination with `EEXIST`. `EXT4Volume.renameItem` papered over this by unlinking the destination first — but **only when FSKit supplied a non-nil `overItem`**.

FSKit populates `overItem` only when the kernel had already resolved the destination this session. So rename-over succeeded on files that had been looked up (e.g. `hostapd.conf`) and failed with `EEXIST` on ones that hadn't (e.g. `/etc/hosts`) — exactly the intermittent symptom reported. `mv` works because it does its own unlink first.

The workaround was also **non-atomic and data-losing**: `unlink(dst)` then `rename(src,dst)` left the original gone if the rename then failed, violating POSIX `rename(2)` atomicity.

## Fix
- `EXT4Backend.rename()` now calls `fs_ext4_rename2(…, FS_EXT4_RENAME_REPLACE)` for atomic POSIX replace.
- Removed the `overItem`-gated unlink/rmdir block in `EXT4Volume.renameItem`; the crate now enforces the semantics (file→file frees old inode, empty-dir→empty-dir, EISDIR/ENOTDIR/ENOTEMPTY at boundaries). Behaviour no longer depends on FSKit cache state.

The crate's overwrite path is already covered by `vendor/rust-fs-ext4/tests/capi_rename_overwrite.rs` (frees old inode, ENOTEMPTY on non-empty dir, hardlink count preserved, persists across remount).

## Test
`xcodebuild -scheme DiskJockeyEXT4 … ARCHS=arm64 build` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)