### PR TITLE
docs: plan and IP protocol for XFS and Btrfs read-write support

### DIFF
--- a/docs/ip-audit-2026-08-25.md
+++ b/docs/ip-audit-2026-08-25.md
@@ -1,0 +1,87 @@
+# IP & License Audit — 2026-08-25
+
+Scope: `rust-fs-xfs` and `rust-fs-btrfs` as of 0.4.0, taken as the baseline before
+read-write work begins. Verified today rather than assumed.
+
+**This document is internal.** It names GPL-licensed tools directly, which the public
+vendor repositories must not do (existing policy). Do not copy it into either crate.
+
+## Summary
+
+✅ **No copyleft anywhere in either dependency tree.** Resolved via `cargo metadata`,
+   not from memory or from the manifests' stated intent.
+
+✅ **No derivation from GPL source.** No file in either crate cites kernel,
+   `xfsprogs` or `btrfs-progs` source as an origin. Both READMEs state the clean-room
+   position explicitly.
+
+✅ **New dependencies added today are permissive.** The Btrfs decompression work
+   pulled in three decoders; all are pure Rust with no C bindings.
+
+## Dependency licences, resolved
+
+**`rust-fs-xfs` 0.4.0** — 5 packages:
+
+| Crate | Licence |
+|---|---|
+| am-fs-core, am-fs-xfs | MIT |
+| crc32c | Apache-2.0 / MIT |
+| rustc_version, semver | MIT OR Apache-2.0 |
+
+**`rust-fs-btrfs` 0.4.0** — 23 packages. Every one MIT, Apache-2.0, Zlib, 0BSD, CC0-1.0
+or MIT-0. The three added for compression:
+
+| Crate | Licence | For |
+|---|---|---|
+| miniz_oxide | MIT OR Zlib OR Apache-2.0 | zlib extents |
+| am-lzo1x | MIT (ours) | LZO extents |
+| ruzstd | MIT | zstd extents |
+
+`ruzstd` and `miniz_oxide` were chosen over the more common `zstd` and `flate2`
+specifically because both of those bind to C libraries; the pure-Rust decoders keep the
+tree free of vendored C whose licensing has to be tracked separately.
+
+## Provenance of the format knowledge
+
+Neither crate cites an implementation as its source. Spot-checked:
+
+- `rust-fs-btrfs/src/btree.rs` states which published structures its offsets came from
+  and, more usefully, how each was **independently corroborated** — the struct sizes are
+  the sums of their own field widths, and `HEADER_SIZE` is confirmed by
+  `nodesize - HEADER_SIZE` being the leaf area every item offset is relative to.
+- `rust-fs-xfs/src/log.rs`, added today, documents why it scans for the newest record
+  rather than locating the head the way the kernel does — a deliberate divergence,
+  which is evidence of independent derivation rather than translation.
+
+That corroboration habit is the strongest part of the current position and should
+continue into the write work: a value that can be derived twice is defensible in a way
+that a value copied once is not.
+
+## The read/write asymmetry, recorded
+
+Worth stating plainly because it changes the risk profile of what comes next.
+
+For reading, permissive references existed — Haiku's drivers are MIT. **For writing,
+none do.** Every complete write implementation of either filesystem is GPL: the kernel,
+`xfsprogs`, `btrfs-progs`.
+
+This does not block the work. It means the write paths must come from format
+documentation and be validated behaviourally, with the GPL tools used as **black-box
+oracles only** — executed and their verdicts recorded, never read as source. Executing
+a program does not create a derivative work of it; the read path already relies on this
+throughout.
+
+The full protocol is in `xfs-btrfs-rw-plan.md` §5.
+
+## Tool-naming policy
+
+Unchanged and still observed: the vendor repositories reference tools by role ("the
+reference debugger", "the filesystem checker"), never by name, in source, README, CLI
+output and commit messages. Both crates comply. The internal documents in this
+directory are where the tools are named.
+
+## Actions
+
+None. The baseline is clean. Re-audit when the write work adds dependencies — most
+likely candidates are a CRC or hashing crate for Btrfs's checksum tree, which should be
+checked against the four already present before anything new is added.

--- a/docs/xfs-btrfs-rw-plan.md
+++ b/docs/xfs-btrfs-rw-plan.md
@@ -1,0 +1,190 @@
+# Read-write support for XFS and Btrfs — plan and IP protocol
+
+**Date:** 2026-08-25
+**Status:** plan. Nothing below is implemented yet except where marked.
+**Internal document.** It names GPL-licensed tools directly, which the public vendor
+repositories must not do. Do not copy it into `rust-fs-xfs` or `rust-fs-btrfs`.
+
+---
+
+## 1. The licensing fact that shapes the engineering
+
+For **reading** these formats there were permissively-licensed references to work
+from: Haiku's drivers are MIT, and both formats have published on-disk documentation.
+That is how both crates were built.
+
+For **writing** there are none. Every complete write implementation of either
+filesystem is GPL:
+
+| Implementation | Licence | Usable as a source? |
+|---|---|---|
+| Linux kernel `fs/xfs`, `fs/btrfs` | GPL-2.0 | **No** |
+| `xfsprogs` (mkfs.xfs, xfs_repair, xfs_db) | GPL-2.0 | **No** as source; **yes** as a black-box oracle |
+| `btrfs-progs` (mkfs.btrfs, btrfs check) | GPL-2.0 | **No** as source; **yes** as a black-box oracle |
+| Haiku | MIT | Read-only; no write path to learn from |
+
+So the write paths cannot be derived from any existing implementation. They have to be
+built from format documentation and validated behaviourally.
+
+### What this actually forbids, and what it does not
+
+**Forbidden:**
+- Reading kernel or `-progs` source to learn how an algorithm works, then writing our
+  own version of it. Clean-room means the person writing the code has not read the
+  implementation, not merely that they retyped it.
+- Translating or transliterating any of it.
+- Copying constant tables, magic values or struct layouts *out of source files*.
+
+**Allowed:**
+- Published on-disk format documentation, and constants taken from it.
+- Running the GPL tools as black boxes: `xfs_repair -n` on an image we wrote,
+  `btrfs check` on an image we wrote, mounting under Linux and comparing. Executing a
+  program does not create a derivative work of it. We already do this throughout the
+  read path.
+- Observing the bytes those tools produce and matching them. A filesystem image is
+  data, not code.
+
+### The liberating consequence
+
+**We do not have to reproduce their algorithms. We have to satisfy their validators.**
+
+Our block allocator need not choose the same blocks the kernel would. It needs to
+produce a filesystem that `xfs_repair` and `btrfs check` call valid, and that the
+kernel mounts and reads back correctly. That is a much weaker obligation than
+behavioural equivalence, and it is checkable — which the read path has already proved
+works, since ten real defects were caught that way and none by inspection.
+
+It does mean **the oracle carries more weight than usual**. On the read path a wrong
+guess produced wrong bytes we could compare against a known answer. On the write path a
+wrong guess produces an image that looks fine to us and that the checker rejects — or,
+worse, that the checker accepts and the kernel later corrupts. Every phase below is
+defined by what the oracle must say, not by what code exists.
+
+---
+
+## 2. The two filesystems are not symmetric
+
+This is the single most important planning fact, and it is easy to miss.
+
+### XFS journals metadata, not data
+
+An overwrite of existing file data, inside an extent that is already allocated and
+already written, changes **no metadata at all**. No allocation, no extent-tree change,
+no timestamp that must be atomic with anything. Nothing that needs the log.
+
+That makes a genuinely safe first increment available: in-place data overwrite. It is
+useful on its own, it exercises the whole device-write path end to end, and it cannot
+corrupt a filesystem even if it crashes mid-write — the failure mode is a partially
+written file, which is the same failure mode the kernel has.
+
+### Btrfs is copy-on-write, so nothing is in place
+
+There is no equivalent first step. A single-byte overwrite in Btrfs requires, at
+minimum:
+
+1. allocate a new block (extent tree, free-space accounting)
+2. write the data
+3. compute and store its checksum in the checksum tree
+4. update the file extent item to point at the new block
+5. rewrite every B-tree node from that leaf up to the root, because none may be
+   modified in place
+6. update extent-tree back references for both the new block and the old one
+7. write a new superblock naming the new tree roots and a new generation
+
+Steps 1, 6 and 7 are the hard ones, and step 6 is the part `btrfs check` is least
+forgiving about.
+
+**Consequence:** XFS reaches useful read-write far sooner. Btrfs's first increment is
+most of a transaction engine. Sequencing them in parallel would leave Btrfs looking
+stalled for a long time; sequencing XFS first delivers something usable while the Btrfs
+foundations are built.
+
+---
+
+## 3. Phases
+
+Each phase names the oracle that closes it. A phase is not done when the code exists;
+it is done when the checker agrees.
+
+### XFS
+
+| Phase | Work | Oracle |
+|---|---|---|
+| **X1** | In-place data overwrite within allocated, written extents. Writable device plumbing, `is_writable` gating, refusal on unwritten/sparse/shared extents. | `xfs_repair -n` clean after; kernel mount reads back the written bytes; SHA-256 matches |
+| **X2** | Timestamp and mode updates — the first metadata writes, and so the first that need the log. Log record construction, one transaction shape. | `xfs_repair -n` clean; kernel sees the new mtime after a mount that replays |
+| **X3** | Allocation: free-space B+trees (`bnobt`/`cntbt`) insert and delete, kept mutually consistent. Extend a file, allocate new extents. | `xfs_repair -n` clean; free-space accounting matches after many alloc/free cycles |
+| **X4** | Inode allocation (`inobt`, `finobt`), create and unlink. | `xfs_repair -n` clean; kernel `ls` matches |
+| **X5** | Directory modification across short-form, block, leaf and node, including the format transitions between them. | `xfs_repair -n` clean; kernel reads every entry |
+| **X6** | `bmbt` insertion — the write half of the walker landed in 0.4.0. | `xfs_repair -n` clean on heavily fragmented files |
+
+**X2 is the real gate.** Everything from X3 on depends on being able to journal a
+transaction correctly. It is worth building the log writer carefully and slowly, with
+the smallest possible transaction, before anything else needs it.
+
+### Btrfs
+
+| Phase | Work | Oracle |
+|---|---|---|
+| **B1** | Transaction skeleton: CoW a B-tree path, write new tree roots, commit a new superblock generation. No user-visible change — modify nothing, but commit a generation the kernel accepts. | `btrfs check` clean; kernel mounts at the new generation |
+| **B2** | Extent tree: allocate and free blocks with correct back references. | `btrfs check` clean, specifically no extent-tree errors, after many cycles |
+| **B3** | Data write: new extent, checksum item, file extent item update. Overwrite an existing file. | `btrfs check` clean; kernel reads back the written bytes |
+| **B4** | B-tree insert and delete with node split and merge. | `btrfs check` clean across trees forced to split |
+| **B5** | Create, unlink, rename; directory index items. | `btrfs check` clean; kernel `ls` matches |
+
+**B1 and B2 are the whole risk.** If the transaction and extent accounting are right,
+the rest is comparatively mechanical. If they are wrong, everything built on them has
+to be redone.
+
+---
+
+## 4. Safety posture
+
+Both drivers currently refuse to mount when the filesystem is mid-operation — XFS on a
+dirty log (as of 0.4.0, correctly), Btrfs on a non-empty log tree. **That refusal
+becomes more important, not less, once writing is possible**, and must stay: writing to
+a filesystem whose log holds unapplied work would compound stale metadata with new.
+
+Additionally:
+
+- **Read-write is opt-in per mount**, and the default stays read-only. A driver that
+  can write should not write because the device happened to be writable.
+- **Every phase ships behind its own refusal.** X1 refuses unwritten, sparse and
+  reflinked extents rather than guessing; each later phase narrows what is refused.
+  Refusing is always the correct answer for a case not yet implemented, and it is
+  never acceptable to write something approximate.
+- **No partial transactions.** Where a phase cannot complete an operation atomically,
+  it must not begin it.
+
+---
+
+## 5. Provenance protocol for this work
+
+To keep the clean-room claim defensible, for the duration of the read-write work:
+
+1. **Format documentation only.** Where a constant or layout is used, the source
+   document is cited in the code, as the read path already does — see
+   `rust-fs-btrfs/src/btree.rs`, which states which structures its offsets came from
+   and how each was independently corroborated.
+2. **Corroborate arithmetic.** Where a value cannot be cited, it must be derivable
+   twice — the existing convention of "the struct size is the sum of its own fields,
+   and the leaf area is `nodesize - HEADER_SIZE`" is the pattern.
+3. **Oracles are executed, never read.** The tools are run and their verdicts recorded.
+   Nobody working on this reads their source.
+4. **Anything uncorroborated is called out at its use site**, so a later reader knows
+   which values are load-bearing guesses.
+5. **The vendor repositories never name the GPL tools** in source, README, CLI output
+   or commit messages — the existing policy. This document is where they are named.
+
+## 6. Recommended order
+
+**X1 first.** It is safe, self-contained, needs no journal, and it builds the writable
+device plumbing every later phase uses. It is also the only phase in either filesystem
+that can be delivered without a transaction engine, so it is the cheapest way to prove
+the whole write path end to end.
+
+**Then X2**, slowly, because everything downstream rests on it.
+
+**Btrfs B1 can start in parallel** once X1 is done, since it shares no code with XFS and
+its risk is concentrated at the front. But it should not be started before X1, because
+X1 will teach us things about the writable-device plumbing and the test harness that
+B1 would otherwise have to discover independently.


### PR DESCRIPTION
The licensing position dictates the engineering approach, so the two are written down together.

**For reading these formats there were permissively-licensed references. For writing there are none** — every complete write implementation of either filesystem is GPL (the kernel, `xfsprogs`, `btrfs-progs`). Haiku's are MIT but read-only.

So the write paths must come from format documentation and be validated behaviourally, with the GPL tools used as **black-box oracles only**: executed and their verdicts recorded, never read as source. Executing a program does not create a derivative work of it, and the read path already relies on this throughout.

## The useful consequence

We do not have to reproduce their algorithms, only **satisfy their validators**. Our allocator need not choose the blocks the kernel would — it needs to produce a filesystem the checker calls valid and the kernel reads back correctly. That is a much weaker obligation, and a checkable one.

It also means the oracle carries more weight than on the read path. A wrong guess there produced wrong bytes we could compare against a known answer. A wrong guess here produces an image that looks fine to us and that the checker rejects — or worse, that it accepts and the kernel later corrupts. Every phase is defined by what the oracle must say, not by what code exists.

## The scheduling fact

The two filesystems are not symmetric:

- **XFS journals metadata, not data.** An overwrite inside an already-written extent needs no log. That is a real first increment, and it shipped as PR #7 on `rust-fs-xfs`.
- **Btrfs is copy-on-write**, so nothing is in place. Its smallest possible change — a single byte — needs a new block, a checksum item, a rewritten B-tree path to the root, extent-tree back references, and a new superblock generation. There is no small first step.

XFS reaches useful read-write far sooner. Sequencing them in parallel would leave Btrfs looking stalled for a long time.

## Also included

`ip-audit-2026-08-25.md` records today's verification of both dependency trees — entirely permissive, no copyleft anywhere — as the baseline this work starts from, along with a spot-check of how the existing format knowledge was corroborated.

Both documents are **internal**: they name the GPL tools directly, which the public vendor repositories must not do.