### PR TITLE
ci(release): build only on v* tags (MAS-only, private)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ name: Release
 
 on:
   push:
-    branches: [main]
     tags: ['v*']
   workflow_dispatch:
 


### PR DESCRIPTION
Release runs on `v*` tags + manual dispatch only (was also every `main` push, which failed at cert import and isn't a release). Repo is now private, so artifacts stay private. Signing secrets are scaffolded; fill them to enable signed MAS uploads.