### PR TITLE
chore(hooks): sync github-guard guards (review fixes from agent-skills#13)

### DIFF
--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -74,12 +74,11 @@ fi
 # keep current untouched. (jq required for the union; without it we already
 # fell through with desired='[]' and keep current.)
 if [ -n "$desired" ] && [ "$desired" != "[]" ]; then
-  if command -v jq >/dev/null 2>&1; then
-    want=$(printf '%s\n%s' "$desired" "$current" \
-      | jq -sc 'add | map(select(.context? != null)) | unique')
-  else
-    want="$desired"
-  fi
+  # $desired is only ever non-'[]' when the jq-guarded discovery above populated
+  # it, so jq is guaranteed here — union discovered with existing (additive; never
+  # a bare replace, which is what would drop checks on a partial discovery).
+  want=$(printf '%s\n%s' "$desired" "$current" \
+    | jq -sc 'add | map(select(.context? != null)) | unique')
 elif [ -n "$current" ] && [ "$current" != "[]" ]; then
   want="$current"
 else

--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -36,7 +36,9 @@ branch=$(gh api "repos/$slug" --jq '.default_branch' 2>/dev/null) || {
 desired='[]'
 if command -v jq >/dev/null 2>&1; then
   # check-suite of the latest pull_request run of each PR-triggering workflow.
-  suite_ids=$(gh api "repos/$slug/actions/runs?event=pull_request&per_page=50" \
+  # per_page=100 (not 50) widens the window so a workflow whose latest PR run is
+  # a bit older still gets discovered; the union below is the backstop for gaps.
+  suite_ids=$(gh api "repos/$slug/actions/runs?event=pull_request&per_page=100" \
     --jq '[.workflow_runs[]?] | group_by(.workflow_id)[] | max_by(.created_at) | .check_suite_id' 2>/dev/null)
   desired=$(
     for sid in $suite_ids; do
@@ -63,10 +65,21 @@ fi
      ((.required_status_checks.checks // []) | map({context: .context}) | unique | tojson)' 2>/dev/null)
 [ -n "$current" ] || current='[]'
 
-# Checks to require: prefer a fresh discovery; else keep what's already set;
-# never strip checks just because this commit's HEAD has no Actions runs yet.
+# Checks to require: be strictly ADDITIVE — union what we just discovered with
+# what's already required, never a bare replace. A discovery that's non-empty but
+# PARTIAL (a PR-gating workflow whose latest run fell outside the window above)
+# would otherwise overwrite `current` and silently drop the missing workflows'
+# checks — the exact "never strip existing checks" promise, broken. Union keeps
+# every already-required check and adds any newly-seen one. Empty discovery →
+# keep current untouched. (jq required for the union; without it we already
+# fell through with desired='[]' and keep current.)
 if [ -n "$desired" ] && [ "$desired" != "[]" ]; then
-  want="$desired"
+  if command -v jq >/dev/null 2>&1; then
+    want=$(printf '%s\n%s' "$desired" "$current" \
+      | jq -sc 'add | map(select(.context? != null)) | unique')
+  else
+    want="$desired"
+  fi
 elif [ -n "$current" ] && [ "$current" != "[]" ]; then
   want="$current"
 else

--- a/.githooks/pre-commit.d/rust-clippy.sh
+++ b/.githooks/pre-commit.d/rust-clippy.sh
@@ -21,6 +21,9 @@ root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 while IFS= read -r toml; do
   [ -f "$root/$toml" ] || continue
   tdir=$(cd "$(dirname "$root/$toml")" && pwd) || continue
+  # Feed the loop each `path = "…"` value from this manifest. Anchor `path` to a
+  # key boundary (start / space / , / {) so `manifest-path` & friends don't match,
+  # and drop full-line comments first.
   while IFS= read -r rel; do
     [ -n "$rel" ] || continue
     if [ ! -e "$tdir/$rel" ]; then
@@ -28,8 +31,6 @@ while IFS= read -r toml; do
       echo "             checked out; clippy can't compile without it. CI enforces clippy." >&2
       exit 0
     fi
-    # Anchor `path` to a key boundary (start / space / , / {) so `manifest-path`
-    # and friends don't match; drop full-line comments too.
   done < <(grep -vE '^[[:space:]]*#' "$root/$toml" 2>/dev/null \
              | grep -oE '(^|[[:space:],{])path[[:space:]]*=[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)".*/\1/')
 done < <(git -C "$root" ls-files '*Cargo.toml' 'Cargo.toml')

--- a/.githooks/pre-commit.d/rust-clippy.sh
+++ b/.githooks/pre-commit.d/rust-clippy.sh
@@ -28,7 +28,10 @@ while IFS= read -r toml; do
       echo "             checked out; clippy can't compile without it. CI enforces clippy." >&2
       exit 0
     fi
-  done < <(grep -oE 'path[[:space:]]*=[[:space:]]*"[^"]+"' "$root/$toml" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/')
+    # Anchor `path` to a key boundary (start / space / , / {) so `manifest-path`
+    # and friends don't match; drop full-line comments too.
+  done < <(grep -vE '^[[:space:]]*#' "$root/$toml" 2>/dev/null \
+             | grep -oE '(^|[[:space:],{])path[[:space:]]*=[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)".*/\1/')
 done < <(git -C "$root" ls-files '*Cargo.toml' 'Cargo.toml')
 
 # Run via gg_cargo (the rustup shim), which honors rust-toolchain.toml so local

--- a/.githooks/pre-commit.d/rust-deps-pinned.sh
+++ b/.githooks/pre-commit.d/rust-deps-pinned.sh
@@ -38,17 +38,34 @@ if [ -n "$owner" ] && [ -d .github/workflows ]; then
   shopt -s nullglob 2>/dev/null || true
   for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
     [ -f "$wf" ] || continue
-    while IFS= read -r line; do
-      case "$line" in
+    # Join shell line-continuations (a trailing '\') into one logical line before
+    # scanning: in a `run: |` block a `git clone …\` and its `--branch vX` land on
+    # two physical lines, and a per-physical-line check would flag the first as
+    # unpinned even though the clone is pinned.
+    logical=""
+    while IFS= read -r line || [ -n "$line" ]; do
+      line=${line%$'\r'}
+      logical="${logical:+$logical }$line"
+      case "$logical" in *\\) logical=${logical%\\}; continue ;; esac   # keep joining
+      case "$logical" in
         *"git clone"*github.com[:/]"$owner"/*)
-          case "$line" in
-            *--branch*|*" -b "*) : ;;                      # pinned to a tag → ok
-            *)
-              echo "[deps] FLOATING git clone of a sibling repo (add --branch v<X>) in $wf:" >&2
-              echo "       ${line#"${line%%[![:space:]]*}"}" >&2
+          # A real pin is an IMMUTABLE ref. Pull out the --branch/-b value: empty
+          # means no pin at all, and a well-known MUTABLE branch name (main/master/
+          # …) is just as floating as none — block both; anything else (a tag) ok.
+          brval=$(printf '%s' "$logical" | sed -nE 's/.*[[:space:]](--branch[ =]|-b[[:space:]])([^[:space:]]+).*/\2/p')
+          case "$brval" in
+            main | master | develop | trunk | HEAD)
+              echo "[deps] FLOATING git clone — --branch '$brval' is a MUTABLE branch (pin a tag) in $wf:" >&2
+              echo "       ${logical#"${logical%%[![:space:]]*}"}" >&2
               fail=1 ;;
+            '')
+              echo "[deps] FLOATING git clone of a sibling repo (add --branch v<X>) in $wf:" >&2
+              echo "       ${logical#"${logical%%[![:space:]]*}"}" >&2
+              fail=1 ;;
+            *) : ;;                                        # pinned to a tag → ok
           esac ;;
       esac
+      logical=""
     done < "$wf"
   done
 
@@ -56,10 +73,21 @@ if [ -n "$owner" ] && [ -d .github/workflows ]; then
   # with ruby's stdlib YAML when available; skipped (never failed) if ruby isn't.
   if command -v ruby >/dev/null 2>&1; then
     ruby -ryaml -e '
+      # aliases: is a ruby >= 2.7 kwarg; on older rubies (e.g. macOS system ruby)
+      # passing it raises ArgumentError, which — if rescued straight to nil — would
+      # silently skip EVERY workflow and disable this check. Fall back to a plain
+      # safe_load there so the ref-pinning check still runs.
+      def load_wf(f)
+        YAML.safe_load(File.read(f), aliases: true)
+      rescue ArgumentError
+        (YAML.safe_load(File.read(f)) rescue nil)
+      rescue
+        nil
+      end
       owner = ARGV[0]
       bad = []
       Dir.glob(".github/workflows/*.{yml,yaml}").each do |wf|
-        doc = (YAML.safe_load(File.read(wf), aliases: true) rescue nil)
+        doc = load_wf(wf)
         next unless doc.is_a?(Hash)
         (doc["jobs"] || {}).each_value do |job|
           next unless job.is_a?(Hash)
@@ -121,7 +149,11 @@ elif [ -f Cargo.lock ]; then
   # crates keep the full check.
   ext_path_dep=0
   while IFS= read -r toml; do
-    if grep -qE 'path[[:space:]]*=[[:space:]]*"\.\.?/' "$toml" 2>/dev/null; then ext_path_dep=1; break; fi
+    # Anchor `path` to a key boundary (start / space / , / {) so it matches the
+    # dependency `path =` key, not a suffix like `manifest-path =`; drop full-line
+    # comments so a commented example doesn't count.
+    if grep -vE '^[[:space:]]*#' "$toml" 2>/dev/null \
+         | grep -qE '(^|[[:space:],{])path[[:space:]]*=[[:space:]]*"\.\.?/'; then ext_path_dep=1; break; fi
   done < <(git ls-files '*Cargo.toml' 'Cargo.toml')
   if [ "$ext_path_dep" = 0 ]; then
     # BLOCK only on the staleness signal; any other failure (empty offline cache,

--- a/.githooks/pre-commit.d/rust-deps-pinned.sh
+++ b/.githooks/pre-commit.d/rust-deps-pinned.sh
@@ -52,9 +52,14 @@ if [ -n "$owner" ] && [ -d .github/workflows ]; then
           # A real pin is an IMMUTABLE ref. Pull out the --branch/-b value: empty
           # means no pin at all, and a well-known MUTABLE branch name (main/master/
           # …) is just as floating as none — block both; anything else (a tag) ok.
-          brval=$(printf '%s' "$logical" | sed -nE 's/.*[[:space:]](--branch[ =]|-b[[:space:]])([^[:space:]]+).*/\2/p')
-          case "$brval" in
-            main | master | develop | trunk | HEAD)
+          brval=$(printf '%s' "$logical" | sed -nE 's/.*(^|[[:space:]])(--branch[ =]|-b[[:space:]]*)([^[:space:]]+).*/\3/p')
+          brval=${brval//\"/}; brval=${brval//\'/}     # strip surrounding quotes
+          # Heuristic blocklist of well-known mutable branch names (not exhaustive
+          # by design — the authoritative reproducibility gate is the Cargo.lock
+          # checks below + CI's --locked; this just catches the common offenders).
+          # Matched case-insensitively so Main/MAIN/Develop are caught too.
+          case "$(printf '%s' "$brval" | tr '[:upper:]' '[:lower:]')" in
+            main | master | develop | dev | trunk | head | next | staging | release | canary)
               echo "[deps] FLOATING git clone — --branch '$brval' is a MUTABLE branch (pin a tag) in $wf:" >&2
               echo "       ${logical#"${logical%%[![:space:]]*}"}" >&2
               fail=1 ;;


### PR DESCRIPTION
Brings the committed `.githooks/` up to the reviewed github-guard payload (antimatter-studios/agent-skills#13). Small guard-only diff:

- **rust-deps-pinned**: join shell `\` line-continuations before the git-clone scan (no false 'floating' when `--branch vX` is on the next line); flag mutable `--branch` (main/master/…); anchor the `path =` match to a key boundary.
- **rust-clippy**: anchor the `path =` match; drop comment lines.
- **github-protect-main**: required checks = union of discovered + already-required (window 50→100) so a pagination gap can't drop a required check.

No behavior change for non-Rust repos beyond the protect-main hardening.