### PR TITLE
chore(githooks): sync github-guard to the trusted-declaration guards

### DIFF
--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -131,15 +131,29 @@ case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
 # to REMOVE a required check that discovery would otherwise keep re-adding, so
 # unlike discovery this path is allowed to strip.
 declared='[]'
-if [ -f "$dir/required-checks" ] && command -v jq >/dev/null 2>&1; then
-  declared=$(sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$dir/required-checks" \
-    | jq -sRc 'split("\n") | map(select(length > 0)) | map({context: .}) | unique')
-  case "$declared" in '' | null) declared='[]' ;; esac
-  if [ "$declared" = '[]' ]; then
-    # Comments-only or empty: NOT read as "require nothing" — a file someone
-    # blanked mid-edit must not silently unprotect the branch. Fall through to
-    # discovery; `none` is the explicit way to ask for an empty set.
-    echo "github-guard: $dir/required-checks lists no checks — ignoring it (write 'none' to require none)" >&2
+if command -v jq >/dev/null 2>&1; then
+  # This declaration is a PRIVILEGED input — it can REMOVE required checks (and
+  # `none` strips them all) — so read it from the TRUSTED default branch on the
+  # SERVER, never the working tree. This hook is pre-commit and runs against
+  # whatever is checked out; an untrusted branch (e.g. a contributor PR reviewed
+  # locally) carrying a `.githooks/required-checks` that says `none` must NOT be
+  # able to clear protection just because the owner commits while it is checked
+  # out. Reading the committed `$branch` copy means a policy change only takes
+  # effect once it is merged to the default branch. Absent/unreadable (404, no
+  # network, no jq) → '[]', i.e. fall through to discovery — never unprotect.
+  decl_raw=$(gh api "repos/$slug/contents/.githooks/required-checks?ref=$branch" \
+    -H "Accept: application/vnd.github.raw" 2>/dev/null) || decl_raw=""
+  if [ -n "$decl_raw" ]; then
+    declared=$(printf '%s\n' "$decl_raw" \
+      | sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' \
+      | jq -sRc 'split("\n") | map(select(length > 0)) | map({context: .}) | unique')
+    case "$declared" in '' | null) declared='[]' ;; esac
+    if [ "$declared" = '[]' ]; then
+      # Comments-only or empty: NOT read as "require nothing" — a file someone
+      # blanked mid-edit must not silently unprotect the branch. Fall through to
+      # discovery; `none` is the explicit way to ask for an empty set.
+      echo "github-guard: .githooks/required-checks on $branch lists no checks — ignoring it (write 'none' to require none)" >&2
+    fi
   fi
 fi
 
@@ -159,8 +173,6 @@ elif [ "$declared" != '[]' ]; then
       or (.context as $c | ($cur | index($c)) != null)
     )) | unique')
   skipped=$(printf '%s\n%s' "$declared" "$want" | jq -sc '(.[0] - .[1]) | map(.context)')
-  [ "$skipped" = '[]' ] || \
-    echo "github-guard: declared checks not required yet (never green on $branch): $skipped" >&2
   if [ "$want" = '[]' ]; then
     # Nothing declared is eligible — a typo, or an aggregate job that has not yet
     # run green on main. Keep whatever is required today rather than stripping the
@@ -168,7 +180,19 @@ elif [ "$declared" != '[]' ]; then
     # to the declared set on the first commit after that check passes on main.
     echo "github-guard: no declared check is eligible yet — keeping current required checks" >&2
     want="$current"
+  elif [ "$skipped" != '[]' ]; then
+    # PARTIAL declaration: some declared checks aren't eligible yet (never green on
+    # $branch). Do NOT exact-replace here — that would DROP currently-required
+    # checks the full declaration will re-add once the deferred ones green, leaving
+    # a WEAKER gate meanwhile (and omitting the ineligible replacements entirely).
+    # Union the eligible-declared set with what's already required; the exact
+    # declared set (which intentionally removes undeclared checks) applies only
+    # once EVERY declared check is eligible, i.e. the `skipped` list is empty.
+    echo "github-guard: declared checks not required yet (never green on $branch): $skipped — unioning with current until they green" >&2
+    want=$(printf '%s\n%s' "$want" "$current" | jq -sc 'add | unique')
   fi
+  # else (skipped empty): every declared check is eligible, so `want` is the exact
+  # declared set and undeclared checks are intentionally removed ("declared wins").
 # Checks to require: be strictly ADDITIVE — union what's already required with the
 # newly-discovered checks THAT HAVE PASSED ON MAIN, never a bare replace. A
 # discovery that's non-empty but PARTIAL (a PR-gating workflow whose latest run

--- a/.githooks/pre-push.d/git-block-merge-commits.sh
+++ b/.githooks/pre-push.d/git-block-merge-commits.sh
@@ -9,12 +9,20 @@ status=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   # Deleting a remote branch (local_sha all-zero): nothing to inspect.
   printf '%s' "$local_sha" | grep -qE '^0+$' && continue
-  if printf '%s' "$remote_sha" | grep -qE '^0+$'; then
-    # New branch on the remote: inspect commits not already on any remote ref.
-    merges=$(git rev-list --merges "$local_sha" --not --remotes 2>/dev/null)
-  else
-    merges=$(git rev-list --merges "${remote_sha}..${local_sha}" 2>/dev/null)
-  fi
+  # Inspect only the merge commits this push actually INTRODUCES: those
+  # reachable from the new head but not from any remote-tracking ref.
+  #
+  # A "<remote_sha>..<local_sha>" range looks equivalent and is not. After
+  # a rebase the old remote tip is no longer an ancestor of the new head,
+  # so that range means "everything reachable from the new head but not
+  # the old tip" — which sweeps in the entire new base, including merge
+  # commits already published on it. The guard then blocks a force-push
+  # that introduces no merges at all, which is the normal way to update a
+  # rebased branch.
+  #
+  # Excluding --remotes is correct for a fast-forward too: anything the
+  # old tip could reach is on a remote ref by definition.
+  merges=$(git rev-list --merges "$local_sha" --not --remotes 2>/dev/null)
   if [ -n "$merges" ]; then
     printf 'github-guard: BLOCKED — push to %s contains merge commit(s):\n' "$remote_ref" >&2
     printf '%s\n' "$merges" | sed 's/^/  /' >&2


### PR DESCRIPTION
chore(githooks): sync github-guard to the trusted-declaration guards

Two guard fixes from upstream:

github-protect-main now reads .githooks/required-checks from the default
branch on the server rather than the working tree. That file can remove
required status checks, and `none` removes all of them, so it is a
privileged input; reading it from whatever happens to be checked out let
an untrusted branch unprotect main on the owner's next commit. A partial
declaration now also unions with the checks already required instead of
replacing them, so it cannot leave a weaker gate than before it existed.

git-block-merge-commits no longer flags merge commits that are already
on the remote. After a rebase the old tip is not an ancestor of the new
head, so the old commit range swept in the whole new base and blocked
ordinary force-pushes of rebased branches.
