### PR TITLE
Validate what the agent is asked to attach and detach

### DIFF
--- a/DiskJockeyAgent/AgentImpl.swift
+++ b/DiskJockeyAgent/AgentImpl.swift
@@ -7,8 +7,42 @@ import Foundation
 extension String: @retroactive Error {}
 
 final class AgentImpl: NSObject, DJAgentProtocol {
-    func attachImage(atPath path: String,
+    /// Whether a path is one this agent will attach.
+    ///
+    /// `attachImage` attached ANY caller-supplied path — no
+    /// canonicalisation, no symlink check, no existence check. That is a
+    /// sandbox-escape primitive dressed as a convenience: a sandboxed
+    /// caller cannot open a file outside its container, but it could ask
+    /// this unsandboxed agent to attach one.
+    ///
+    /// The connection is now mutually authenticated, so the caller is at
+    /// least our own app — but an app is a large thing to trust
+    /// wholesale, and a bug in it should not become a whole-disk read.
+    /// So: resolve symlinks first, then require a regular file that
+    /// exists. Resolving BEFORE checking is the order that matters; a
+    /// symlink checked and then followed is the classic race.
+    static func attachableImage(_ path: String) -> Result<String, String> {
+        let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: resolved,
+                                             isDirectory: &isDirectory) else {
+            return .failure("no such file: \(path)")
+        }
+        guard !isDirectory.boolValue else {
+            return .failure("not a disk image: \(path) is a directory")
+        }
+        return .success(resolved)
+    }
+
+    func attachImage(atPath incoming: String,
                      reply: @escaping ([String]?, String?) -> Void) {
+        let path: String
+        switch Self.attachableImage(incoming) {
+        case .success(let resolved): path = resolved
+        case .failure(let why):
+            reply(nil, why)
+            return
+        }
         switch Self.hdiutilAttach(path: path) {
         case .success(let slices):
             reply(slices, nil)
@@ -107,8 +141,26 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         proc.waitUntilExit()
     }
 
+    /// A BSD disk name, and nothing else.
+    ///
+    /// `detachDevice` hands its argument to `hdiutil detach`. The
+    /// INTERNAL caller at the top of this file already checks the shape;
+    /// this XPC entry point did not, so a peer could name any device —
+    /// including volumes this agent never attached — and have them
+    /// forced offline.
+    ///
+    /// Anchored at both ends deliberately: an unanchored match would
+    /// accept `/dev/disk1 ; anything`.
+    static func isBSDDiskName(_ name: String) -> Bool {
+        name.range(of: #"^/dev/disk\d+(s\d+)?$"#, options: .regularExpression) != nil
+    }
+
     func detachDevice(_ bsdName: String,
                       reply: @escaping (Bool, String?) -> Void) {
+        guard Self.isBSDDiskName(bsdName) else {
+            reply(false, "refusing to detach \(bsdName): not a BSD disk name")
+            return
+        }
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
         proc.arguments = ["detach", bsdName]


### PR DESCRIPTION
Validate what the agent is asked to attach and detach

The connection is mutually authenticated now, so the peer is our own
app. That is not the same as the arguments being safe: an app is a large
thing to trust wholesale, and a bug in it should not become a whole-disk
read.

`attachImage` attached ANY caller-supplied path — no canonicalisation,
no symlink check, not even an existence check. A sandboxed caller cannot
open a file outside its container, but it could ask this unsandboxed
agent to attach one, which is a sandbox-escape primitive dressed as a
convenience API. It now resolves symlinks FIRST and then requires the
result to exist and not be a directory. The order is the point: a
symlink checked and then followed is the classic race.

`detachDevice` passed its argument to `hdiutil detach` unchecked, so a
peer could name any device — including volumes this agent never attached
— and have them forced offline. It now requires a BSD disk name,
anchored at both ends, because an unanchored match accepts
`/dev/disk1 ; anything`. The internal caller in this file already did
this check; only the XPC entry point did not.

Two things this does NOT fix, both from the same review:

`mountFSKit` still composes a root shell line from four unvalidated
inputs and runs it through NSAppleScript with administrator privileges.
Its quoting is correct today and it has no callers, which is the only
reason it is not the first thing here — but "correct today, unused, and
untested" is three pieces of luck.

The agent has no test target, so none of this is covered. That is
downstream of the agent having ZERO references in the Xcode project: its
entitlements, signing identity and launchd registration are not
reproducible from the repo, and neither is a build of it. It typechecks
(`swiftc -typecheck`) and nothing more. Committing the target is the
prerequisite for testing any of it.
