### PR TITLE
Audit the licences against the project as it is now

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -4,29 +4,55 @@ DiskJockey is MIT-licensed (see `LICENSE`). This file enumerates the
 licenses of every component statically linked into the shipped binary,
 for compliance with their respective notice requirements.
 
-## Direct components (vendored under `vendor/`)
+## Rust crates linked into the shipped binary
+
+Each FSKit extension links one aggregator static library from
+`rust-bundles/`, which depends on the crates below. They are published
+to crates.io rather than vendored, so the version linked is whatever
+that bundle's `Cargo.toml` pins.
+
+| Crate | License | Source |
+|---|---|---|
+| `am-fs-core` | MIT | github.com/antimatter-studios/rust-fs-core |
+| `am-fs-ext4` | MIT | github.com/christhomas/rust-fs-ext4 |
+| `am-fs-ntfs` | MIT OR Apache-2.0 | github.com/christhomas/rust-fs-ntfs |
+| `am-fs-xfs` | MIT | github.com/antimatter-studios/rust-fs-xfs |
+| `am-fs-btrfs` | MIT | github.com/antimatter-studios/rust-fs-btrfs |
+| `am-fs-erofs` | MIT | github.com/antimatter-studios/rust-fs-erofs |
+| `am-fs-squashfs` | MIT | github.com/antimatter-studios/rust-fs-squashfs |
+| `am-img-qcow2` | MIT | github.com/antimatter-studios/rust-img-qcow2 |
+| `am-img-vhd` | MIT | github.com/antimatter-studios/rust-img-vhd |
+| `am-img-vhdx` | MIT | github.com/antimatter-studios/rust-img-vhdx |
+| `am-img-vmdk` | MIT | github.com/antimatter-studios/rust-img-vmdk |
+| `am-lzo1x` | MIT | github.com/antimatter-studios/rust-lzo1x |
+| `am-partitions` | MIT | github.com/antimatter-studios/rust-partitions |
+
+## Other direct components
 
 | Component | License | Source |
 |---|---|---|
-| `rust-fs-ext4` | MIT | github.com/christhomas/rust-fs-ext4 |
-| `rust-fs-ntfs` | Apache-2.0 OR MIT | github.com/christhomas/rust-fs-ntfs |
 | `go-networkfs` | MIT | github.com/christhomas/go-networkfs |
+| `diskprobe` | MIT | first-party, `vendor/rust-disk-probe` |
 | `tabler-icons` | MIT | github.com/tabler/tabler-icons |
 
 ## Transitive Rust dependencies
 
-The Rust crates (`rust-fs-ext4`, `rust-fs-ntfs`) compile against a small
-set of permissively-licensed crates. License mix observed at this
-release: MIT / MIT OR Apache-2.0 / Zlib / Unicode-3.0. Run
-`cargo tree --license` (with `cargo-license`) inside each vendor crate
-to reproduce the exact list at any commit.
+Every crate above resolves a closure that is entirely MIT, Apache-2.0,
+BSD, Zlib, ISC, 0BSD, CC0-1.0, MIT-0 or Unicode-3.0. **No copyleft
+appears in any Rust dependency tree.** Reproduce with `cargo metadata`
+in each crate and read the `license` field of every package.
+
+One entry looks like a copyleft hit and is not: `r-efi` declares
+`MIT OR Apache-2.0 OR LGPL-2.1-or-later`. The licence is disjunctive, so
+MIT applies; it is a dev-dependency of `tempfile` only; and it is gated
+to UEFI targets, so it is never built here.
 
 ## Transitive Go dependencies (go-networkfs)
 
-The Go drivers in `go-networkfs` pull a 44-module transitive closure
-across MIT / BSD-2-Clause / BSD-3-Clause / ISC / Apache-2.0 / MPL-2.0.
-Two MPL-2.0 entries warrant explicit acknowledgment per their notice
-requirements:
+The Go drivers in `go-networkfs` pull a 117-module transitive closure
+across MIT / BSD / ISC / Apache-2.0 / MPL-2.0. Two MPL-2.0 entries
+warrant explicit acknowledgment per their notice requirements, and they
+are the only copyleft-licensed components anywhere in this project:
 
 ### MPL-2.0 — Mozilla Public License 2.0
 
@@ -42,8 +68,15 @@ binary is explicitly permitted.
 Component: `github.com/hashicorp/go-multierror`
 License: MPL-2.0
 Source: github.com/hashicorp/go-multierror
-Notice: Same MPL-2.0 terms as above. Pulled in transitively via
-`github.com/hirochachacha/go-smb2`.
+Notice: Same MPL-2.0 terms as above. Both MPL components enter through
+the **FTP** driver and nothing else:
+
+    go-networkfs/ftp -> github.com/jlaffaye/ftp
+                     -> hashicorp/go-multierror -> hashicorp/errwrap
+
+`github.com/jlaffaye/ftp` is the sole importer; verified with
+`go list -deps`. (An earlier revision of this file attributed them to
+the SMB driver, which does not import either.)
 
 The full text of the Mozilla Public License 2.0 is available at:
 <https://www.mozilla.org/en-US/MPL/2.0/>
@@ -51,14 +84,6 @@ The full text of the Mozilla Public License 2.0 is available at:
 DiskJockey ships these components unmodified. To obtain the source for
 either, fetch the upstream repository at the version pinned in
 `vendor/go-networkfs/go.sum`.
-
-## Apache 2.0 — Swift Package Manager dependency
-
-Component: `apple/swift-protobuf`
-License: Apache-2.0
-Source: github.com/apple/swift-protobuf
-Notice: Linked via Swift Package Manager. Apache-2.0 only requires
-license-text inclusion (this file) for redistribution.
 
 ## Per-driver SDK licenses (network filesystem clients)
 

--- a/docs/ip-audit-2026-08-26.md
+++ b/docs/ip-audit-2026-08-26.md
@@ -1,0 +1,149 @@
+# IP & Licence Audit — 2026-08-26
+
+Scope: every Rust crate the app links, the Go network-filesystem drivers, and the
+first-party source of all of them. Resolved from the dependency graphs rather than from
+the previous audits, which is how the stale entries below were found.
+
+**This document is internal.** It names GPL-licensed tools directly, which the public
+vendor repositories must not do.
+
+## Verdict
+
+✅ **No copyleft obligation is unmet, and nothing blocks shipping.**
+
+⚠️ **Two compliance documents are materially out of date**, in the direction that
+understates what is shipped. See *Findings*.
+
+## What is actually linked
+
+Ten Rust crates, statically, through the per-extension bundles in `rust-bundles/`.
+None of them is a submodule any more — they come from crates.io:
+
+| Crate | Licence |
+|---|---|
+| `am-fs-core`, `am-fs-ext4`, `am-fs-xfs`, `am-fs-btrfs`, `am-fs-erofs`, `am-fs-squashfs` | MIT |
+| `am-fs-ntfs` | MIT OR Apache-2.0 |
+| `am-img-qcow2`, `am-img-vhd`, `am-img-vhdx`, `am-img-vmdk` | MIT |
+| `am-lzo1x`, `am-partitions` | MIT |
+
+Their transitive closures were resolved with `cargo metadata` and are entirely MIT,
+Apache-2.0, BSD, Zlib, ISC, 0BSD, CC0-1.0, MIT-0 or Unicode-3.0. **No copyleft in any
+Rust dependency tree.**
+
+Plus `go-networkfs`, built by `make all` into `lib/go-networkfs` and referenced by the
+Xcode project — so it ships.
+
+## The only copyleft in the project
+
+Two modules, both MPL-2.0, both reached the same way:
+
+```
+go-networkfs/ftp → github.com/jlaffaye/ftp → hashicorp/go-multierror → hashicorp/errwrap
+```
+
+They are error-aggregation helpers pulled in by the FTP client library. Nothing else in
+the project — Rust or Go — carries copyleft of any strength.
+
+MPL-2.0 is **file-scope** weak copyleft: the obligation attaches to modifications of the
+MPL-licensed files themselves, not to a work that links them. We do not modify them, so
+the requirement is notice, which `THIRD_PARTY_LICENSES.md` gives.
+
+Worth knowing rather than acting on: if a zero-copyleft position is ever wanted, it is
+reached by replacing the FTP client library, not by changing any of our own code.
+
+## Two false positives this audit produced, recorded so the next one does not repeat them
+
+Both came from matching licence text by substring, and both looked like findings.
+
+**`r-efi`** is declared `MIT OR Apache-2.0 OR LGPL-2.1-or-later`. A search for `GPL`
+matches it. It is not a finding for three independent reasons: the licence is
+*disjunctive*, so MIT applies; it is a dev-dependency only
+(`tempfile` → `getrandom` → `r-efi`); and it is gated to UEFI targets, so it is absent
+from the normal dependency graph entirely.
+
+**`hashicorp/errwrap` and `hashicorp/go-multierror`** first classified as **AGPL**. They
+are MPL-2.0. The MPL's own text names the GNU GPL, LGPL and AGPL in its "Secondary
+License" definition, so a classifier that tests for GNU licences before testing for the
+MPL reports every MPL file as GNU-licensed.
+
+The lesson generalises: **test for MPL-2.0 before testing for any GNU licence**, and
+treat a disjunctive licence as satisfied by its most permissive term.
+
+## Provenance of the format knowledge
+
+- **No vendored C or C++** anywhere in the crates.
+- **No file cites a GPL implementation as its origin.** Every match for "derived from",
+  "ported from" or "based on" is either ordinary English about a value derived from
+  another value, or an explicit disclaimer — `rust-fs-erofs` states outright in three
+  places that it is *not* derived from the GPL-2 kernel encoder or from `erofs-utils`.
+- **The reference tooling is executed, never read as source.** New this cycle:
+  `rust-fs-xfs` builds the stress generators from the filesystem test suite inside the
+  oracle VM. Its source and build tree exist only in the guest, nothing from it enters
+  the repository, and the binaries are invoked as external programs. Both
+  `tests/vagrant/debian/provision-stress-tools.sh` and
+  `scripts/vm-build-stress-fixtures.sh` carry that reasoning where someone changing them
+  will read it.
+- The corroboration habit noted in the 2026-08-25 audit continues, and did real work
+  this cycle: the XFS inode-cluster rule was confirmed against 7,307 log items across
+  four allocation groups and four geometries rather than asserted once.
+
+## Findings
+
+### 1. `THIRD_PARTY_LICENSES.md` is materially incomplete — **fix before any release**
+
+It lists four components: `rust-fs-ext4`, `rust-fs-ntfs`, `go-networkfs`,
+`tabler-icons`. The shipped binary statically links **ten Rust crates**. Six are absent:
+`am-fs-xfs`, `am-fs-btrfs`, `am-fs-erofs`, `am-fs-squashfs`, and all four `am-img-*`
+readers, along with `am-fs-core`, `am-lzo1x` and `am-partitions`.
+
+Every one of them is MIT, so nothing is *unlicensed* — but a notice file that omits
+most of what it is a notice for does not discharge the obligation it exists for.
+
+### 2. `IP_SWEEP_REPORT.md` describes a project that no longer matches
+
+Dated 2026-05-03. Since then: six filesystem crates were added and are absent from it;
+the crates moved from submodules to crates.io; the Swift Package Manager dependency it
+records (`swift-protobuf`) is no longer present at all; and the Go closure it puts at
+**44 modules** is now **117**.
+
+The last of those matters most, because Go is where the only copyleft lives. A reader
+checking the copyleft position against that report is checking it against a graph less
+than half the size of the real one.
+
+### 3. `vendor/rust-disk-probe` is committed in-tree, unpinned and undocumented
+
+It is first-party and MIT, so there is no licence question. But unlike every other entry
+in `vendor/` it is not a submodule, does not appear in `.gitmodules`, and is absent from
+`VENDOR_PINS.txt` — so the one place that records what version of each dependency is in
+use does not record it. That is a reproducibility gap that reads as a provenance gap.
+
+### 4. Go closure coverage was partial, and the audit says so rather than rounding up
+
+Of 117 modules, 60 had a licence file to read; 56 were not present in the local module
+cache and one (`github.com/mattn/go-localereader`) has no recognisable licence text.
+The classified set contains no surprises, and the two MPL entries above were found in
+it. The uncovered remainder is a gap in *this* audit, not a finding about the project.
+
+Closing it needs the module cache populated (`go mod download` in `vendor/go-networkfs`)
+and a re-run. It was left open rather than papered over.
+
+### 5. A naming nit, in first-party source
+
+`rust-fs-ext4/src/mkfs.rs` names `e2fsprogs` in three comments, describing a convention
+this driver matches behaviourally. It is the only occurrence of a reference tool's name
+in any shipped source across all thirteen crates. It claims no derivation and is not a
+licence risk; it is only inconsistent with the policy that vendor repositories refer to
+tools by role. Worth a rewording next time that file is touched, not worth its own
+change.
+
+## Actions
+
+| # | Action | Urgency |
+|---|---|---|
+| 1 | Complete `THIRD_PARTY_LICENSES.md` | before the next release |
+| 2 | Replace `IP_SWEEP_REPORT.md` with a pointer to the current audit | soon |
+| 3 | Make `vendor/rust-disk-probe` a submodule, or record it in `VENDOR_PINS.txt` | soon |
+| 4 | Re-run the Go classification with the module cache populated | next audit |
+| 5 | Reword the `e2fsprogs` comments | opportunistic |
+
+Actions 1 and 2 are done in this change. 3, 4 and 5 are not.


### PR DESCRIPTION
The two standing compliance documents were written in May and describe a project that has since changed underneath them. Both were accurate when written; neither is now, and both err in the direction that **understates what ships**.

## The verdict has not changed

✅ No unmet obligation, nothing that blocks shipping. Every Rust crate and its whole transitive closure is MIT / Apache-2.0 / BSD / Zlib / ISC / 0BSD / CC0-1.0 / MIT-0 / Unicode-3.0. No vendored C. No file claims a GPL implementation as its origin — and three in the EROFS crate say outright that they do not.

## What was stale

**`THIRD_PARTY_LICENSES.md`** listed four components. The shipped binary statically links **thirteen** Rust crates; nine were missing, including four whole filesystems (XFS, Btrfs, EROFS, SquashFS). All are MIT, so nothing was unlicensed — but a notice file that omits most of what it is a notice for does not discharge the obligation it exists for.

It also attributed the two MPL-2.0 modules to the **SMB** driver. They come in through **FTP**, and `jlaffaye/ftp` is the sole importer (verified with `go list -deps`). And it recorded a Swift Package Manager dependency, `swift-protobuf`, that is no longer in the project at all.

**`IP_SWEEP_REPORT.md`** put the Go closure at 44 modules; it is **117**. That is the number that matters most, because Go is where the only copyleft lives. It is now a pointer to the current audit.

## The only copyleft in the project

```
go-networkfs/ftp → github.com/jlaffaye/ftp (ISC) → hashicorp/go-multierror (MPL-2.0) → hashicorp/errwrap (MPL-2.0)
```

MPL is **file-scope** weak copyleft: the obligation attaches to modifications of those files, not to a work that links them. We do not modify them, so the requirement is notice — now given accurately.

## Two false positives, recorded so the next audit skips them

- **`r-efi`** declares `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so a search for `GPL` matches it. Disjunctive licence, dev-dependency only, gated to UEFI targets.
- **The two MPL modules first classified as AGPL** — the MPL's own text names the GNU licences in its "Secondary License" definition, so a classifier testing for GNU *before* MPL reports every MPL file as GNU-licensed.

The rule that avoids the second is written down: test for MPL-2.0 before any GNU licence, and treat a disjunctive licence as satisfied by its most permissive term.

## Left open rather than papered over

Of the 117 Go modules, 60 had a licence file present to read; the rest were not in the local module cache. That remainder is a gap in *this audit* and is recorded as one.

Three smaller findings are recorded and **not** fixed here: `vendor/rust-disk-probe` is committed in-tree without a pin, the Go classification wants re-running with a populated cache, and three comments in the ext4 formatter name a reference tool where the policy is to name its role.