### PR TITLE
chore: refresh github-guard hooks

### DIFF
--- a/.githooks/pre-commit.d/github-merge-squash-only.sh
+++ b/.githooks/pre-commit.d/github-merge-squash-only.sh
@@ -12,11 +12,17 @@ gg_have_gh || { echo "github-guard: gh not installed/authed — skipping merge-s
 owner=${slug%%/*}
 gg_user_owns "$owner" || exit 0
 
-# Reconcile the FULL desired state — no merge commits, squash + rebase allowed —
-# whenever ANY of the three differ. Reading only allow_merge_commit missed the
-# common case of a repo that already has merge commits off but still disallows
-# squash (e.g. rebase-only): the old check saw merge_commit=false and skipped,
-# leaving squash disabled so `gh pr merge --squash` failed.
+# Reconcile the FULL desired state — SQUASH ONLY — whenever any of the three
+# differ. Reading only allow_merge_commit missed the common case of a repo that
+# already has merge commits off but still disallows squash (e.g. rebase-only): the
+# old check saw merge_commit=false and skipped, leaving squash disabled so
+# `gh pr merge --squash` failed.
+#
+# Rebase is off, not merely unused. This guard used to ENFORCE rebase=true, so a
+# repo set to squash-only was silently switched back on the next commit. One commit
+# per pull request is the point: a branch's work-in-progress history is noise once
+# it lands, and the squash message is written deliberately rather than composed by
+# GitHub from whatever the commits happened to say.
 set -- $(gh api "repos/$slug" \
   --jq '"\(.allow_merge_commit) \(.allow_squash_merge) \(.allow_rebase_merge)"' 2>/dev/null)
 mc=${1:-} sq=${2:-} rb=${3:-}
@@ -30,10 +36,10 @@ for v in "$mc" "$sq" "$rb"; do
   esac
 done
 
-if [ "$mc" != "false" ] || [ "$sq" != "true" ] || [ "$rb" != "true" ]; then
-  echo "github-guard: $slug merge settings (merge=$mc squash=$sq rebase=$rb) — reconciling to squash+rebase only…" >&2
+if [ "$mc" != "false" ] || [ "$sq" != "true" ] || [ "$rb" != "false" ]; then
+  echo "github-guard: $slug merge settings (merge=$mc squash=$sq rebase=$rb) — reconciling to squash only…" >&2
   if gh api -X PATCH "repos/$slug" \
-       -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=true \
+       -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false \
        >/dev/null 2>&1; then
     echo "github-guard: $slug merge settings fixed ✓" >&2
   else

--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -111,6 +111,64 @@ fi
 # Sanitize to digits so only a number can reach the JSON payload below.
 case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
 
+# An OPTIONAL committed declaration OVERRIDES discovery: `.githooks/required-checks`,
+# one check-run name per line (`#` comments and blank lines ignored; the single
+# word `none` means require no checks at all).
+#
+# Discovery below requires checks BY JOB NAME, which is only ever a guess at the
+# PR gate — and one class of guess is unfixable from the API alone. A workflow
+# whose `on: pull_request:` carries `paths:` filters reports NO check run for a PR
+# that touches nothing it watches; GitHub reads a required-but-absent check as
+# pending, so with enforce_admins nobody can merge and there is no failure to
+# point at. (A job skipped by a job-level `if:` is fine — it still reports, with
+# conclusion `skipped`, which SATISFIES protection. Only the workflow never
+# starting is fatal.) Telling those apart means parsing every workflow's YAML and
+# guessing at its filters, so instead a repo can just say what its gate is.
+#
+# The idiomatic answer is one always-run aggregate job that `needs:` the others,
+# named here — then jobs can be renamed, split into a matrix, made conditional or
+# path-filtered without ever stranding a merge. Declaring it is also the only way
+# to REMOVE a required check that discovery would otherwise keep re-adding, so
+# unlike discovery this path is allowed to strip.
+declared='[]'
+if [ -f "$dir/required-checks" ] && command -v jq >/dev/null 2>&1; then
+  declared=$(sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$dir/required-checks" \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | map({context: .}) | unique')
+  case "$declared" in '' | null) declared='[]' ;; esac
+  if [ "$declared" = '[]' ]; then
+    # Comments-only or empty: NOT read as "require nothing" — a file someone
+    # blanked mid-edit must not silently unprotect the branch. Fall through to
+    # discovery; `none` is the explicit way to ask for an empty set.
+    echo "github-guard: $dir/required-checks lists no checks — ignoring it (write 'none' to require none)" >&2
+  fi
+fi
+
+if [ "$declared" = '[{"context":"none"}]' ]; then
+  want='[]'
+elif [ "$declared" != '[]' ]; then
+  # Declared wins, exactly — except for a context that has NEITHER passed on the
+  # default branch NOR is already required. That is the typo gate: a misspelled
+  # name here would otherwise be required immediately, never report, and lock the
+  # repo with enforce_admins on (the same trap the `passed` promotion gate below
+  # exists to avoid). A declared check that is not eligible yet is skipped and
+  # self-heals as soon as it goes green on main once.
+  want=$(printf '%s\n%s\n%s' "$declared" "$passed" "$current" | jq -sc '
+    .[0] as $declared | .[1] as $passed | (.[2] | map(.context)) as $cur |
+    $declared | map(select(
+      (.context as $c | ($passed | index($c)) != null)
+      or (.context as $c | ($cur | index($c)) != null)
+    )) | unique')
+  skipped=$(printf '%s\n%s' "$declared" "$want" | jq -sc '(.[0] - .[1]) | map(.context)')
+  [ "$skipped" = '[]' ] || \
+    echo "github-guard: declared checks not required yet (never green on $branch): $skipped" >&2
+  if [ "$want" = '[]' ]; then
+    # Nothing declared is eligible — a typo, or an aggregate job that has not yet
+    # run green on main. Keep whatever is required today rather than stripping the
+    # gate down to nothing on the strength of a name that may not exist. It flips
+    # to the declared set on the first commit after that check passes on main.
+    echo "github-guard: no declared check is eligible yet — keeping current required checks" >&2
+    want="$current"
+  fi
 # Checks to require: be strictly ADDITIVE — union what's already required with the
 # newly-discovered checks THAT HAVE PASSED ON MAIN, never a bare replace. A
 # discovery that's non-empty but PARTIAL (a PR-gating workflow whose latest run
@@ -121,8 +179,9 @@ case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
 # (green on the default branch at least once) — a still-red / never-passed check
 # is discovered but NOT promoted to required, so it can't block merges. Empty
 # discovery → keep current untouched. (jq required for the union; without it we
-# already fell through with desired='[]' and keep current.)
-if [ -n "$desired" ] && [ "$desired" != "[]" ]; then
+# already fell through with desired='[]' and keep current.) Reached only when the
+# repo has NOT declared its gate in .githooks/required-checks above.
+elif [ -n "$desired" ] && [ "$desired" != "[]" ]; then
   # $desired is only ever non-'[]' when the jq-guarded discovery above populated
   # it, so jq is guaranteed here — union existing (`current`, always kept) with
   # the subset of discovered checks that are also in `passed`. `current` is added


### PR DESCRIPTION
Picks up the guard version that reads `.githooks/required-checks`, so this repo can state which status checks its default branch requires instead of having every discovered job name unioned into the required set.

That matters because a required check which no longer reports — a renamed job, a job refactored into a matrix, or a workflow whose `paths:` filters keep it from starting — reads as *pending* forever, and `enforce_admins` means an admin cannot merge past it either.

**No behaviour change here.** Without a `required-checks` file the guard discovers checks exactly as before. This is the payload refresh; declaring a gate is a separate, optional step.

Also carries an installer fix: re-installing no longer marks a repo's own files executable.

- antimatter-studios/agent-skills#26 — the declaration, plus that repo's first CI and tests
- antimatter-studios/agent-skills#27 — the installer fix