### PR TITLE
chore(github-guard): sync deployed hooks to latest

### DIFF
--- a/.githooks/lib/common.sh
+++ b/.githooks/lib/common.sh
@@ -9,15 +9,33 @@
 # Echo the GitHub "owner/repo" slug for origin, or nothing if origin is missing
 # or not on github.com.
 gg_repo_slug() {
-  local url
+  local url rest host path
   url=$(git remote get-url origin 2>/dev/null) || return 0
+  url=${url%.git}
   case "$url" in
-    *github.com[:/]*) ;;
+    ssh://*|https://*|http://*)
+      # scheme://[user@]host[:port]/owner/repo (incl. GitHub SSH-over-443,
+      # ssh://git@ssh.github.com:443/owner/repo).
+      rest=${url#*://}; rest=${rest#*@}
+      host=${rest%%/*}; host=${host%%:*}
+      path=${rest#*/}
+      ;;
+    *:*)
+      # scp-style [user@]host:owner/repo (git@github.com:owner/repo).
+      host=${url%%:*}; host=${host#*@}
+      path=${url#*:}
+      ;;
+    *)
+      return 0 ;;
+  esac
+  # Only claim a slug for a real GitHub host — never a substring match like
+  # https://evil.com/github.com/owner/repo or ssh://git@github.com.example.org/…,
+  # which would otherwise let the GitHub guards act on an unrelated repo.
+  case "$host" in
+    github.com|ssh.github.com) ;;
     *) return 0 ;;
   esac
-  url=${url%.git}
-  url=${url#*github.com[:/]}
-  printf '%s' "$url"
+  printf '%s' "$path"
 }
 
 # True if gh is installed and authenticated.

--- a/.githooks/pre-commit.d/github-merge-squash-only.sh
+++ b/.githooks/pre-commit.d/github-merge-squash-only.sh
@@ -12,11 +12,26 @@ gg_have_gh || { echo "github-guard: gh not installed/authed — skipping merge-s
 owner=${slug%%/*}
 gg_user_owns "$owner" || exit 0
 
-allow=$(gh api "repos/$slug" --jq '.allow_merge_commit' 2>/dev/null) || {
-  echo "github-guard: couldn't read merge settings for $slug — skipping" >&2; exit 0; }
+# Reconcile the FULL desired state — no merge commits, squash + rebase allowed —
+# whenever ANY of the three differ. Reading only allow_merge_commit missed the
+# common case of a repo that already has merge commits off but still disallows
+# squash (e.g. rebase-only): the old check saw merge_commit=false and skipped,
+# leaving squash disabled so `gh pr merge --squash` failed.
+set -- $(gh api "repos/$slug" \
+  --jq '"\(.allow_merge_commit) \(.allow_squash_merge) \(.allow_rebase_merge)"' 2>/dev/null)
+mc=${1:-} sq=${2:-} rb=${3:-}
+# Only act on a well-formed response: each field must be a literal boolean. A
+# missing field makes jq emit "null" (non-empty), and a failed/edge read yields
+# empty — neither must be mistaken for "needs reconciling" and trigger a PATCH.
+for v in "$mc" "$sq" "$rb"; do
+  case "$v" in
+    true|false) ;;
+    *) echo "github-guard: unexpected merge-settings response for $slug — skipping" >&2; exit 0 ;;
+  esac
+done
 
-if [ "$allow" = "true" ]; then
-  echo "github-guard: $slug allows merge commits — switching to squash+rebase only…" >&2
+if [ "$mc" != "false" ] || [ "$sq" != "true" ] || [ "$rb" != "true" ]; then
+  echo "github-guard: $slug merge settings (merge=$mc squash=$sq rebase=$rb) — reconciling to squash+rebase only…" >&2
   if gh api -X PATCH "repos/$slug" \
        -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=true \
        >/dev/null 2>&1; then


### PR DESCRIPTION
Re-syncs this repo's committed `.githooks/` to the current github-guard source: the squash-only guard now reconciles the full merge-method state (not just `allow_merge_commit`), plus the `ssh://…:443` slug fix in `common.sh`. Mechanical sync.