### PR TITLE
harden(release): robust profile install + cache key + runtime cert pins

### DIFF
--- a/.github/ExportOptions.plist
+++ b/.github/ExportOptions.plist
@@ -32,17 +32,22 @@
     <string>manual</string>
 
     <!--
-        Pin BOTH identities by SHA-1 so xcodebuild doesn't conflate them:
+        Pin BOTH identities so xcodebuild doesn't conflate them:
           * signingCertificate           = Apple Distribution (signs .app + extensions)
           * installerSigningCertificate  = 3rd Party Mac Developer Installer (signs .pkg)
         Without the installer pin, xcodebuild tried to sign the app targets with
         the installer identity ("profile doesn't include signing certificate
         '3rd Party Mac Developer Installer'").
+
+        The SHA-1 fingerprints are injected at runtime by release.yml from the
+        certificates it actually imported (APP_CERT_SHA1 / INSTALLER_CERT_SHA1),
+        so rotating the .p12 secrets needs no change here. SHA-1 (not a name) is
+        used because multiple "Apple Distribution" certs can share a name.
     -->
     <key>signingCertificate</key>
-    <string>65F8156857B05C340368A2235792B44FE624365E</string>
+    <string>APP_CERT_SHA1</string>
     <key>installerSigningCertificate</key>
-    <string>F1929FCBD230EA7A859A1398918D1E9C233523A8</string>
+    <string>INSTALLER_CERT_SHA1</string>
 
     <key>provisioningProfiles</key>
     <dict>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,10 @@ jobs:
           path: lib/
           # v2 salt busts caches saved by earlier failed runs that populated
           # lib/fs_* but not lib/bundle_* (incomplete tree → missing headers).
-          key: vendor-${{ runner.os }}-v2-${{ hashFiles('VENDOR_PINS.txt', 'scripts/build-bundles.sh') }}
+          # Also key on the bundle crates' manifests/lockfiles: lib/bundle_*
+          # (staticlibs + headers) are produced from rust-bundles/dj-*-bundle, so
+          # a dependency/version change there must invalidate the cache too.
+          key: vendor-${{ runner.os }}-v3-${{ hashFiles('VENDOR_PINS.txt', 'scripts/build-bundles.sh', 'rust-bundles/**/Cargo.toml', 'rust-bundles/**/Cargo.lock') }}
 
       - name: Restore Cargo cache
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -138,6 +141,18 @@ jobs:
 
           security list-keychain -d user -s "$KEYCHAIN_PATH"
 
+          # Resolve the imported identities' SHA-1 fingerprints for the export
+          # step (ExportOptions pins them). Derived from whatever certs the .p12
+          # secrets contain, so rotating a cert needs no plist/workflow change.
+          APP_CERT_SHA1=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk '/Apple Distribution/{print $2; exit}')
+          INSTALLER_CERT_SHA1=$(security find-identity -v "$KEYCHAIN_PATH" | awk '/3rd Party Mac Developer Installer/{print $2; exit}')
+          if [ -z "$APP_CERT_SHA1" ] || [ -z "$INSTALLER_CERT_SHA1" ]; then
+            echo "::error::Couldn't resolve the Apple Distribution / 3rd Party Mac Developer Installer identities from the imported certificates."
+            exit 1
+          fi
+          echo "APP_CERT_SHA1=$APP_CERT_SHA1" >> "$GITHUB_ENV"
+          echo "INSTALLER_CERT_SHA1=$INSTALLER_CERT_SHA1" >> "$GITHUB_ENV"
+
       - name: Set up App Store Connect API key (cloud signing + upload)
         env:
           ASC_KEY_ID:     ${{ secrets.APPLE_ASC_KEY_ID }}
@@ -197,7 +212,9 @@ jobs:
       # Inject the real team ID into the committed template at export time.
       - name: Export for App Store
         run: |
-          sed "s/XXXXXXXXXX/${{ secrets.APPLE_TEAM_ID }}/g" \
+          sed -e "s/XXXXXXXXXX/${{ secrets.APPLE_TEAM_ID }}/g" \
+              -e "s/APP_CERT_SHA1/$APP_CERT_SHA1/g" \
+              -e "s/INSTALLER_CERT_SHA1/$INSTALLER_CERT_SHA1/g" \
             .github/ExportOptions.plist > "$RUNNER_TEMP/ExportOptions.plist"
 
           xcodebuild -exportArchive \

--- a/scripts/install-profiles.py
+++ b/scripts/install-profiles.py
@@ -3,47 +3,75 @@
 Connect and install them so xcodebuild can sign manually. Idempotent; no secret
 values are printed. Env: ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY_B64 (base64 .p8).
 
-Profiles are matched by the name prefix used when they were created
-(DiskJockey-*-AppStore) and written to
-~/Library/MobileDevice/Provisioning Profiles/<UUID>.provisionprofile.
+Requires ALL of the profiles below (one per app/extension bundle id); the export
+plist references each explicitly, so a partial set must fail HERE — naming the
+missing profile — rather than later during `xcodebuild -exportArchive`. Profiles
+are written to ~/Library/MobileDevice/Provisioning Profiles/<UUID>.provisionprofile.
 """
 import base64, json, time, os, sys, urllib.request, urllib.error
 from cryptography.hazmat.primitives.asymmetric import ec, utils as asymutils
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
-kid=os.environ["ASC_KEY_ID"].strip()
-iss=os.environ["ASC_ISSUER_ID"].strip()
-p8=base64.b64decode(os.environ["ASC_API_KEY_B64"].strip())
-PREFIX=os.environ.get("PROFILE_PREFIX","DiskJockey-")
+# The App Store distribution profiles this build must sign against — every one
+# is required (they map 1:1 to the provisioningProfiles in ExportOptions.plist).
+REQUIRED = [
+    "DiskJockey-app-AppStore",
+    "DiskJockey-fileprovider-AppStore",
+    "DiskJockey-ntfs-AppStore",
+    "DiskJockey-ext4-AppStore",
+    "DiskJockey-erofs-AppStore",
+    "DiskJockey-squashfs-AppStore",
+]
+
+kid = os.environ["ASC_KEY_ID"].strip()
+iss = os.environ["ASC_ISSUER_ID"].strip()
+p8 = base64.b64decode(os.environ["ASC_API_KEY_B64"].strip())
 
 def b64u(b): return base64.urlsafe_b64encode(b).rstrip(b"=")
 def jwt():
-    key=load_pem_private_key(p8,None); now=int(time.time())
-    h=b64u(json.dumps({"alg":"ES256","kid":kid,"typ":"JWT"}).encode())
-    pl=b64u(json.dumps({"iss":iss,"iat":now,"exp":now+900,"aud":"appstoreconnect-v1"}).encode())
-    si=h+b"."+pl
-    r,s=asymutils.decode_dss_signature(key.sign(si,ec.ECDSA(hashes.SHA256())))
-    return (si+b"."+b64u(r.to_bytes(32,"big")+s.to_bytes(32,"big"))).decode()
+    key = load_pem_private_key(p8, None); now = int(time.time())
+    h = b64u(json.dumps({"alg": "ES256", "kid": kid, "typ": "JWT"}).encode())
+    pl = b64u(json.dumps({"iss": iss, "iat": now, "exp": now + 900, "aud": "appstoreconnect-v1"}).encode())
+    si = h + b"." + pl
+    r, s = asymutils.decode_dss_signature(key.sign(si, ec.ECDSA(hashes.SHA256())))
+    return (si + b"." + b64u(r.to_bytes(32, "big") + s.to_bytes(32, "big"))).decode()
 def api(path):
-    req=urllib.request.Request("https://api.appstoreconnect.apple.com"+path,
-        headers={"Authorization":"Bearer "+jwt()})
-    with urllib.request.urlopen(req,timeout=60) as r: return json.load(r)
+    req = urllib.request.Request("https://api.appstoreconnect.apple.com" + path,
+                                 headers={"Authorization": "Bearer " + jwt()})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
 
-dest=os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles")
-os.makedirs(dest,exist_ok=True)
+# Fetch ALL profiles, following pagination — a required profile may sit past the
+# first page once the account accumulates >200 profiles.
+def all_profiles():
+    items, path = [], "/v1/profiles?limit=200&fields[profiles]=name,uuid,profileContent,profileState"
+    while path:
+        page = api(path)
+        items.extend(page.get("data", []))
+        nxt = (page.get("links") or {}).get("next")
+        path = nxt[len("https://api.appstoreconnect.apple.com"):] if nxt else None
+    return items
 
-data=api("/v1/profiles?limit=200&fields[profiles]=name,uuid,profileContent,profileState")["data"]
-installed=0
-for p in data:
-    a=p["attributes"]
-    if not a["name"].startswith(PREFIX): continue
-    if a.get("profileState")!="ACTIVE": continue
-    content=base64.b64decode(a["profileContent"])
-    path=os.path.join(dest,a["uuid"]+".provisionprofile")
-    open(path,"wb").write(content)
-    print(f"installed {a['name']}  ({a['uuid']})")
-    installed+=1
-if installed==0:
-    print("ERROR: no matching profiles found",file=sys.stderr); sys.exit(1)
-print(f"{installed} profile(s) installed into {dest}")
+by_name = {}
+for p in all_profiles():
+    by_name[p["attributes"]["name"]] = p["attributes"]
+
+dest = os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles")
+os.makedirs(dest, exist_ok=True)
+
+missing, inactive = [], []
+for name in REQUIRED:
+    a = by_name.get(name)
+    if a is None:
+        missing.append(name); continue
+    if a.get("profileState") != "ACTIVE":
+        inactive.append(f"{name} ({a.get('profileState')})"); continue
+    open(os.path.join(dest, a["uuid"] + ".provisionprofile"), "wb").write(base64.b64decode(a["profileContent"]))
+    print(f"installed {name}  ({a['uuid']})")
+
+if missing or inactive:
+    if missing:   print("ERROR: missing App Store profiles: " + ", ".join(missing), file=sys.stderr)
+    if inactive:  print("ERROR: non-ACTIVE App Store profiles: " + ", ".join(inactive), file=sys.stderr)
+    sys.exit(1)
+print(f"all {len(REQUIRED)} required profile(s) installed into {dest}")


### PR DESCRIPTION
Follow-up addressing the Greptile review on #45.

- **install-profiles.py** now requires **all six** App Store profiles (was: install any `DiskJockey-*` prefix match, succeed if `>=1`). It paginates the profiles list and **fails naming the missing/inactive profile**, instead of letting a partial install surface later as a cryptic `xcodebuild -exportArchive` error.
- **Vendor cache key** also hashes `rust-bundles/**/Cargo.{toml,lock}` — `lib/bundle_*` (staticlibs + headers) come from the bundle crates, so a dependency/version bump there must invalidate the cache (bumped `v2`→`v3`).
- **ExportOptions.plist** pins the signing identities via `APP_CERT_SHA1`/`INSTALLER_CERT_SHA1` placeholders that release.yml fills at runtime from the **actually-imported** certs — rotating the `.p12` secrets no longer requires editing the plist. SHA-1 (not a name) is kept because multiple "Apple Distribution" certs can share a name.