### PR TITLE
ci(release): validate ASC issuer, force distribution identity, verify signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,9 +133,10 @@ jobs:
       - name: Set up App Store Connect API key (cloud signing + upload)
         env:
           ASC_KEY_ID:     ${{ secrets.APPLE_ASC_KEY_ID }}
+          ASC_ISSUER_ID:  ${{ secrets.APPLE_ASC_ISSUER_ID }}
           ASC_KEY_BASE64: ${{ secrets.APPLE_ASC_API_KEY }}
         run: |
-          if [ -z "$ASC_KEY_BASE64" ] || [ -z "$ASC_KEY_ID" ]; then
+          if [ -z "$ASC_KEY_BASE64" ] || [ -z "$ASC_KEY_ID" ] || [ -z "$ASC_ISSUER_ID" ]; then
             echo "::error::Cloud signing needs an App Store Connect API key — set APPLE_ASC_KEY_ID, APPLE_ASC_ISSUER_ID and APPLE_ASC_API_KEY."
             exit 1
           fi
@@ -163,6 +164,7 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             -allowProvisioningUpdates \
             -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
             -authenticationKeyID "$ASC_KEY_ID" \
@@ -185,6 +187,26 @@ jobs:
             -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+      # ---------------------------------------------------------------------------
+      # Verify signatures — fails the build if the app/pkg aren't correctly signed
+      # by the expected identities. Pure inspection; nothing is submitted.
+      # ---------------------------------------------------------------------------
+      - name: Verify signatures
+        run: |
+          APP=$(find "$EXPORT_PATH" -maxdepth 3 -name '*.app' | head -1)
+          PKG=$(find "$EXPORT_PATH" -maxdepth 3 -name '*.pkg' | head -1)
+          echo "== app bundle: $APP =="
+          if [ -n "$APP" ]; then
+            codesign --verify --deep --strict --verbose=2 "$APP"
+            codesign -dvvv "$APP" 2>&1 | grep -E 'Authority=|TeamIdentifier=|Identifier=' || true
+          fi
+          echo "== installer pkg: $PKG =="
+          if [ -n "$PKG" ]; then
+            pkgutil --check-signature "$PKG"
+          else
+            echo "::warning::no .pkg found in export"
+          fi
 
       # ---------------------------------------------------------------------------
       # App Store Connect upload


### PR DESCRIPTION
Addresses the Greptile review: fail-fast on a missing `APPLE_ASC_ISSUER_ID`, force `Apple Distribution` on the archive (project defaults to Apple Development), and add a **Verify signatures** step (`codesign --verify` + `pkgutil --check-signature`) so each build proves its own signing without submitting.