### PR TITLE
chore(githooks): upgrade github-guard guards to current version

### DIFF
--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -26,9 +26,10 @@ branch=$(gh api "repos/$slug" --jq '.default_branch' 2>/dev/null) || {
 # that can't complete. Take the latest pull_request run per workflow and union
 # their check-run names: exactly the PR gate. The github-actions app filter
 # still excludes third-party checks like coderabbit. Self-healing — a renamed or
-# added CI job syncs after the next PR runs it; never strips existing checks on
-# a transient empty discovery. jq required; without it we preserve whatever's
-# already set (fail-open).
+# added CI job syncs after the next PR runs it AND it has passed on main once
+# (see the `passed` gate below); never strips existing checks on a transient
+# empty discovery. jq required; without it we preserve whatever's already set
+# (fail-open).
 #
 # Both `desired` (here) and `current` (the read-back below) end as compact JSON
 # straight from jq (`jq -c` / `tojson`), so escaping (quotes, backslashes) and
@@ -51,6 +52,28 @@ if command -v jq >/dev/null 2>&1; then
   case "$desired" in '' | null) desired='[]' ;; esac
 fi
 
+# Checks that have ACTUALLY PASSED on the default branch — the gate for ADDING a
+# newly-discovered check to REQUIRED. A check discovered from PR runs is only
+# eligible to become required once it has concluded `success` on the default
+# branch's latest commit at least once; a check that has only ever been
+# pending/failure is NOT added. Without this gate the additive union below would
+# auto-require a brand-new or still-red check (e.g. a just-landed "E2E (full
+# topology)" that has never gone green on main), and because we also set
+# enforce_admins + strict that check would block EVERY merge — no one, not even
+# an admin, could merge until a check that has never passed somehow passes. We
+# never STRIP already-required checks (the union preserves `current`), so this
+# gates only the additive step. Query the default branch HEAD's check-runs and
+# keep the github-actions ones that concluded `success`. jq required; without it
+# `passed` stays '[]' so nothing new is added and `current` is preserved
+# (fail-open — never blocks). Empty/failed query behaves the same: add nothing.
+passed='[]'
+if command -v jq >/dev/null 2>&1; then
+  passed=$(gh api --paginate "repos/$slug/commits/$branch/check-runs?per_page=100" \
+    --jq '.check_runs[]? | select(.app.slug=="github-actions") | select(.conclusion=="success") | .name' 2>/dev/null \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | unique')
+  case "$passed" in '' | null) passed='[]' ;; esac
+fi
+
 # Current protection facts in one call: PR reviews present? admins enforced?
 # plus the currently-required checks from the modern `checks` field (normalized
 # to {context}, sorted). Each value is emitted on its OWN line, NOT through
@@ -71,20 +94,48 @@ fi
 # Sanitize to digits so only a number can reach the JSON payload below.
 case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
 
-# Checks to require: be strictly ADDITIVE — union what we just discovered with
-# what's already required, never a bare replace. A discovery that's non-empty but
-# PARTIAL (a PR-gating workflow whose latest run fell outside the window above)
-# would otherwise overwrite `current` and silently drop the missing workflows'
-# checks — the exact "never strip existing checks" promise, broken. Union keeps
-# every already-required check and adds any newly-seen one. Empty discovery →
-# keep current untouched. (jq required for the union; without it we already
-# fell through with desired='[]' and keep current.)
+# Checks to require: be strictly ADDITIVE — union what's already required with the
+# newly-discovered checks THAT HAVE PASSED ON MAIN, never a bare replace. A
+# discovery that's non-empty but PARTIAL (a PR-gating workflow whose latest run
+# fell outside the window above) would otherwise overwrite `current` and silently
+# drop the missing workflows' checks — the exact "never strip existing checks"
+# promise, broken. The union keeps every already-required check (so nothing is
+# ever stripped) and adds a newly-seen check only when it appears in `passed`
+# (green on the default branch at least once) — a still-red / never-passed check
+# is discovered but NOT promoted to required, so it can't block merges. Empty
+# discovery → keep current untouched. (jq required for the union; without it we
+# already fell through with desired='[]' and keep current.)
 if [ -n "$desired" ] && [ "$desired" != "[]" ]; then
   # $desired is only ever non-'[]' when the jq-guarded discovery above populated
-  # it, so jq is guaranteed here — union discovered with existing (additive; never
-  # a bare replace, which is what would drop checks on a partial discovery).
-  want=$(printf '%s\n%s' "$desired" "$current" \
-    | jq -sc 'add | map(select(.context? != null)) | unique')
+  # it, so jq is guaranteed here — union existing (`current`, always kept) with
+  # the subset of discovered checks that are also in `passed`. `current` is added
+  # unconditionally so this never strips; discovered checks are gated on `passed`
+  # so a never-green check is never newly required.
+  want=$(printf '%s\n%s\n%s' "$current" "$desired" "$passed" \
+    | jq -sc '
+        .[0] as $current | .[1] as $desired | .[2] as $passed |
+        ( $current
+          + ( $desired | map(select(.context as $c | ($passed | index($c)) != null)) )
+        )
+        | map(select(.context? != null)) | unique')
+  # Heal a stale matrix-PARENT context. When a CI job is refactored from a single
+  # job (check run "Build") into a matrix (runs "Build (cmd/api)", "Build (…)"),
+  # the bare "Build" is NEVER reported as a check run again — but the additive
+  # union above keeps requiring it, so every PR blocks forever on a check that
+  # can't complete (enforce_admins means not even an admin merge escapes). Prune a
+  # required context C when discovery shows matrix children "C (…)" but no bare
+  # "C". Only prunes a shadowed parent: a context that is itself a discovered
+  # check, or a standalone check from a workflow whose run fell outside the
+  # discovery window, is always kept.
+  want=$(printf '%s\n%s' "$want" "$desired" | jq -sc '
+    .[0] as $want | (.[1] | map(.context)) as $dctx |
+    $want | map(
+      (.context) as $c |
+      select(
+        ($dctx | index($c)) != null                       # itself a discovered check → keep
+        or (($dctx | any(startswith($c + " ("))) | not)   # no matrix child shadows it → keep
+      )
+    )')
 elif [ -n "$current" ] && [ "$current" != "[]" ]; then
   want="$current"
 else

--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -74,6 +74,23 @@ if command -v jq >/dev/null 2>&1; then
   case "$passed" in '' | null) passed='[]' ;; esac
 fi
 
+# ALL github-actions check-run NAMES on the default-branch HEAD (ANY conclusion)
+# — the evidence that lets the matrix-parent prune below fire ONLY on positive
+# proof a required context has vanished. Unlike `passed` (success-only, the
+# promotion gate) this keeps pending/failed runs too, because the prune's only
+# question is "does a check by this EXACT name still RUN on main at all". A real,
+# independent required check whose latest PR run merely fell outside the bounded
+# discovery window above still runs here, so it is never mistaken for a stale
+# matrix parent and stripped. jq required; empty on failure, and the prune treats
+# an empty list as "no evidence" and preserves the context (fail-open).
+head_names='[]'
+if command -v jq >/dev/null 2>&1; then
+  head_names=$(gh api --paginate "repos/$slug/commits/$branch/check-runs?per_page=100" \
+    --jq '.check_runs[]? | select(.app.slug=="github-actions") | .name' 2>/dev/null \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | unique')
+  case "$head_names" in '' | null) head_names='[]' ;; esac
+fi
+
 # Current protection facts in one call: PR reviews present? admins enforced?
 # plus the currently-required checks from the modern `checks` field (normalized
 # to {context}, sorted). Each value is emitted on its OWN line, NOT through
@@ -123,17 +140,24 @@ if [ -n "$desired" ] && [ "$desired" != "[]" ]; then
   # the bare "Build" is NEVER reported as a check run again — but the additive
   # union above keeps requiring it, so every PR blocks forever on a check that
   # can't complete (enforce_admins means not even an admin merge escapes). Prune a
-  # required context C when discovery shows matrix children "C (…)" but no bare
-  # "C". Only prunes a shadowed parent: a context that is itself a discovered
-  # check, or a standalone check from a workflow whose run fell outside the
-  # discovery window, is always kept.
-  want=$(printf '%s\n%s' "$want" "$desired" | jq -sc '
-    .[0] as $want | (.[1] | map(.context)) as $dctx |
+  # required context C ONLY with POSITIVE evidence it has vanished: discovery
+  # shows a matrix child "C (…)", AND bare C is confirmed ABSENT from the default
+  # branch HEAD's own check-runs ($head_names). Name-prefix alone is too weak —
+  # discovery is bounded to recent PR runs, so an independent required "C" can be
+  # absent from discovery while an UNRELATED "C (…)" is present; keying off that
+  # would strip a still-valid gate. Requiring C to also be missing from the fresh
+  # HEAD check-run set rules that out: a real, active C still runs on main and
+  # stays in $head_names, so only a genuinely refactored-away parent is pruned. No
+  # HEAD evidence (empty $head_names) → preserve (fail-open, never strip).
+  want=$(printf '%s\n%s\n%s' "$want" "$desired" "$head_names" | jq -sc '
+    .[0] as $want | (.[1] | map(.context)) as $dctx | .[2] as $head |
     $want | map(
       (.context) as $c |
       select(
         ($dctx | index($c)) != null                       # itself a discovered check → keep
         or (($dctx | any(startswith($c + " ("))) | not)   # no matrix child shadows it → keep
+        or (($head | length) == 0)                        # no HEAD evidence → keep (fail-open)
+        or (($head | index($c)) != null)                  # still runs on main HEAD → keep (not stale)
       )
     )')
 elif [ -n "$current" ] && [ "$current" != "[]" ]; then


### PR DESCRIPTION
Syncs this repo's committed github-guard hooks (`.githooks/`) to the current
skill version.

## Key fix
`pre-commit.d/github-protect-main.sh` — the additive required-check promotion is
now gated on checks that have actually **passed on the default branch**
(`current ∪ (desired ∩ passed)`), plus healing of a stale matrix-**parent**
context. This prevents a newly-discovered / never-green check (or a
matrix-refactored parent such as a bare "Build") from being auto-promoted to
required and then silently blocking **all** merges — including admin merges
under `enforce_admins`.

## Guard files changed
- `pre-commit.d/github-protect-main.sh`

## Notes
- Standard version-drift upgrade (committed guard `04d33619` → current
  `3b8cddc2`); no hand-edited/repo-custom guard logic was detected or clobbered.
- `core.hooksPath` is per-clone local config and is **not** committed — only the
  `.githooks/` files travel with this PR.