### PR TITLE
Give XFS and Btrfs their own item tags

### DIFF
--- a/DiskJockeyBTRFS/BtrfsVolume.swift
+++ b/DiskJockeyBTRFS/BtrfsVolume.swift
@@ -1,11 +1,12 @@
 /*
  * BtrfsVolume.swift — FSKit volume for BTRFS (read-only).
  *
- * Mirror of DiskJockeySQUASHFS's volume. Implements FSVolume.Operations +
- * FSVolume.ReadWriteOperations + FSVolume.PathConfOperations. BTRFS is
- * read-only, so every mutating op returns BTRFS; reads/lookups/enumeration
- * dispatch to the fs_btrfs_* C ABI. BTRFS NIDs are 64-bit, so item identity
- * is UInt64 (ErofsItem / ErofsTag).
+ * Implements FSVolume.Operations + FSVolume.ReadWriteOperations +
+ * FSVolume.PathConfOperations. This extension is read-only, so every
+ * mutating op returns EROFS — the errno for a read-only filesystem, not
+ * the filesystem of that name; reads/lookups/enumeration dispatch to the
+ * fs_btrfs_* C ABI. Btrfs inode numbers are 64-bit, so item identity is
+ * UInt64 (BtrfsItem / BtrfsTag).
  *
  * MIT License — see LICENSE
  */
@@ -25,7 +26,7 @@ final class BtrfsVolume: FSVolume,
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
     private let stats: IOStatsCollector
-    private let items = FileIDCache<ErofsItem>()
+    private let items = FileIDCache<BtrfsItem>()
 
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
@@ -45,11 +46,11 @@ final class BtrfsVolume: FSVolume,
     // MARK: - Item cache
 
     private func item(forInode inode: UInt64, path: String,
-                      parentInode: UInt64?) -> ErofsItem {
+                      parentInode: UInt64?) -> BtrfsItem {
         items.getOrCreate(
             id: inode,
             validate: { $0.path == path && $0.parentInode == parentInode },
-            create: { ErofsItem(inode: inode, path: path, parentInode: parentInode) }
+            create: { BtrfsItem(inode: inode, path: path, parentInode: parentInode) }
         )
     }
 
@@ -60,11 +61,18 @@ final class BtrfsVolume: FSVolume,
         caps.supportsPersistentObjectIDs = true
         caps.supportsSymbolicLinks = true
         caps.supportsHardLinks = false
-        caps.supportsJournal = false
+        // Btrfs is a journalling filesystem — this said `false`,
+        // inherited from the EROFS volume this file was copied from,
+        // and EROFS genuinely has no journal.
+        //
+        // `supportsJournal` describes the FORMAT; `supportsActiveJournal`
+        // describes this mount. The driver refuses a dirty log rather
+        // than replaying one, so the log tree is never active from here.
+        caps.supportsJournal = true
         caps.supportsActiveJournal = false
         caps.supportsSparseFiles = true
         caps.supports2TBFiles = true
-        // BTRFS NIDs are 64-bit.
+        // Btrfs inode numbers are 64-bit.
         caps.supports64BitObjectIDs = true
         // BTRFS (Linux) is case-sensitive.
         caps.caseFormat = .sensitive
@@ -137,7 +145,7 @@ final class BtrfsVolume: FSVolume,
         _ desiredAttributes: FSItem.GetAttributesRequest,
         of item: FSItem
     ) async throws -> FSItem.Attributes {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? BtrfsItem else {
             throw POSIXError(.EBADF)
         }
         var attr = fs_btrfs_attr_t()
@@ -160,7 +168,7 @@ final class BtrfsVolume: FSVolume,
         named name: FSFileName,
         inDirectory directory: FSItem
     ) async throws -> (FSItem, FSFileName) {
-        guard let fs = bridgeFS, let dirItem = directory as? ErofsItem else {
+        guard let fs = bridgeFS, let dirItem = directory as? BtrfsItem else {
             throw POSIXError(.EBADF)
         }
         guard let nameStr = name.string else { throw POSIXError(.EINVAL) }
@@ -181,7 +189,7 @@ final class BtrfsVolume: FSVolume,
         attributes: FSItem.GetAttributesRequest?,
         packer: FSDirectoryEntryPacker
     ) async throws -> FSDirectoryVerifier {
-        guard let fs = bridgeFS, let dirItem = directory as? ErofsItem else {
+        guard let fs = bridgeFS, let dirItem = directory as? BtrfsItem else {
             throw POSIXError(.EBADF)
         }
         guard let iter = fs_btrfs_dir_open(fs, dirItem.path) else {
@@ -226,7 +234,7 @@ final class BtrfsVolume: FSVolume,
     }
 
     func reclaimItem(_ item: FSItem) async throws {
-        if let eItem = item as? ErofsItem {
+        if let eItem = item as? BtrfsItem {
             items.remove(id: eItem.inode)
         }
     }
@@ -234,7 +242,7 @@ final class BtrfsVolume: FSVolume,
     // MARK: - Symlink
 
     func readSymbolicLink(_ item: FSItem) async throws -> FSFileName {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? BtrfsItem else {
             throw POSIXError(.EBADF)
         }
         var buf = [CChar](repeating: 0, count: 4096)
@@ -304,7 +312,7 @@ final class BtrfsVolume: FSVolume,
         from item: FSItem, at offset: off_t, length: Int,
         into buffer: FSMutableFileDataBuffer
     ) throws -> Int {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? BtrfsItem else {
             throw POSIXError(.EBADF)
         }
         return buffer.withUnsafeMutableBytes { rawBuf in

--- a/DiskJockeyLibrary/FileSystemItem.swift
+++ b/DiskJockeyLibrary/FileSystemItem.swift
@@ -152,6 +152,61 @@ public extension FileSystemItem where Tag == SquashfsTag {
     }
 }
 
+// MARK: - XFS specialisation
+
+/// Phantom tag selecting `UInt64` identity for XFS inode numbers.
+///
+/// XFS inode numbers are 64-bit and encode the allocation group in
+/// their high bits, so the width is not a matter of headroom — a
+/// 32-bit truncation would silently move an inode to a different AG.
+public enum XfsTag: FileSystemTag {
+    public typealias ID = UInt64
+}
+
+/// Per-FS item type for the XFS extension.
+public typealias XfsItem = FileSystemItem<XfsTag>
+
+public extension FileSystemItem where Tag == XfsTag {
+    /// XFS inode number — friendly spelling for `id`.
+    var inode: UInt64 { id }
+
+    /// Parent directory's inode — friendly spelling for `parentID`.
+    var parentInode: UInt64? { parentID }
+
+    convenience init(inode: UInt64, path: String, parentInode: UInt64?) {
+        self.init(id: inode, path: path, parentID: parentInode)
+    }
+}
+
+// MARK: - Btrfs specialisation
+
+/// Phantom tag selecting `UInt64` identity for Btrfs inode numbers.
+///
+/// Btrfs objectids are 64-bit, and an inode number is only unique
+/// WITHIN a subvolume — two subvolumes of one filesystem both have an
+/// inode 256. The tag does not encode that, so anything resolving an
+/// item across subvolumes has to carry the subvolume separately; the
+/// tag's job is only to stop a btrfs id being handed to another
+/// filesystem's code path.
+public enum BtrfsTag: FileSystemTag {
+    public typealias ID = UInt64
+}
+
+/// Per-FS item type for the Btrfs extension.
+public typealias BtrfsItem = FileSystemItem<BtrfsTag>
+
+public extension FileSystemItem where Tag == BtrfsTag {
+    /// Btrfs inode number — friendly spelling for `id`.
+    var inode: UInt64 { id }
+
+    /// Parent directory's inode — friendly spelling for `parentID`.
+    var parentInode: UInt64? { parentID }
+
+    convenience init(inode: UInt64, path: String, parentInode: UInt64?) {
+        self.init(id: inode, path: path, parentID: parentInode)
+    }
+}
+
 // MARK: - EROFS specialisation
 
 /// Phantom tag selecting `UInt64` identity for EROFS inode numbers

--- a/DiskJockeyLibraryTests/FileSystemItemTests.swift
+++ b/DiskJockeyLibraryTests/FileSystemItemTests.swift
@@ -123,4 +123,78 @@ final class FileSystemItemTests: XCTestCase {
         // refactor that collapses them shows up here too.
         XCTAssertFalse(type(of: ext) == type(of: ntfs))
     }
+
+    // MARK: - The tags that had no tests
+    //
+    // SquashFS, EROFS, XFS and Btrfs were all added as a typealias plus
+    // an extension, and none of the four was covered here. That is how a
+    // botched rename survived: XfsVolume and BtrfsVolume were copies of
+    // ErofsVolume that still declared `FileIDCache<ErofsItem>`, so the
+    // phantom tag — whose entire job is to make a cross-filesystem
+    // mix-up a compile error — was silently pointing at the wrong
+    // filesystem in two of the six extensions, and nothing said so.
+    //
+    // These pin the same two properties the ext4 and NTFS cases pin: the
+    // friendly accessors read back what the generic ones do, and the ID
+    // width is the one the tag chose.
+
+    func testSquashfsSpecialisationRoundTrips() {
+        let item = SquashfsItem(inode: 11, path: "/sq", parentInode: 1)
+        XCTAssertEqual(item.inode, 11)
+        XCTAssertEqual(item.parentInode, 1)
+        XCTAssertEqual(item.id, item.inode)
+        XCTAssertEqual(item.parentID, item.parentInode)
+    }
+
+    func testErofsSpecialisationRoundTrips() {
+        let item = ErofsItem(inode: 22, path: "/er", parentInode: 2)
+        XCTAssertEqual(item.inode, 22)
+        XCTAssertEqual(item.parentInode, 2)
+        XCTAssertEqual(item.id, item.inode)
+        XCTAssertEqual(item.parentID, item.parentInode)
+    }
+
+    func testXfsSpecialisationRoundTrips() {
+        let item = XfsItem(inode: 33, path: "/xfs", parentInode: 3)
+        XCTAssertEqual(item.inode, 33)
+        XCTAssertEqual(item.parentInode, 3)
+        XCTAssertEqual(item.id, item.inode)
+        XCTAssertEqual(item.parentID, item.parentInode)
+    }
+
+    func testBtrfsSpecialisationRoundTrips() {
+        let item = BtrfsItem(inode: 44, path: "/btrfs", parentInode: 4)
+        XCTAssertEqual(item.inode, 44)
+        XCTAssertEqual(item.parentInode, 4)
+        XCTAssertEqual(item.id, item.inode)
+        XCTAssertEqual(item.parentID, item.parentInode)
+    }
+
+    /// Every tag's ID width, together.
+    ///
+    /// Written as one test over all six rather than one per filesystem
+    /// so that adding a seventh and forgetting it is visible here as an
+    /// absence rather than passing by default.
+    func testEachTagUsesTheIdentityWidthItsFilesystemNeeds() {
+        XCTAssertTrue(EXT4Tag.ID.self == UInt32.self, "ext4 inodes are 32-bit")
+        XCTAssertTrue(SquashfsTag.ID.self == UInt32.self, "SquashFS inodes are 32-bit")
+        XCTAssertTrue(NTFSTag.ID.self == UInt64.self, "MFT record numbers are 64-bit")
+        XCTAssertTrue(ErofsTag.ID.self == UInt64.self, "EROFS NIDs are 64-bit")
+        XCTAssertTrue(XfsTag.ID.self == UInt64.self, "XFS inode numbers are 64-bit")
+        XCTAssertTrue(BtrfsTag.ID.self == UInt64.self, "Btrfs objectids are 64-bit")
+    }
+
+    /// The tags really are distinct types.
+    ///
+    /// The compiler enforces this and a runtime test cannot reach a
+    /// mix-up — but it CAN check the premise the enforcement rests on,
+    /// which is that no two tags are the same type. Two filesystems
+    /// sharing a tag would compile, and would silently accept each
+    /// other's items. That is close to what the copied volumes did.
+    func testNoTwoFilesystemsShareATag() {
+        XCTAssertFalse(XfsTag.self == ErofsTag.self, "XFS and EROFS share a tag")
+        XCTAssertFalse(BtrfsTag.self == ErofsTag.self, "Btrfs and EROFS share a tag")
+        XCTAssertFalse(XfsTag.self == BtrfsTag.self, "XFS and Btrfs share a tag")
+        XCTAssertFalse(SquashfsTag.self == EXT4Tag.self, "SquashFS and ext4 share a tag")
+    }
 }

--- a/DiskJockeyXFS/XfsVolume.swift
+++ b/DiskJockeyXFS/XfsVolume.swift
@@ -1,11 +1,12 @@
 /*
  * XfsVolume.swift — FSKit volume for XFS (read-only).
  *
- * Mirror of DiskJockeySQUASHFS's volume. Implements FSVolume.Operations +
- * FSVolume.ReadWriteOperations + FSVolume.PathConfOperations. XFS is
- * read-only, so every mutating op returns XFS; reads/lookups/enumeration
- * dispatch to the fs_xfs_* C ABI. XFS NIDs are 64-bit, so item identity
- * is UInt64 (ErofsItem / ErofsTag).
+ * Implements FSVolume.Operations + FSVolume.ReadWriteOperations +
+ * FSVolume.PathConfOperations. This extension is read-only, so every
+ * mutating op returns EROFS — the errno for a read-only filesystem, not
+ * the filesystem of that name; reads/lookups/enumeration dispatch to the
+ * fs_xfs_* C ABI. XFS inode numbers are 64-bit, so item identity is
+ * UInt64 (XfsItem / XfsTag).
  *
  * MIT License — see LICENSE
  */
@@ -25,7 +26,7 @@ final class XfsVolume: FSVolume,
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
     private let stats: IOStatsCollector
-    private let items = FileIDCache<ErofsItem>()
+    private let items = FileIDCache<XfsItem>()
 
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
@@ -45,11 +46,11 @@ final class XfsVolume: FSVolume,
     // MARK: - Item cache
 
     private func item(forInode inode: UInt64, path: String,
-                      parentInode: UInt64?) -> ErofsItem {
+                      parentInode: UInt64?) -> XfsItem {
         items.getOrCreate(
             id: inode,
             validate: { $0.path == path && $0.parentInode == parentInode },
-            create: { ErofsItem(inode: inode, path: path, parentInode: parentInode) }
+            create: { XfsItem(inode: inode, path: path, parentInode: parentInode) }
         )
     }
 
@@ -60,11 +61,18 @@ final class XfsVolume: FSVolume,
         caps.supportsPersistentObjectIDs = true
         caps.supportsSymbolicLinks = true
         caps.supportsHardLinks = false
-        caps.supportsJournal = false
+        // XFS is a journalling filesystem — this said `false`,
+        // inherited from the EROFS volume this file was copied from,
+        // and EROFS genuinely has no journal.
+        //
+        // `supportsJournal` describes the FORMAT; `supportsActiveJournal`
+        // describes this mount. The driver refuses a dirty log rather
+        // than replaying one, so the log is never active from here.
+        caps.supportsJournal = true
         caps.supportsActiveJournal = false
         caps.supportsSparseFiles = true
         caps.supports2TBFiles = true
-        // XFS NIDs are 64-bit.
+        // XFS inode numbers are 64-bit.
         caps.supports64BitObjectIDs = true
         // XFS (Linux) is case-sensitive.
         caps.caseFormat = .sensitive
@@ -128,7 +136,7 @@ final class XfsVolume: FSVolume,
         _ desiredAttributes: FSItem.GetAttributesRequest,
         of item: FSItem
     ) async throws -> FSItem.Attributes {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? XfsItem else {
             throw POSIXError(.EBADF)
         }
         var attr = fs_xfs_attr_t()
@@ -151,7 +159,7 @@ final class XfsVolume: FSVolume,
         named name: FSFileName,
         inDirectory directory: FSItem
     ) async throws -> (FSItem, FSFileName) {
-        guard let fs = bridgeFS, let dirItem = directory as? ErofsItem else {
+        guard let fs = bridgeFS, let dirItem = directory as? XfsItem else {
             throw POSIXError(.EBADF)
         }
         guard let nameStr = name.string else { throw POSIXError(.EINVAL) }
@@ -172,7 +180,7 @@ final class XfsVolume: FSVolume,
         attributes: FSItem.GetAttributesRequest?,
         packer: FSDirectoryEntryPacker
     ) async throws -> FSDirectoryVerifier {
-        guard let fs = bridgeFS, let dirItem = directory as? ErofsItem else {
+        guard let fs = bridgeFS, let dirItem = directory as? XfsItem else {
             throw POSIXError(.EBADF)
         }
         guard let iter = fs_xfs_dir_open(fs, dirItem.path) else {
@@ -217,7 +225,7 @@ final class XfsVolume: FSVolume,
     }
 
     func reclaimItem(_ item: FSItem) async throws {
-        if let eItem = item as? ErofsItem {
+        if let eItem = item as? XfsItem {
             items.remove(id: eItem.inode)
         }
     }
@@ -225,7 +233,7 @@ final class XfsVolume: FSVolume,
     // MARK: - Symlink
 
     func readSymbolicLink(_ item: FSItem) async throws -> FSFileName {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? XfsItem else {
             throw POSIXError(.EBADF)
         }
         var buf = [CChar](repeating: 0, count: 4096)
@@ -295,7 +303,7 @@ final class XfsVolume: FSVolume,
         from item: FSItem, at offset: off_t, length: Int,
         into buffer: FSMutableFileDataBuffer
     ) throws -> Int {
-        guard let fs = bridgeFS, let eItem = item as? ErofsItem else {
+        guard let fs = bridgeFS, let eItem = item as? XfsItem else {
             throw POSIXError(.EBADF)
         }
         return buffer.withUnsafeMutableBytes { rawBuf in


### PR DESCRIPTION
Give XFS and Btrfs their own item tags

XfsVolume.swift and BtrfsVolume.swift were copied from ErofsVolume.swift
and renamed with a find-and-replace. The replace was both too narrow and
too wide.

TOO NARROW: both files still declared `FileIDCache<ErofsItem>` and cast
every item to `ErofsItem`. `FileSystemItem`'s whole purpose is the
phantom tag — its own header says the tag exists so "the compiler refuses
any code that accidentally feeds an ext4 inode into an NTFS code path".
Two of the six extensions were pointing that guarantee at the wrong
filesystem, so for XFS and Btrfs it guaranteed nothing.

XfsTag/XfsItem and BtrfsTag/BtrfsItem now exist, added the way the header
says to add one: a typealias plus a small extension. Both are UInt64,
with the reason written down rather than assumed — XFS inode numbers
encode the allocation group in their high bits, so a 32-bit truncation
would silently move an inode to a different AG; Btrfs objectids are
64-bit and unique only WITHIN a subvolume, which the tag deliberately
does not model.

TOO WIDE: the replace also hit the errno. `POSIXError(.EROFS)` is the
error for "read-only filesystem", not the filesystem of that name, and
it is correct in all fourteen places it appears — but the same pass
rewrote the prose around it, leaving XfsVolume.swift claiming "every
mutating op returns XFS". The comment now says which EROFS it means. The
rename here was done by replacing only `ErofsItem` and `ErofsTag`, with
an assertion that the count of `POSIXError(.EROFS)` was unchanged.

Both files also inherited `supportsJournal = false`, which is right for
EROFS and wrong for two journalling filesystems. It is `true` now, with
`supportsActiveJournal` left false and the distinction explained: the
first describes the format, the second this mount, and both drivers
refuse a dirty log rather than replaying one.

The reason none of this was caught: XFS and Btrfs were the only two
filesystems with no tests, and SquashFS and EROFS had none either — four
of six tags were uncovered. All four are covered now, plus two tests that
would have caught this class of thing directly: one asserting each tag's
ID width, written as a single test over all six so a seventh added and
forgotten shows up as an absence; and one asserting no two filesystems
share a tag, which is the premise the compile-time guarantee rests on and
is close to exactly what the copied volumes did.

Verified: DiskJockeyLibrary, DiskJockeyXFS, DiskJockeyBTRFS and
DiskJockeyEROFS all build, and 17 FileSystemItemTests pass. A normalised
diff against ErofsVolume.swift confirms nothing else in either file was
disturbed.

Found by the human-code review in docs/human-code-report-2026-08-28.md.

What this does NOT do is remove the duplication that caused it. Three
volumes are still near-identical copies, which is why a find-and-replace
was the tool reached for. That is a larger change and its own decision.

Based on main rather than on cth/chore-tasks. The first attempt branched
from the latter and so carried an unmerged chore-migration commit, which
is what made CI fail: that commit adds a `make vendor-*` step, and
ci.yml notes in its own comment that the runner has no `chore` install
and that adding one is a separate decision. None of that is this change.
