### PR TITLE
ci: unify push + pull_request runs into one concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,17 @@ on:
   pull_request:
     branches: [main]
 
+# `head_ref` is set on `pull_request` events (the source branch);
+# `ref_name` is the short ref for `push` events. Using
+# `head_ref || ref_name` unifies the two events into one concurrency
+# group per branch — without this, GitHub fires both a `push` run
+# (group key `refs/heads/<branch>`) and a `pull_request` run (group
+# key `refs/pull/<n>/merge`) for the same commit, and they race for
+# the limited macos-26 runner pool. Observed symptom: one run passes
+# in ~2 min, the duplicate hangs for an hour waiting for a slot that
+# never frees.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Single-line change to the concurrency group key in `.github/workflows/ci.yml` so each commit fires **one** CI run instead of two parallel ones.

## The bug

The workflow triggers on both `push` and `pull_request` events. For the same commit on a branch with an open PR, GitHub fires two runs concurrently. The `concurrency` block:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

keys on `github.ref`, which differs between events:

| Event | `github.ref` |
|---|---|
| `push` to branch | `refs/heads/<branch>` |
| `pull_request` | `refs/pull/<n>/merge` |

Different group keys → both runs proceed → they race for the limited `macos-26` runner pool.

## Observed symptom — PR #21

For commit `47a2bd9` (the most recent push to `refactor/repair-watcher`):

| Run | Trigger | Result |
|---|---|---|
| [26786492284](https://github.com/antimatter-studios/diskjockey/actions/runs/26786492284) | (one of the two) | ✅ passed in 1m58s |
| [26786493739](https://github.com/antimatter-studios/diskjockey/actions/runs/26786493739) | (the other) | ⏳ hung "in_progress" for over an hour |

The hung run was waiting for a `macos-26` runner slot that never freed. The PR's check status stayed `pending` even though tests passed.

## The fix

Switch the group key to `github.head_ref || github.ref_name`:

| Event | `head_ref` | `ref_name` | Resolved |
|---|---|---|---|
| `push` to branch | (empty) | `<branch>` | `<branch>` |
| `pull_request` | `<branch>` | `<n>/merge` | `<branch>` |

Same value on both events → same concurrency group → `cancel-in-progress: true` keeps only one run live per branch. The pattern is the recommended workaround in [GitHub's docs](https://docs.github.com/en/actions/using-jobs/using-concurrency).

## Test plan

- [x] Local YAML syntax check ✅ (committed; pre-commit hook passed)
- [ ] Open this PR; observe exactly **one** Build & Test run appears (was two)
- [ ] Force-push this branch; observe the prior in-progress run cancels (was: ran in parallel)
- [ ] Cancelled the previously-stuck duplicate on PR #21 manually (`gh run cancel 26786493739`) so #21's CI status reflects the passing run

## Notes

- No source-code or test changes; CI hygiene only.
- Future side benefit: `cancel-in-progress` now actually does what its name suggests on force-pushes to a PR branch — previously the push-event run would survive even though the PR-event run got cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)