### PR TITLE
fix: address PR #35 review (FSClient enable-state follow-ups)

### DIFF
--- a/DiskJockeyAgent/AgentImpl.swift
+++ b/DiskJockeyAgent/AgentImpl.swift
@@ -2,7 +2,9 @@ import Foundation
 
 // `hdiutilAttach` returns `Result<[String], String>`, using a plain string
 // as the lightweight internal failure value. Allow String as an Error.
-extension String: Error {}
+// `@retroactive` acknowledges this conformance is on a type we don't own
+// (SE-0364) and silences the Swift 6 retroactive-conformance warning.
+extension String: @retroactive Error {}
 
 final class AgentImpl: NSObject, DJAgentProtocol {
     func attachImage(atPath path: String,
@@ -182,43 +184,6 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         }
         let json = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
         reply(json, nil)
-    }
-
-    func extensionStates(forBundleIDs ids: [String],
-                         reply: @escaping (String?, String?) -> Void) {
-        var map: [String: Bool] = [:]
-        for id in ids {
-            if let enabled = Self.pluginkitEnabled(bundleID: id) {
-                map[id] = enabled
-            }
-        }
-        guard let data = try? JSONSerialization.data(withJSONObject: map, options: []),
-              let json = String(data: data, encoding: .utf8) else {
-            reply(nil, "failed to serialize extension states")
-            return
-        }
-        reply(json, nil)
-    }
-
-    /// Run `pluginkit -m -i <id>` and read the leading flag: '+' = enabled,
-    /// '-' / blank = disabled. nil when the query produced no usable answer.
-    /// Runs unsandboxed here so it can reach the pkd daemon (the host app's
-    /// sandbox can't).
-    private static func pluginkitEnabled(bundleID: String) -> Bool? {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/pluginkit")
-        proc.arguments = ["-m", "-i", bundleID]
-        let outPipe = Pipe()
-        proc.standardOutput = outPipe
-        proc.standardError = Pipe()
-        do { try proc.run() } catch { return nil }
-        proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else { return nil }
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8),
-              let line = text.split(separator: "\n").first.map(String.init),
-              !line.isEmpty else { return nil }
-        return line.hasPrefix("+")
     }
 
     private static func locateDiskprobe() -> URL? {

--- a/DiskJockeyAgent/DJAgentProtocol.swift
+++ b/DiskJockeyAgent/DJAgentProtocol.swift
@@ -10,9 +10,4 @@ import Foundation
                     reply: @escaping (_ success: Bool, _ error: String?) -> Void)
     func probeImage(atPath path: String,
                     reply: @escaping (_ json: String?, _ error: String?) -> Void)
-    /// Reports per-extension enable state by running `pluginkit` from the
-    /// unsandboxed agent (the host app's own sandbox can't read it). Returns
-    /// a JSON object mapping each requested bundle id to a bool, or error.
-    func extensionStates(forBundleIDs ids: [String],
-                         reply: @escaping (_ json: String?, _ error: String?) -> Void)
 }

--- a/DiskJockeyApplication/Services/DJAgentClient.swift
+++ b/DiskJockeyApplication/Services/DJAgentClient.swift
@@ -87,29 +87,6 @@ final class DJAgentClient {
         }
     }
 
-    /// Per-extension enable state, read by the unsandboxed agent via
-    /// pluginkit. Keyed by the bundle ids passed in; ids the agent couldn't
-    /// determine are simply absent from the result.
-    func extensionStates(forBundleIDs ids: [String]) async throws -> [String: Bool] {
-        let proxy = try makeProxy()
-        return try await withCheckedThrowingContinuation { continuation in
-            proxy.extensionStates(forBundleIDs: ids) { json, error in
-                if let errorMsg = error {
-                    continuation.resume(throwing: FSKitMountService.FSKitError.processFailed(
-                        exitCode: -1, stderr: errorMsg))
-                    return
-                }
-                guard let json, let data = json.data(using: .utf8),
-                      let map = try? JSONDecoder().decode([String: Bool].self, from: data) else {
-                    continuation.resume(throwing: FSKitMountService.FSKitError.processFailed(
-                        exitCode: -1, stderr: "agent returned no extension states"))
-                    return
-                }
-                continuation.resume(returning: map)
-            }
-        }
-    }
-
     func detachDevice(_ bsdName: String) async throws {
         let proxy = try makeProxy()
         try await callAgent(fallbackError: "agent detach failed") { cb in

--- a/DiskJockeyApplication/Services/DJAgentProtocol.swift
+++ b/DiskJockeyApplication/Services/DJAgentProtocol.swift
@@ -10,9 +10,4 @@ import Foundation
                     reply: @escaping (_ success: Bool, _ error: String?) -> Void)
     func probeImage(atPath path: String,
                     reply: @escaping (_ json: String?, _ error: String?) -> Void)
-    /// Reports per-extension enable state by running `pluginkit` from the
-    /// unsandboxed agent (the host app's own sandbox can't read it). Returns
-    /// a JSON object mapping each requested bundle id to a bool, or error.
-    func extensionStates(forBundleIDs ids: [String],
-                         reply: @escaping (_ json: String?, _ error: String?) -> Void)
 }


### PR DESCRIPTION
## Summary
Follow-ups to the [PR #35](https://github.com/antimatter-studios/diskjockey/pull/35) review (FSClient enable-state). That code is already merged to `main`; this PR addresses the remaining reviewer feedback.

- **`@retroactive` on `String: Error`** (`AgentImpl.swift`) — silences the Swift 6 retroactive-conformance warning (SE-0364) on a type we don't own.
- **Remove the agent's `extensionStates(forBundleIDs:)` path** — the enable-state-via-`pluginkit` query on the unsandboxed agent (`DJAgentClient`, both `DJAgentProtocol` files, `AgentImpl` + its `pluginkitEnabled` helper). Superseded by the in-app `FSClient` path and unreachable in the shipped sandboxed app.

Not changed: the reviewer's `#available(macOS 15.4)` suggestion on `ExtensionStateService` — the project's lowest deployment target is **15.5** (≥ 15.4), so the API is always available; a guard would be dead-always-true.

## Review feedback addressed (PR #35)
| Reviewer | Path:line | Verdict | Fix |
|---|---|---|---|
| greptile-apps | DiskJockeyAgent/AgentImpl.swift:5 | adopt | Added `@retroactive` to the `String: Error` conformance. Commit 1a03f0a. |
| greptile-apps | DiskJockeyApplication/Services/ExtensionStateService.swift:97 | wrong | Lowest deployment target is 15.5 ≥ 15.4, so `FSClient.installedExtensions` is always available; `#available` guard would be dead-always-true. No code change. |
| greptile-apps | DiskJockeyApplication/Services/DJAgentClient.swift:115 | adopt | Removed the dead `extensionStates(forBundleIDs:)` path across client, both protocols, and the agent impl/helper. Commit 1a03f0a. |

## Test plan
- [ ] Build app + DiskJockeyAgent — no retroactive-conformance warning, no missing-symbol from the removed method
- [ ] Home extension Enabled/Disabled state still works (unaffected FSClient path)
