### PR TITLE
MAS release pipeline: build fix + manual App Store signing

### DIFF
--- a/.github/ExportOptions.plist
+++ b/.github/ExportOptions.plist
@@ -32,14 +32,18 @@
     <string>manual</string>
 
     <!--
-        No signingCertificate here on purpose: xcodebuild signs the .app with
-        the certificate embedded in each provisioning profile below (Apple
-        Distribution) and signs the .pkg with the imported "3rd Party Mac
-        Developer Installer" identity automatically. Pinning signingCertificate
-        made xcodebuild mis-select the installer identity for the app targets
-        ("profile doesn't include signing certificate '3rd Party Mac Developer
-        Installer'").
+        Pin BOTH identities by SHA-1 so xcodebuild doesn't conflate them:
+          * signingCertificate           = Apple Distribution (signs .app + extensions)
+          * installerSigningCertificate  = 3rd Party Mac Developer Installer (signs .pkg)
+        Without the installer pin, xcodebuild tried to sign the app targets with
+        the installer identity ("profile doesn't include signing certificate
+        '3rd Party Mac Developer Installer'").
     -->
+    <key>signingCertificate</key>
+    <string>65F8156857B05C340368A2235792B44FE624365E</string>
+    <key>installerSigningCertificate</key>
+    <string>F1929FCBD230EA7A859A1398918D1E9C233523A8</string>
+
     <key>provisioningProfiles</key>
     <dict>
         <key>com.antimatterstudios.diskjockey</key>

--- a/.github/ExportOptions.plist
+++ b/.github/ExportOptions.plist
@@ -16,13 +16,39 @@
     <string>XXXXXXXXXX</string>
 
     <!--
-        Automatic (cloud) signing: Xcode generates the App Store distribution
-        provisioning profiles on the fly using the App Store Connect API key that
-        release.yml passes to xcodebuild (-allowProvisioningUpdates + the
-        -authenticationKey* flags). No manual .provisionprofile files are needed.
+        Manual signing. Xcode's cloud signing (-allowProvisioningUpdates + an
+        App Store Connect API key) CANNOT manage macOS App Store *distribution*
+        profiles for this team/key — it fails with "Cloud signing permission
+        error / No profiles were found". So we sign manually:
+          * the App Store distribution profiles are pre-created in App Store
+            Connect (one per bundle id, each carrying that target's capabilities
+            e.g. com.apple.developer.fskit.fsmodule for the FSKit extensions),
+          * release.yml installs them on the runner ("Install App Store
+            provisioning profiles" step) before export,
+          * and we re-sign against the imported "Apple Distribution" certificate.
+        Profile names below must match those created in App Store Connect.
     -->
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
+
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.antimatterstudios.diskjockey</key>
+        <string>DiskJockey-app-AppStore</string>
+        <key>com.antimatterstudios.diskjockey.fileprovider</key>
+        <string>DiskJockey-fileprovider-AppStore</string>
+        <key>com.antimatterstudios.diskjockey.ntfs</key>
+        <string>DiskJockey-ntfs-AppStore</string>
+        <key>com.antimatterstudios.diskjockey.ext4</key>
+        <string>DiskJockey-ext4-AppStore</string>
+        <key>com.antimatterstudios.diskjockey.erofs</key>
+        <string>DiskJockey-erofs-AppStore</string>
+        <key>com.antimatterstudios.diskjockey.squashfs</key>
+        <string>DiskJockey-squashfs-AppStore</string>
+    </dict>
 
     <!-- Bitcode is not supported on macOS. -->
     <key>uploadBitcode</key>

--- a/.github/ExportOptions.plist
+++ b/.github/ExportOptions.plist
@@ -31,9 +31,15 @@
     <key>signingStyle</key>
     <string>manual</string>
 
-    <key>signingCertificate</key>
-    <string>Apple Distribution</string>
-
+    <!--
+        No signingCertificate here on purpose: xcodebuild signs the .app with
+        the certificate embedded in each provisioning profile below (Apple
+        Distribution) and signs the .pkg with the imported "3rd Party Mac
+        Developer Installer" identity automatically. Pinning signingCertificate
+        made xcodebuild mis-select the installer identity for the app targets
+        ("profile doesn't include signing certificate '3rd Party Mac Developer
+        Installer'").
+    -->
     <key>provisioningProfiles</key>
     <dict>
         <key>com.antimatterstudios.diskjockey</key>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,25 @@ jobs:
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
+      # Install the App Store *distribution* provisioning profiles. They are
+      # pre-created in App Store Connect (one per bundle id, each carrying that
+      # target's capabilities, e.g. com.apple.developer.fskit.fsmodule for the
+      # FSKit extensions) and fetched here via the App Store Connect API. Xcode
+      # cloud signing (-allowProvisioningUpdates) cannot manage macOS App Store
+      # distribution profiles for this key — it fails with "Cloud signing
+      # permission error" — so the export below signs manually against them.
+      - name: Install App Store provisioning profiles
+        env:
+          ASC_KEY_ID:      ${{ secrets.APPLE_ASC_KEY_ID }}
+          ASC_ISSUER_ID:   ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          ASC_API_KEY_B64: ${{ secrets.APPLE_ASC_API_KEY }}
+        run: |
+          python3 -m venv "$RUNNER_TEMP/pyvenv"
+          "$RUNNER_TEMP/pyvenv/bin/pip" install --quiet cryptography
+          "$RUNNER_TEMP/pyvenv/bin/python" scripts/install-profiles.py
+
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store
-        env:
-          ASC_KEY_ID:    ${{ secrets.APPLE_ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
         run: |
           sed "s/XXXXXXXXXX/${{ secrets.APPLE_TEAM_ID }}/g" \
             .github/ExportOptions.plist > "$RUNNER_TEMP/ExportOptions.plist"
@@ -189,11 +203,7 @@ jobs:
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
-            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
 
       # ---------------------------------------------------------------------------
       # Verify signatures — fails the build if the app/pkg aren't correctly signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,16 +194,6 @@ jobs:
           "$RUNNER_TEMP/pyvenv/bin/pip" install --quiet cryptography
           "$RUNNER_TEMP/pyvenv/bin/python" scripts/install-profiles.py
 
-      # TEMP diagnostic: show which signing identities xcodebuild can see.
-      - name: Debug signing identities
-        run: |
-          echo "== codesigning identities =="
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
-          echo "== macappstore identities =="
-          security find-identity -v -p macappstore "$KEYCHAIN_PATH" || true
-          echo "== all identities in CI keychain =="
-          security find-identity -v "$KEYCHAIN_PATH" || true
-
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store
         run: |
@@ -214,19 +204,6 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
-
-      # TEMP diagnostic: on export failure, dump xcodebuild's IDEDistribution
-      # decision log — it records exactly which identity/profile it chose per
-      # target and why the choice was rejected.
-      - name: Dump distribution logs on failure
-        if: failure()
-        run: |
-          for d in $(find "${TMPDIR:-/tmp}" /var/folders -maxdepth 4 -name '*.xcdistributionlogs' -type d 2>/dev/null); do
-            echo "##### logs dir: $d"
-            find "$d" -type f | while read -r f; do
-              echo "===== $f ====="; cat "$f"; echo
-            done
-          done
 
       # ---------------------------------------------------------------------------
       # Verify signatures — fails the build if the app/pkg aren't correctly signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,10 +151,11 @@ jobs:
       # ---------------------------------------------------------------------------
 
       - name: Archive
-        env:
-          ASC_KEY_ID:    ${{ secrets.APPLE_ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
         run: |
+          # Archive WITHOUT signing. The app-store export step below re-signs the
+          # app + all extensions with the distribution cert and generates the
+          # provisioning profiles via the ASC key — so the archive needs no
+          # development identity (which CI doesn't have).
           xcodebuild archive \
             -project DiskJockey.xcodeproj \
             -scheme DiskJockey \
@@ -163,11 +164,7 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
-            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
 
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,16 @@ jobs:
           "$RUNNER_TEMP/pyvenv/bin/pip" install --quiet cryptography
           "$RUNNER_TEMP/pyvenv/bin/python" scripts/install-profiles.py
 
+      # TEMP diagnostic: show which signing identities xcodebuild can see.
+      - name: Debug signing identities
+        run: |
+          echo "== codesigning identities =="
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+          echo "== macappstore identities =="
+          security find-identity -v -p macappstore "$KEYCHAIN_PATH" || true
+          echo "== all identities in CI keychain =="
+          security find-identity -v "$KEYCHAIN_PATH" || true
+
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store
         run: |
@@ -204,6 +214,19 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+
+      # TEMP diagnostic: on export failure, dump xcodebuild's IDEDistribution
+      # decision log — it records exactly which identity/profile it chose per
+      # target and why the choice was rejected.
+      - name: Dump distribution logs on failure
+        if: failure()
+        run: |
+          for d in $(find "${TMPDIR:-/tmp}" /var/folders -maxdepth 4 -name '*.xcdistributionlogs' -type d 2>/dev/null); do
+            echo "##### logs dir: $d"
+            find "$d" -type f | while read -r f; do
+              echo "===== $f ====="; cat "$f"; echo
+            done
+          done
 
       # ---------------------------------------------------------------------------
       # Verify signatures — fails the build if the app/pkg aren't correctly signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: lib/
-          key: vendor-${{ runner.os }}-${{ hashFiles('VENDOR_PINS.txt') }}
+          # v2 salt busts caches saved by earlier failed runs that populated
+          # lib/fs_* but not lib/bundle_* (incomplete tree → missing headers).
+          key: vendor-${{ runner.os }}-v2-${{ hashFiles('VENDOR_PINS.txt', 'scripts/build-bundles.sh') }}
 
       - name: Restore Cargo cache
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -93,7 +95,11 @@ jobs:
 
       - name: Build vendor libraries
         if: steps.vendor-cache.outputs.cache-hit != 'true'
-        run: make vendor-fs-ext4 vendor-fs-ntfs vendor-fs-erofs vendor-fs-squashfs vendor-img-containers vendor-gonetworkfs
+        # vendor-bundles builds lib/bundle_<fs>/{libdj_<fs>_bundle.a,include/*.h}
+        # (via build-bundles.sh) — the aggregator staticlibs + C headers the
+        # FSKit extensions actually link/#import (e.g. fs_ntfs.h). Without it the
+        # archive fails: DiskJockeyNTFS-Bridging-Header.h → 'fs_ntfs.h' not found.
+        run: make vendor-fs-ext4 vendor-fs-ntfs vendor-fs-erofs vendor-fs-squashfs vendor-img-containers vendor-gonetworkfs vendor-bundles
 
       # ---------------------------------------------------------------------------
       # Code signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,6 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
             -allowProvisioningUpdates \
             -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
             -authenticationKeyID "$ASC_KEY_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,15 @@ jobs:
 
       - name: Import signing certificates (app + installer)
         env:
-          APPLE_CERTIFICATE:           ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_INSTALLER_CERTIFICATE: ${{ secrets.APPLE_INSTALLER_CERTIFICATE }}
-          P12_PASSWORD:                ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_CERTIFICATE:              ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_INSTALLER_CERTIFICATE:    ${{ secrets.APPLE_INSTALLER_CERTIFICATE }}
+          APPLE_DEVELOPMENT_CERTIFICATE:  ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE }}
+          P12_PASSWORD:                   ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
           KEYCHAIN_PASSWORD=$(openssl rand -base64 24)   # CI-only keychain, never stored
-          echo -n "$APPLE_CERTIFICATE"           | base64 --decode -o "$RUNNER_TEMP/app_cert.p12"
-          echo -n "$APPLE_INSTALLER_CERTIFICATE" | base64 --decode -o "$RUNNER_TEMP/installer_cert.p12"
+          echo -n "$APPLE_CERTIFICATE"             | base64 --decode -o "$RUNNER_TEMP/app_cert.p12"
+          echo -n "$APPLE_INSTALLER_CERTIFICATE"   | base64 --decode -o "$RUNNER_TEMP/installer_cert.p12"
+          echo -n "$APPLE_DEVELOPMENT_CERTIFICATE" | base64 --decode -o "$RUNNER_TEMP/dev_cert.p12"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
@@ -115,7 +117,7 @@ jobs:
 
           # app cert = Apple Distribution (signs the app); installer cert = Mac
           # Installer Distribution (signs the .pkg for the store).
-          for p12 in app_cert installer_cert; do
+          for p12 in app_cert installer_cert dev_cert; do
             security import "$RUNNER_TEMP/$p12.p12" \
               -P "$P12_PASSWORD" \
               -A -t cert -f pkcs12 \
@@ -151,11 +153,10 @@ jobs:
       # ---------------------------------------------------------------------------
 
       - name: Archive
+        env:
+          ASC_KEY_ID:    ${{ secrets.APPLE_ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
         run: |
-          # Archive WITHOUT signing. The app-store export step below re-signs the
-          # app + all extensions with the distribution cert and generates the
-          # provisioning profiles via the ASC key — so the archive needs no
-          # development identity (which CI doesn't have).
           xcodebuild archive \
             -project DiskJockey.xcodeproj \
             -scheme DiskJockey \
@@ -164,7 +165,11 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
-            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/asc_key.p8" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store

--- a/scripts/install-profiles.py
+++ b/scripts/install-profiles.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""CI: download the DiskJockey App Store provisioning profiles from App Store
+Connect and install them so xcodebuild can sign manually. Idempotent; no secret
+values are printed. Env: ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY_B64 (base64 .p8).
+
+Profiles are matched by the name prefix used when they were created
+(DiskJockey-*-AppStore) and written to
+~/Library/MobileDevice/Provisioning Profiles/<UUID>.provisionprofile.
+"""
+import base64, json, time, os, sys, urllib.request, urllib.error
+from cryptography.hazmat.primitives.asymmetric import ec, utils as asymutils
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+kid=os.environ["ASC_KEY_ID"].strip()
+iss=os.environ["ASC_ISSUER_ID"].strip()
+p8=base64.b64decode(os.environ["ASC_API_KEY_B64"].strip())
+PREFIX=os.environ.get("PROFILE_PREFIX","DiskJockey-")
+
+def b64u(b): return base64.urlsafe_b64encode(b).rstrip(b"=")
+def jwt():
+    key=load_pem_private_key(p8,None); now=int(time.time())
+    h=b64u(json.dumps({"alg":"ES256","kid":kid,"typ":"JWT"}).encode())
+    pl=b64u(json.dumps({"iss":iss,"iat":now,"exp":now+900,"aud":"appstoreconnect-v1"}).encode())
+    si=h+b"."+pl
+    r,s=asymutils.decode_dss_signature(key.sign(si,ec.ECDSA(hashes.SHA256())))
+    return (si+b"."+b64u(r.to_bytes(32,"big")+s.to_bytes(32,"big"))).decode()
+def api(path):
+    req=urllib.request.Request("https://api.appstoreconnect.apple.com"+path,
+        headers={"Authorization":"Bearer "+jwt()})
+    with urllib.request.urlopen(req,timeout=60) as r: return json.load(r)
+
+dest=os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles")
+os.makedirs(dest,exist_ok=True)
+
+data=api("/v1/profiles?limit=200&fields[profiles]=name,uuid,profileContent,profileState")["data"]
+installed=0
+for p in data:
+    a=p["attributes"]
+    if not a["name"].startswith(PREFIX): continue
+    if a.get("profileState")!="ACTIVE": continue
+    content=base64.b64decode(a["profileContent"])
+    path=os.path.join(dest,a["uuid"]+".provisionprofile")
+    open(path,"wb").write(content)
+    print(f"installed {a['name']}  ({a['uuid']})")
+    installed+=1
+if installed==0:
+    print("ERROR: no matching profiles found",file=sys.stderr); sys.exit(1)
+print(f"{installed} profile(s) installed into {dest}")


### PR DESCRIPTION
Gets the Release workflow to build, sign, and (when `MAS_SUBMIT=true`) submit DiskJockey to the Mac App Store. Triggers only on `v*` tags + manual dispatch; submission stays gated behind the `MAS_SUBMIT` repo variable.

## What was broken, and the fixes

1. **Build failed at the FSKit extensions** (`'fs_ntfs.h' file not found`).
   CI built only the per-crate `lib/fs_*` halves, never `vendor-bundles`, so `lib/bundle_<fs>/include/*.h` (the headers the extensions `#import`) never existed on the runner. Added `vendor-bundles` to the build step and salted the vendor cache key (`v2`) to drop caches poisoned by earlier failed runs.

2. **Cloud signing can't manage macOS App Store *distribution* profiles for this team/key** (`Cloud signing permission error / No profiles were found`), even after the profiles exist. Switched export to **manual signing**:
   - `scripts/install-profiles.py` fetches the App Store distribution profiles from App Store Connect at runtime (reuses the existing `APPLE_ASC_*` secrets — no new secret).
   - `ExportOptions.plist`: `signingStyle=manual` + explicit `provisioningProfiles` map for all 6 bundle ids.

3. **xcodebuild signed app targets with the installer identity** (`profile doesn't include signing certificate '3rd Party Mac Developer Installer'`). Pinned **both** identities by SHA-1: `signingCertificate` (Apple Distribution, for the app) and `installerSigningCertificate` (3rd Party Mac Developer Installer, for the `.pkg`).

Also created via the ASC API (persist in the account, backed up locally): the Apple Distribution + Mac Installer Distribution + Apple Development certs, and one `MAC_APP_STORE` profile per bundle id (each carrying its target's capabilities, incl. `com.apple.developer.fskit.fsmodule`).

## ⚠️ One manual step before this is green

The **erofs** and **squashfs** bundle ids are missing the **App Group** `group.com.antimatterstudios.diskjockey` (the other four targets have it — your local Xcode associates it automatically via `-allowProvisioningUpdates`). The App Store Connect API has **no App Groups support** (`/v1/appGroups` doesn't exist), so this can't be automated. Do one of:

- **Xcode** → select the *DiskJockeyEROFS* and *DiskJockeySQUASHFS* targets → Signing & Capabilities → App Groups → add `group.com.antimatterstudios.diskjockey`; or
- **developer.apple.com** → Identifiers → `com.antimatterstudios.diskjockey.erofs` and `.squashfs` → App Groups → assign `group.com.antimatterstudios.diskjockey`.

Then re-run the Release workflow (manual dispatch). It should go green.

## Current validation state

On the latest run, **4 of 6 targets sign fully** (app, fileprovider, ntfs, ext4 — cert + FSKit + App Groups all pass). Only erofs + squashfs fail, and only on the App Group above — proving the rest of the pipeline (build, profile install, manual signing, cert pinning) is correct.