### PR TITLE
Pin the XFS and Btrfs bundles to the 0.5.0 drivers

### DIFF
--- a/rust-bundles/dj-btrfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-btrfs-bundle/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "am-fs-btrfs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb14dbf27f15fca88759c322278ab21ac50c47383e04ca38c5db0e942599cee1"
+checksum = "8e26e780caef3d46e36ef3602476f1253708f9adf8d8b3d75b67226ec1401d17"
 dependencies = [
  "am-fs-core",
  "am-lzo1x",

--- a/rust-bundles/dj-btrfs-bundle/Cargo.toml
+++ b/rust-bundles/dj-btrfs-bundle/Cargo.toml
@@ -15,7 +15,7 @@ name = "dj_btrfs_bundle"
 crate-type = ["staticlib"]
 
 [dependencies]
-am-fs-btrfs = "0.4.0"
+am-fs-btrfs = "0.5.0"
 am-img-qcow2 = "0.4.2"
 am-img-vhd = "0.3.2"
 am-img-vhdx = "0.3.2"

--- a/rust-bundles/dj-xfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-xfs-bundle/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
 
 [[package]]
 name = "am-fs-xfs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c649f6d33587dfcd0b03b449ae18856a6a7dae3f9372c62b60d48adc81e1e1"
+checksum = "612becd726fb31295c54de699306c86e2de3b96d6efa0ceb21f2b13f3dba57f3"
 dependencies = [
  "am-fs-core",
  "crc32c",

--- a/rust-bundles/dj-xfs-bundle/Cargo.toml
+++ b/rust-bundles/dj-xfs-bundle/Cargo.toml
@@ -15,7 +15,7 @@ name = "dj_xfs_bundle"
 crate-type = ["staticlib"]
 
 [dependencies]
-am-fs-xfs = "0.4.0"
+am-fs-xfs = "0.5.0"
 am-img-qcow2 = "0.4.2"
 am-img-vhd = "0.3.2"
 am-img-vhdx = "0.3.2"


### PR DESCRIPTION
Both drivers can now write, and the extensions could not reach any of it until this.

## am-fs-xfs 0.4.0 → 0.5.0

Overwrites file data in place, changes an inode's timestamps, permissions and ownership, and shortens a file. Refused **by name**: growing, filling a hole, writing an unwritten or reflinked extent, and anything that allocates, frees or touches a directory.

## am-fs-btrfs 0.4.0 → 0.5.0

Overwrites files marked `NODATACOW` — the one shape Btrfs writes in place. The extent's reference count is checked first: the flag promises in-place writes only while the extent belongs to one file, and **a snapshot ends that**.

`fs_btrfs_can_write_in_place` lets a caller ask whether a given file qualifies rather than attempting a write and interpreting the refusal.

## Two limits worth carrying into whatever presents this

- **XFS truncate does not reclaim space.** Freeing blocks needs the log, so a shortened file still occupies what it did — `du` will say so while `ls` does not.
- **An XFS inode write is not protected against a torn sector.** It goes down as one sector with a recomputed CRC; a machine dying mid-write leaves that inode's checksum failing. Devices write sectors atomically so the window is narrow, but it is the one a log would close.

Writing stays opt-in in both: the C ABI gates every write on the **handle** rather than the call, so a volume opened for reading cannot be written to by mistake.

Both bundles build clean with `--locked`. `check-vendor-pins.sh` reports up to date — the bundles consume crates.io releases, so no submodule pin moves.
