### PR TITLE
chore: add `make installable` for a /Applications-ready DiskJockey.app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,28 @@ install-agent:
 	@scripts/install-agent-dev.sh
 
 # ---------------------------------------------------------------------------
+# Installable .app
+# ---------------------------------------------------------------------------
+#
+# `installable` builds a Release-configured DiskJockey.app signed with
+# the team's Apple Development certificate — ready to live at
+# /Applications/DiskJockey.app instead of being run out of Xcode's
+# DerivedData. The .app lands at build/export/DiskJockey.app.
+#
+# `installable-install` does the same, then copies the result into
+# /Applications (prompting first if a previous install is there).
+#
+# Both delegate to scripts/build-installable.sh; the comment header on
+# that script has the full rationale, signing notes, and switching
+# guidance for Developer ID / App Store distribution.
+
+installable:
+	@scripts/build-installable.sh
+
+installable-install:
+	@scripts/build-installable.sh --install
+
+# ---------------------------------------------------------------------------
 # Vendor-pin manifest
 # ---------------------------------------------------------------------------
 #

--- a/scripts/ExportOptions-development.plist
+++ b/scripts/ExportOptions-development.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ExportOptions-development.plist — export options for `xcodebuild
+  -exportArchive` when building a locally-installable .app signed
+  with an Apple Development certificate.
+
+  Used by scripts/build-installable.sh (and `make installable`).
+  Not intended for App Store or notarized Developer ID distribution
+  — those would need their own ExportOptions files with
+  `method = app-store-connect` or `method = developer-id`.
+
+  Notes:
+    * `method = development` produces a .app signed with the team's
+      Apple Development certificate. The signed app runs on Macs that
+      are registered to that Apple Developer account; Gatekeeper
+      accepts it without notarization.
+    * `signingStyle = automatic` lets Xcode pick the matching cert +
+      provisioning profile for each of the 5 bundle IDs (parent +
+      EXT4 + NTFS + FileProvider + Agent). Avoids having to maintain
+      a manual mapping of bundle ID → profile name in this plist.
+    * `teamID` pins the team to the one the project's
+      `DEVELOPMENT_TEAM` is set to, so a stray Apple ID with multiple
+      teams doesn't pick the wrong one silently.
+    * `uploadSymbols = false` — symbols only ship to App Store
+      Connect; meaningless for a local install.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Apple renamed `development` to `debugging` in newer Xcode
+         versions. Using the new name silences the deprecation
+         warning on Xcode 16+. -->
+    <key>method</key>
+    <string>debugging</string>
+    <key>destination</key>
+    <string>export</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>43UMKXZ8P4</string>
+    <key>uploadSymbols</key>
+    <false/>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/build-installable.sh
+++ b/scripts/build-installable.sh
@@ -123,7 +123,7 @@ xcodebuild archive \
     -skipPackagePluginValidation \
     -allowProvisioningUpdates \
     ONLY_ACTIVE_ARCH=YES \
-    ARCHS=arm64
+    ARCHS=arm64          # Apple Silicon only — intentional; not a universal build
 
 # --- export -------------------------------------------------------------
 
@@ -140,6 +140,12 @@ if [ ! -d "$EXPORT_DIR/DiskJockey.app" ]; then
     echo "ERROR: exported .app not found at $EXPORT_DIR/DiskJockey.app" >&2
     exit 1
 fi
+
+# Verify the exported bundle here so a signing/export problem surfaces on
+# EVERY build path, not only when --install is passed (e.g. a developer who
+# `ditto`s the built .app manually still gets a checked signature).
+echo "==> verifying signature"
+codesign --verify --verbose=1 "$EXPORT_DIR/DiskJockey.app"
 
 echo "==> built: $EXPORT_DIR/DiskJockey.app"
 
@@ -161,25 +167,34 @@ if [ "$DO_INSTALL" = true ]; then
                 exit 0
                 ;;
         esac
-        rm -rf "$INSTALL_DEST"
     fi
 
+    # Install atomically: stage into a temp path beside the destination,
+    # prove it copied and verifies cleanly, and only THEN swap it in. This
+    # way a `ditto` failure (disk full, I/O error) can never leave the user
+    # with their previous install deleted and no replacement.
+    staging="${INSTALL_DEST}.installing.$$"
+    rm -rf "$staging"
     # `ditto` preserves code signatures and extended attributes that
     # `cp -R` strips; required for the signed bundle to keep working.
     echo "==> installing to $INSTALL_DEST"
-    ditto "$EXPORT_DIR/DiskJockey.app" "$INSTALL_DEST"
+    ditto "$EXPORT_DIR/DiskJockey.app" "$staging"
 
     # Strip the quarantine attribute LaunchServices applies to anything
     # arriving through "untrusted" channels. Without this, Gatekeeper
     # prompts the user on first launch even though the bundle is
     # validly signed — annoying for a local-build install path.
-    xattr -dr com.apple.quarantine "$INSTALL_DEST" 2>/dev/null || true
+    xattr -dr com.apple.quarantine "$staging" 2>/dev/null || true
 
-    # Verify the install actually signed-bundle-checks-cleanly so a
-    # copy mishap or stripped signature surfaces here, not at first
-    # launch.
-    echo "==> verifying signature"
-    codesign --verify --verbose=1 "$INSTALL_DEST"
+    # Verify the staged copy before the swap so a copy mishap or stripped
+    # signature surfaces here, not at first launch.
+    echo "==> verifying staged copy"
+    codesign --verify --verbose=1 "$staging"
+
+    # Atomic-ish swap: the old install only disappears once the new copy
+    # is proven good.
+    rm -rf "$INSTALL_DEST"
+    mv "$staging" "$INSTALL_DEST"
 
     echo ""
     echo "Installed: $INSTALL_DEST"

--- a/scripts/build-installable.sh
+++ b/scripts/build-installable.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# build-installable.sh — produce a release-configured DiskJockey.app
+# that can be installed to /Applications and run like a normal app
+# (not out of Xcode DerivedData).
+#
+# Signed with the team's Apple Development certificate via Xcode's
+# automatic signing. Runs on Macs registered to your Apple Developer
+# account; Gatekeeper accepts it without notarization.
+#
+# For external distribution or notarized installs, switch to a
+# Developer ID workflow — different cert, different ExportOptions,
+# plus a `xcrun notarytool submit` step.
+#
+# Usage:
+#   ./scripts/build-installable.sh           # build only, leave .app in build/export/
+#   ./scripts/build-installable.sh --install # build, then copy to /Applications
+#   ./scripts/build-installable.sh -h        # help
+#
+# Exit codes:
+#   0  success
+#   1  general failure (xcodebuild, ditto, etc.)
+#   2  precondition failure (wrong CWD, missing tools)
+#
+
+set -euo pipefail
+
+# Resolve project root from this script's location, so the script
+# works regardless of CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+BUILD_DIR="$PROJECT_ROOT/build"
+ARCHIVE_PATH="$BUILD_DIR/DiskJockey.xcarchive"
+EXPORT_DIR="$BUILD_DIR/export"
+EXPORT_PLIST="$SCRIPT_DIR/ExportOptions-development.plist"
+INSTALL_DEST="/Applications/DiskJockey.app"
+
+DO_INSTALL=false
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/build-installable.sh [--install] [-h|--help]
+
+Builds a Release-configured DiskJockey.app signed with the team's
+Apple Development certificate, ready for /Applications.
+
+Without --install, leaves the artifact at build/export/DiskJockey.app.
+With --install, copies it to /Applications (replacing any existing
+copy) after prompting.
+
+Requires:
+  * Xcode + matching Apple Development cert in team 43UMKXZ8P4
+  * Vendor libraries built (`make vendor-all` runs automatically if
+    `lib/` is missing or stale)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --install)
+            DO_INSTALL=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- precondition checks ------------------------------------------------
+
+if [ ! -f "$PROJECT_ROOT/DiskJockey.xcodeproj/project.pbxproj" ]; then
+    echo "ERROR: DiskJockey.xcodeproj not found in $PROJECT_ROOT" >&2
+    exit 2
+fi
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+    echo "ERROR: xcodebuild not in PATH (Xcode command-line tools missing?)" >&2
+    exit 2
+fi
+
+# Make sure the team's Apple Development cert is available. We don't
+# fail hard on absence — xcodebuild's automatic signing might still
+# resolve it via the account credentials — but warn loudly so a
+# missing cert doesn't look like a cryptic build error later.
+if ! security find-identity -v -p codesigning 2>/dev/null \
+    | grep -q '"Apple Development:'; then
+    echo "WARNING: no 'Apple Development' code-signing identity found in keychain." >&2
+    echo "         Open Xcode > Settings > Accounts and make sure the team is added." >&2
+fi
+
+# --- vendor libraries ---------------------------------------------------
+#
+# The build links against three vendor static libs (lib/fs_ext4,
+# lib/fs_ntfs, lib/go-networkfs) plus the four img-* containers
+# (lib/img_qcow2, lib/img_vhd, lib/img_vhdx, lib/img_vmdk). Run the
+# umbrella `vendor-all` target — its stamp files mean a no-op fast
+# path when they're already current.
+
+echo "==> building vendor libraries (lib/)"
+make vendor-all
+
+# --- archive ------------------------------------------------------------
+
+echo "==> archiving (Release, ARCHS=arm64)"
+rm -rf "$ARCHIVE_PATH"
+mkdir -p "$BUILD_DIR"
+
+xcodebuild archive \
+    -project DiskJockey.xcodeproj \
+    -scheme DiskJockey \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -archivePath "$ARCHIVE_PATH" \
+    -skipPackagePluginValidation \
+    -allowProvisioningUpdates \
+    ONLY_ACTIVE_ARCH=YES \
+    ARCHS=arm64
+
+# --- export -------------------------------------------------------------
+
+echo "==> exporting .app from archive"
+rm -rf "$EXPORT_DIR"
+
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_DIR" \
+    -exportOptionsPlist "$EXPORT_PLIST" \
+    -allowProvisioningUpdates
+
+if [ ! -d "$EXPORT_DIR/DiskJockey.app" ]; then
+    echo "ERROR: exported .app not found at $EXPORT_DIR/DiskJockey.app" >&2
+    exit 1
+fi
+
+echo "==> built: $EXPORT_DIR/DiskJockey.app"
+
+# --- install (optional) -------------------------------------------------
+
+if [ "$DO_INSTALL" = true ]; then
+    if [ -d "$INSTALL_DEST" ]; then
+        # Replacing /Applications/DiskJockey.app — confirm so a stray
+        # `--install` flag can't silently overwrite an installed copy
+        # that might be from a different signing identity / Xcode
+        # version / hand-modified bundle.
+        printf "==> %s already exists. Replace it? [y/N] " "$INSTALL_DEST"
+        read -r answer
+        case "$answer" in
+            y|Y|yes|YES) ;;
+            *)
+                echo "Aborted; leaving existing install in place."
+                echo "Built copy is at: $EXPORT_DIR/DiskJockey.app"
+                exit 0
+                ;;
+        esac
+        rm -rf "$INSTALL_DEST"
+    fi
+
+    # `ditto` preserves code signatures and extended attributes that
+    # `cp -R` strips; required for the signed bundle to keep working.
+    echo "==> installing to $INSTALL_DEST"
+    ditto "$EXPORT_DIR/DiskJockey.app" "$INSTALL_DEST"
+
+    # Strip the quarantine attribute LaunchServices applies to anything
+    # arriving through "untrusted" channels. Without this, Gatekeeper
+    # prompts the user on first launch even though the bundle is
+    # validly signed — annoying for a local-build install path.
+    xattr -dr com.apple.quarantine "$INSTALL_DEST" 2>/dev/null || true
+
+    # Verify the install actually signed-bundle-checks-cleanly so a
+    # copy mishap or stripped signature surfaces here, not at first
+    # launch.
+    echo "==> verifying signature"
+    codesign --verify --verbose=1 "$INSTALL_DEST"
+
+    echo ""
+    echo "Installed: $INSTALL_DEST"
+    echo "Open with: open '$INSTALL_DEST'"
+else
+    echo ""
+    echo "Built: $EXPORT_DIR/DiskJockey.app"
+    echo "Install to /Applications by re-running with --install,"
+    echo "or copy manually:  ditto '$EXPORT_DIR/DiskJockey.app' /Applications/DiskJockey.app"
+fi


### PR DESCRIPTION
## Summary

Adds a focused build path for "I want a Release-signed app I can run from /Applications instead of out of Xcode DerivedData."

```sh
make installable           # produces build/export/DiskJockey.app
make installable-install   # same + copies to /Applications (prompts before overwriting)
```

Three new files:

| File | Purpose |
|---|---|
| `scripts/build-installable.sh` | Drives the pipeline: `make vendor-all` → `xcodebuild archive` (Release, `ARCHS=arm64`) → `xcodebuild -exportArchive` → optional `--install` to /Applications. Strips quarantine xattr, codesign-verifies the installed bundle. |
| `scripts/ExportOptions-development.plist` | `method=debugging` (the new name for what used to be `development`), `signingStyle=automatic`, `teamID=43UMKXZ8P4` (matches `DEVELOPMENT_TEAM`). |
| `Makefile` | `installable` + `installable-install` targets wrapping the script. |

## Verified end-to-end during this PR

- ✅ `** ARCHIVE SUCCEEDED **` + `** EXPORT SUCCEEDED **` on Xcode 26
- ✅ Bundle structure: `Contents/MacOS/DiskJockey`, `Contents/Extensions/{DiskJockeyEXT4.appex, DiskJockeyNTFS.appex}`, `Contents/PlugIns/DiskJockeyFileProvider.appex`, `Contents/Frameworks/DiskJockeyLibrary.framework`, `Contents/embedded.provisionprofile`
- ✅ `codesign --verify --verbose=1`: *valid on disk* + *satisfies its Designated Requirement*
- ✅ Signing authority: `Apple Development: Chris Thomas`, TeamIdentifier `43UMKXZ8P4`
- ✅ Identifier: `com.antimatterstudios.diskjockey`

## Known limitation: DiskJockeyAgent isn't included

The `DiskJockeyAgent/` source directory exists (with `main.swift`, `AgentImpl.swift`, entitlements) and `scripts/install-agent-dev.sh` expects the Agent at `<app>/Contents/Library/LaunchAgents/`, but **there is currently no DiskJockeyAgent target in the Xcode project** (`grep -c 'DiskJockeyAgent' DiskJockey.xcodeproj/project.pbxproj` = 0). So the built `.app` does not include the Agent — `make installable` can only embed what Xcode can build.

Once the Agent is added as an Xcode target, the same script will pick it up automatically; no script change needed.

## Not in scope for this PR

- **Notarized Developer ID builds** — different cert, different ExportOptions, plus a `xcrun notarytool submit` step. The existing path is fine for a personal install on Macs registered to the Apple Developer account.
- **App Store Connect uploads** — `.github/workflows/release.yml` already handles those with a separate set of secrets + provisioning profiles.

## Test plan

- [x] `make installable` builds end-to-end and produces a valid signed bundle ✅
- [x] Bundle has the three FSKit/FileProvider appex extensions in the right subdirs ✅
- [x] `codesign --verify` is clean ✅
- [ ] `make installable-install` (you'd run this) — copies to /Applications, app launches and the FSKit extensions register

🤖 Generated with [Claude Code](https://claude.com/claude-code)