### PR TITLE
Bump go-networkfs: no copyleft, no known vulnerability

### DIFF
--- a/VENDOR_PINS.txt
+++ b/VENDOR_PINS.txt
@@ -3,7 +3,7 @@
 
 submodule                sha                                        ref
 ---------                ---                                        ---
-vendor/go-networkfs      9199629e756672d218f37d890aa5d7be752b88f3   (v0.1.3-16-g9199629)
+vendor/go-networkfs      2e5da313fe65dc69246adb8a133dcba602070b99   (v0.1.3-18-g2e5da31)
 vendor/rust-fs-core      27898d4cc0519afdfa50c01c77497f062b95f7a5   (v0.2.0-4-g27898d4)
 vendor/rust-fs-erofs     1edd5340e6eb068f09db1023f251a53d138d5e8e   (v0.1.1)
 vendor/rust-fs-ext4      c41de5b972af26e72120164340f2839e4b51b7ef   (v0.2.1-43-gc41de5b)


### PR DESCRIPTION
The pin was at a commit from May. Since then the network drivers lost their only copyleft dependency and gained a fix for a vulnerability the advisory says has none upstream.

## MPL-2.0 is gone

Two error-aggregation helpers reached through the FTP driver's client library were the **only copyleft this project shipped**. That client was replaced with one depending on nothing outside the Go standard library, so the obligation and its notice go with it.

## GO-2026-5051 is fixed

An out-of-bounds read and panic in the SMB driver's `ReadDir`, reachable from a hostile or man-in-the-middle server — a directory listing crashes the process.

Upstream is unmaintained and the advisory records `Fixed in: N/A`. The maintained fork would have brought **five** vulnerabilities and the MPL back via Kerberos, so the fix was backported to a fork of the original instead.

## The FTP driver also gains

- uploads no longer buffer the whole file in memory — a gigabyte file cost a gigabyte of RAM
- FTPS works against servers requiring TLS session reuse (proftpd's default, vsftpd's `require_ssl_reuse`) — those mounts previously failed outright
- Windows and IIS servers can be listed at all
- a failed transfer no longer leaks a file descriptor per failure

```
go list -deps ./... | grep -c hashicorp   ->  0
govulncheck ./...                         ->  No vulnerabilities found
```

Verified locally — GitHub Actions is in a major outage, so remote checks may not report.