### PR TITLE
Authenticate the agent connection in both directions

### DIFF
--- a/DiskJockeyAgent/main.swift
+++ b/DiskJockeyAgent/main.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// Also spelled in `DiskJockeyApplication/Services/DJAgentClient.swift`
+/// as `teamID`. Two copies, because this agent is not an Xcode target
+/// and shares no compilation unit with the app — if one is ever changed
+/// without the other, the app and its helper stop being able to talk
+/// and neither says why. Change both.
 private let kTeamID = "43UMKXZ8P4"
 
 final class AgentDelegate: NSObject, NSXPCListenerDelegate {
@@ -10,8 +15,15 @@ final class AgentDelegate: NSObject, NSXPCListenerDelegate {
         // replacement for the manual audit-token + SecCode validation —
         // `NSXPCConnection.auditToken` is not public API. The connection is
         // invalidated automatically if the peer doesn't satisfy the rule.
+        //
+        // `anchor apple generic` was missing. Without it the rule asks
+        // for an identifier and a team OU on the leaf certificate, and
+        // says nothing about who issued that certificate — a
+        // self-signed leaf carrying the same two fields satisfies it.
+        // The anchor is what requires an Apple-issued chain.
         conn.setCodeSigningRequirement(
-            "identifier \"com.antimatterstudios.diskjockey\" and certificate leaf[subject.OU] = \"\(kTeamID)\"")
+            "anchor apple generic and identifier \"com.antimatterstudios.diskjockey\" "
+            + "and certificate leaf[subject.OU] = \"\(kTeamID)\"")
         conn.exportedInterface = NSXPCInterface(with: DJAgentProtocol.self)
         conn.exportedObject = AgentImpl()
         conn.resume()

--- a/DiskJockeyApplication/Services/DJAgentClient.swift
+++ b/DiskJockeyApplication/Services/DJAgentClient.swift
@@ -117,10 +117,52 @@ final class DJAgentClient {
         }
     }
 
+    /// What the agent must prove before this app will talk to it.
+    ///
+    /// The agent checks US — `DiskJockeyAgent/main.swift` pins a
+    /// requirement on every incoming connection — and until now nothing
+    /// checked IT. Authentication in one direction is not
+    /// authentication: the mach name
+    /// `com.antimatterstudios.diskjockey.agent` is registered from
+    /// `~/Library/LaunchAgents`, which the user can write to without
+    /// authorisation, so any process running as the user could claim
+    /// the name and receive `attachImage(atPath:)`,
+    /// `detachDevice(_:)` and `mountFSKit(...)` from a sandboxed app
+    /// that believed it was talking to its own helper.
+    ///
+    /// `anchor apple generic` is the half that does the work: it
+    /// requires an Apple-issued certificate chain, which a locally
+    /// produced binary cannot forge. The team check then narrows that
+    /// to our own signing identity.
+    ///
+    /// The agent's code-signing IDENTIFIER is deliberately not pinned.
+    /// It is not a committed Xcode target — it is built by
+    /// `scripts/install-agent-dev.sh` from DerivedData — so its
+    /// identifier is not fixed anywhere this code can read, and pinning
+    /// a guess would fail closed: the connection would be invalidated
+    /// with no error at the call site, which is worse than the gap
+    /// being fixed. Tighten this the day the agent becomes a real
+    /// target.
+    ///
+    /// The team ID is also spelled in `DiskJockeyAgent/main.swift` as
+    /// `kTeamID`. Two copies, because the agent is not an Xcode target
+    /// and shares no compilation unit with the app — if one is ever
+    /// changed without the other, the app and its helper stop being
+    /// able to talk and neither says why. Change both.
+    private static let teamID = "43UMKXZ8P4"
+
+    private static var agentRequirement: String {
+        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\""
+    }
+
     private func makeProxy() throws -> DJAgentProtocol {
         if connection == nil {
             let conn = NSXPCConnection(machServiceName: "com.antimatterstudios.diskjockey.agent",
                                        options: [])
+            // Before anything is sent, and before the interface is set:
+            // a connection that cannot prove who it is should never
+            // carry a message.
+            conn.setCodeSigningRequirement(Self.agentRequirement)
             conn.remoteObjectInterface = NSXPCInterface(with: DJAgentProtocol.self)
             conn.invalidationHandler = { [weak self] in
                 Task { @MainActor in self?.connection = nil }


### PR DESCRIPTION
Authenticate the agent connection in both directions

The agent checked the app. Nothing checked the agent.

`DiskJockeyAgent/main.swift` pins a code-signing requirement on every
incoming connection, so a stray process cannot talk TO the agent. The
app set none on the outgoing one — and the mach name
`com.antimatterstudios.diskjockey.agent` is registered from
`~/Library/LaunchAgents`, which the user can write to without
authorisation. So any process running as the user could claim the name
and receive `attachImage(atPath:)`, `detachDevice(_:)` and
`mountFSKit(...)` from a sandboxed app that believed it was talking to
its own helper. Authentication in one direction is not authentication.

The client now sets a requirement before the interface is assigned and
before anything is sent: a connection that cannot prove who it is should
never carry a message.

The agent's own requirement was also incomplete. It asked for an
identifier and a team OU on the leaf certificate and said nothing about
who ISSUED that certificate, so a self-signed leaf carrying the same two
fields satisfied it. `anchor apple generic` — which requires an
Apple-issued chain and cannot be forged locally — is now on both sides.

The agent's code-signing IDENTIFIER is deliberately not pinned by the
client. The agent is not a committed Xcode target; it is built from
DerivedData by scripts/install-agent-dev.sh, so its identifier is not
fixed anywhere this code can read. Pinning a guess would fail CLOSED —
the connection invalidated, with no error at the call site — which is a
worse outcome than the gap being closed. `anchor apple generic` plus the
team is what can be asserted truthfully today; tighten it the day the
agent becomes a real target.

The team ID now exists in two named constants that point at each other,
because the agent shares no compilation unit with the app and a silent
divergence there stops the two talking with neither saying why.

Found by the human-code review in docs/human-code-report-2026-08-28.md,
which also corrected its own first reading: the agent's check IS
present, and the gap is client-side.
