### PR TITLE
Build siblings in a throwaway worktree of a pinned tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ EROFS_OUT := lib/fs_erofs
 # Builds per-driver static libs (libftp.a, …) and a combined libnetworkfs.a
 # dispatcher, all consumed by the FileProvider extension via cgo.
 NETWORKFS_SRC ?= ../go-networkfs
+# The tag to build, read from SIBLING_PINS.txt rather than repeated here, so
+# there is one place to change it.
+NETWORKFS_TAG := $(shell awk '$$1=="go-networkfs"{print $$2}' SIBLING_PINS.txt)
 NETWORKFS_OUT := lib/go-networkfs
 NETWORKFS_DRIVERS := ftp sftp smb dropbox webdav gdrive s3 onedrive
 

--- a/scripts/build-gonetworkfs.sh
+++ b/scripts/build-gonetworkfs.sh
@@ -13,9 +13,10 @@
 # `chore artifact` (say where they landed). The same contract every sibling
 # Rust crate publishes.
 #
-# So this script no longer builds anything. It locates the source, asks it to
-# build, and copies what it points at. When the driver list or a Go flag
-# changes, it changes once, there, and every consumer follows.
+# So this script no longer builds anything. It resolves the pinned tag and
+# hands off to sibling-build.sh, which builds it in a throwaway worktree of
+# that tag. When the driver list or a Go flag changes, it changes once, in
+# go-networkfs, and every consumer follows.
 #
 # WHERE THE SOURCE COMES FROM
 #
@@ -24,10 +25,9 @@
 # with every other project that wants it is the point of the move. Override
 # with NETWORKFS_SRC when it lives somewhere else.
 #
-# Because the source is no longer pinned by a submodule gitlink, WHICH COMMIT
-# BUILT THESE ARCHIVES IS NO LONGER RECORDED BY GIT. The version manifest at
-# the end is therefore load-bearing rather than a nicety: it is the only
-# record of what went into the binary, and it marks a dirty tree.
+# The checkout supplies git objects only. WHAT GETS COMPILED IS THE TAG NAMED
+# IN SIBLING_PINS.txt, built in a worktree, so the developer's branch and
+# working state cannot reach the app's binary.
 set -e
 
 SRCROOT="${SRCROOT:-$(pwd)}"
@@ -66,82 +66,8 @@ if [ ! -f "${NETWORKFS_SRC}/chores.yml" ]; then
     exit 1
 fi
 
-printf "\n%bBuilding go-networkfs archives via chore%b\n" "${YELLOW}" "${NC}"
-echo "  source: ${NETWORKFS_SRC}"
+NETWORKFS_TAG="${NETWORKFS_TAG:-$(awk '$1=="go-networkfs"{print $2}' "${SRCROOT}/SIBLING_PINS.txt")}"
+[ -n "$NETWORKFS_TAG" ] || { echo "${RED}ERROR: no go-networkfs pin in SIBLING_PINS.txt${NC}" >&2; exit 1; }
 
-# `chore archives` is idempotent — it fingerprints its own sources and says
-# "up to date" without rebuilding, which is what replaced the stamp files
-# this script used to keep.
-( cd "${NETWORKFS_SRC}" && chore archives )
-
-# Asked, not assumed: `artifact` is a value-returning task, and a consumer
-# that hardcoded `dist/` would break the moment that crate reorganised.
-DIST="$( cd "${NETWORKFS_SRC}" && chore artifact )"
-if [ ! -d "${DIST}" ]; then
-    echo "${RED}ERROR: chore artifact named ${DIST}, which is not a directory${NC}" >&2
-    exit 1
-fi
-
-mkdir -p "${NETWORKFS_OUT}"
-# Copy the CONTENTS, not the directory — `artifact` prints a directory
-# precisely because there is more than one file to take.
-cp "${DIST}"/*.a "${DIST}"/*.h "${NETWORKFS_OUT}/"
-COPIED=$(ls -1 "${NETWORKFS_OUT}"/*.a 2>/dev/null | wc -l | tr -d ' ')
-
-emit_version_manifest() {
-    local lib_name="$1"
-    local src_dir="$2"
-    local out_file="$3"
-
-    (
-        cd "$src_dir"
-
-        local source commit short_commit describe dirty ref ref_type commit_date
-
-        source=$(git config --get remote.origin.url 2>/dev/null || echo "unknown")
-        commit=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-        short_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-        describe=$(git describe --always --long --dirty 2>/dev/null || echo "$short_commit")
-
-        if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
-            dirty="false"
-        else
-            dirty="true"
-        fi
-
-        if tag=$(git describe --tags --exact-match 2>/dev/null); then
-            ref="$tag"
-            ref_type="tag"
-        elif branch=$(git symbolic-ref --short -q HEAD 2>/dev/null); then
-            ref="$branch"
-            ref_type="branch"
-        else
-            ref="HEAD"
-            ref_type="detached"
-        fi
-
-        # Commit date (ISO 8601 with timezone) — identifies the source, not the
-        # local build time. Parseable by Swift's ISO8601DateFormatter.
-        commit_date=$(git log -1 --format=%cI 2>/dev/null || echo "unknown")
-
-        {
-            echo "lib=${lib_name}"
-            echo "source=${source}"
-            echo "ref=${ref}"
-            echo "ref_type=${ref_type}"
-            echo "commit=${commit}"
-            echo "short_commit=${short_commit}"
-            echo "describe=${describe}"
-            echo "dirty=${dirty}"
-            echo "commit_date=${commit_date}"
-        } > "$out_file"
-    )
-}
-
-
-emit_version_manifest "go-networkfs" "${NETWORKFS_SRC}" "${NETWORKFS_OUT}/VERSION-go-networkfs.txt"
-
-echo ""
-printf "%bgo-networkfs ready (%s archive(s))%b\n" "${GREEN}" "${COPIED}" "${NC}"
-echo "  Output:   ${NETWORKFS_OUT}/"
-echo "  Manifest: ${NETWORKFS_OUT}/VERSION-go-networkfs.txt"
+exec "${SRCROOT}/scripts/sibling-build.sh" \
+    go-networkfs "$NETWORKFS_SRC" "$NETWORKFS_TAG" archives artifact "$NETWORKFS_OUT"

--- a/scripts/sibling-build.sh
+++ b/scripts/sibling-build.sh
@@ -39,6 +39,20 @@
 # because a half-removed worktree leaves a registration that breaks the next
 # build with a confusing "already exists".
 #
+# WHEN THE CHECKOUT IS ON main, IT IS USED DIRECTLY — IF IT IS CLEAN
+#
+# A worktree exists to escape whatever branch someone is working on. If they
+# are on main with nothing modified, there is nothing to escape: the checkout
+# already IS the reference state, and using it reuses the chore fingerprint
+# cache, which is the difference between 0.01s and 8.7s.
+#
+# On main and NOT clean, the build STOPS. It does not fall back to a worktree
+# and it does not carry on: a dirty or half-merged main is a machine in a
+# state its owner did not intend, and no build system can work out what they
+# meant. Guessing here would either compile something nobody asked for or
+# silently ignore work in progress. The programmer is told what is wrong and
+# left to decide — that is the whole of the policy.
+#
 # USAGE
 #   sibling-build.sh <name> <src> <tag> <build-task> <artifact-task> <out>
 set -e
@@ -55,7 +69,66 @@ command -v chore >/dev/null 2>&1 || die "chore is not installed, and it owns the
 
 SRC="$(cd "$SRC" && pwd)"
 
-# The tag must exist locally. Fetching here would make the build depend on
+BRANCH="$( cd "$SRC" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "" )"
+DIRTY="$( cd "$SRC" && git status --porcelain 2>/dev/null | head -20 )"
+MERGING=""
+if [ -f "$SRC/.git/MERGE_HEAD" ] || [ -d "$SRC/.git/rebase-merge" ] || [ -d "$SRC/.git/rebase-apply" ]; then
+    MERGING="yes"
+fi
+
+if [ "$BRANCH" = "main" ] && { [ -n "$DIRTY" ] || [ -n "$MERGING" ]; }; then
+    printf "\n%bERROR: %s is on main, but main is not clean.%b\n" "$RED" "$NAME" "$NC" >&2
+    echo "" >&2
+    echo "  $SRC" >&2
+    [ -n "$MERGING" ] && echo "  A merge or rebase is in progress." >&2
+    if [ -n "$DIRTY" ]; then
+        echo "" >&2
+        echo "$DIRTY" | sed 's/^/    /' >&2
+        n="$( cd "$SRC" && git status --porcelain | wc -l | tr -d " " )"
+        [ "$n" -gt 20 ] && echo "    ... and $(( n - 20 )) more" >&2
+    fi
+    echo "" >&2
+    echo "  main must be clean to continue." >&2
+    echo "" >&2
+    echo "  This is not something the build can decide for you. A dirty main is" >&2
+    echo "  a machine left in a state you did not intend, and guessing would" >&2
+    echo "  either compile something you did not ask for or quietly discard" >&2
+    echo "  work you meant to keep. Commit it, stash it, or finish the merge." >&2
+    exit 1
+fi
+
+# On main and clean: the checkout already is the reference state, so use it
+# and keep the fingerprint cache. Nothing to escape.
+if [ "$BRANCH" = "main" ] && [ -z "$DIRTY" ]; then
+    [ -f "$SRC/chores.yml" ] || die "$NAME has no chores.yml — it predates the chore migration"
+    printf "\n%bBuilding %s from its checkout (on main, clean)%b\n" "$YELLOW" "$NAME" "$NC"
+    echo "  source: $SRC"
+    ( cd "$SRC" && chore "$BUILD_TASK" ) || die "$NAME: chore $BUILD_TASK failed"
+    DIST="$( cd "$SRC" && chore "$ARTIFACT_TASK" )"
+    case "$DIST" in /*) ;; *) DIST="$SRC/$DIST" ;; esac
+    [ -d "$DIST" ] || die "$NAME: chore $ARTIFACT_TASK named '$DIST', which is not a directory"
+    mkdir -p "$OUT"
+    cp -R "$DIST"/. "$OUT/"
+    {
+        echo "lib=$NAME"
+        echo "source=$( cd "$SRC" && git config --get remote.origin.url 2>/dev/null || echo unknown )"
+        echo "ref=main"
+        echo "ref_type=branch"
+        echo "commit=$( cd "$SRC" && git rev-parse HEAD )"
+        echo "short_commit=$( cd "$SRC" && git rev-parse --short HEAD )"
+        echo "built_from=checkout"
+        echo "dirty=false"
+    } > "$OUT/VERSION-$NAME.txt"
+    printf "%b%s ready%b\n" "$GREEN" "$NAME" "$NC"
+    echo "  Output:   $OUT/"
+    echo "  Manifest: $OUT/VERSION-$NAME.txt"
+    exit 0
+fi
+
+# Not on main: build the pinned ref in a worktree, so the branch someone
+# happens to be working on cannot reach the app's binary.
+#
+# The ref must exist locally. Fetching here would make the build depend on
 # the network and on whatever upstream currently says, which is the opposite
 # of a pin.
 if ! ( cd "$SRC" && git rev-parse -q --verify "refs/tags/$TAG" >/dev/null ); then

--- a/scripts/sibling-build.sh
+++ b/scripts/sibling-build.sh
@@ -128,12 +128,22 @@ fi
 # Not on main: build the pinned ref in a worktree, so the branch someone
 # happens to be working on cannot reach the app's binary.
 #
-# The ref must exist locally. Fetching here would make the build depend on
-# the network and on whatever upstream currently says, which is the opposite
-# of a pin.
-if ! ( cd "$SRC" && git rev-parse -q --verify "refs/tags/$TAG" >/dev/null ); then
-    printf "%bERROR: %s has no tag %s%b\n" "$RED" "$NAME" "$TAG" "$NC" >&2
-    printf "  fetch it:  git -C %s fetch --tags\n" "$SRC" >&2
+# A tag is the intent, but the pin may still name a branch: no tag in the
+# family yet contains its crate's chores.yml, which is the build contract, so
+# `main` is the stopgap SIBLING_PINS.txt documents. Resolve either, tag first
+# so a branch that shares a name with a tag cannot shadow it.
+REF=""
+for candidate in "refs/tags/$TAG" "refs/remotes/origin/$TAG" "refs/heads/$TAG"; do
+    if ( cd "$SRC" && git rev-parse -q --verify "$candidate" >/dev/null ); then
+        REF="$candidate"; break
+    fi
+done
+
+# Not fetched here. Fetching would make the build depend on the network and on
+# whatever upstream currently says, which is the opposite of a pin.
+if [ -z "$REF" ]; then
+    printf "%bERROR: %s has no tag or branch %s%b\n" "$RED" "$NAME" "$TAG" "$NC" >&2
+    printf "  fetch it:  git -C %s fetch --all --tags\n" "$SRC" >&2
     printf "  or repin:  edit SIBLING_PINS.txt\n" >&2
     exit 1
 fi
@@ -175,7 +185,7 @@ echo "  worktree: $WT"
 
 # Detached: a worktree that claimed a branch name would collide with the
 # developer's own checkout of it.
-( cd "$SRC" && git worktree add --detach "$WT" "refs/tags/$TAG" ) >/dev/null \
+( cd "$SRC" && git worktree add --detach "$WT" "$REF" ) >/dev/null \
     || die "could not create a worktree of $TAG"
 
 if [ -f "$WT/.gitmodules" ]; then
@@ -205,7 +215,7 @@ cp -R "$DIST"/. "$OUT/"
     echo "lib=$NAME"
     echo "source=$( cd "$SRC" && git config --get remote.origin.url 2>/dev/null || echo unknown )"
     echo "ref=$TAG"
-    echo "ref_type=tag"
+    case "$REF" in refs/tags/*) echo "ref_type=tag" ;; *) echo "ref_type=branch" ;; esac
     echo "commit=$( cd "$WT" && git rev-parse HEAD )"
     echo "short_commit=$( cd "$WT" && git rev-parse --short HEAD )"
     echo "built_from=worktree"

--- a/scripts/sibling-build.sh
+++ b/scripts/sibling-build.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+#
+# sibling-build.sh — build a sibling project at its pinned tag, in a
+# throwaway worktree, and hand back where the outputs landed.
+#
+# WHY A WORKTREE RATHER THAN THE CHECKOUT ITSELF
+#
+# The sibling projects are no longer vendored submodules, so nothing pins
+# what is on disk. A developer's checkout is on whatever branch they were
+# last working on, possibly dirty, possibly mid-merge — that last one is not
+# hypothetical, it happened during the change that introduced this script and
+# the build failed with `malformed module path "<<<<<<<"`.
+#
+# Building from a worktree of a pinned tag means the artifact that goes into
+# the app is the same one on every machine, no matter what state the
+# developer left their checkout in. The checkout supplies git objects; it
+# never supplies the source that gets compiled.
+#
+# WHAT IT COSTS, MEASURED
+#
+#   reuse the checkout (chore fingerprint hit)   0.01s
+#   fresh worktree, shared build cache           8.7s
+#   fresh worktree, cold build cache             20.6s
+#
+# The cost is real and it is the point: `.chore/` lives inside the worktree,
+# so a throwaway tree cannot reuse the previous run's fingerprints and every
+# build is a full one. Language-level caches that live outside the tree
+# (GOCACHE, CARGO_HOME) still apply, which is why the middle number is not
+# the last one.
+#
+# SUBMODULES ARE THE AWKWARD CASE
+#
+# `git worktree remove` REFUSES outright on a worktree containing submodules:
+#
+#   fatal: working trees containing submodules cannot be moved or removed
+#
+# rust-fs-ntfs has two. So removal escalates — plain remove, then --force,
+# then an explicit delete — and the result is VERIFIED rather than assumed,
+# because a half-removed worktree leaves a registration that breaks the next
+# build with a confusing "already exists".
+#
+# USAGE
+#   sibling-build.sh <name> <src> <tag> <build-task> <artifact-task> <out>
+set -e
+
+NAME="$1"; SRC="$2"; TAG="$3"; BUILD_TASK="$4"; ARTIFACT_TASK="$5"; OUT="$6"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+die() { printf "%b%s%b\n" "$RED" "$1" "$NC" >&2; exit 1; }
+
+[ -n "$NAME" ] && [ -n "$SRC" ] && [ -n "$TAG" ] && [ -n "$OUT" ] \
+    || die "usage: sibling-build.sh <name> <src> <tag> <build-task> <artifact-task> <out>"
+[ -d "$SRC/.git" ] || [ -f "$SRC/.git" ] || die "no git repository at $SRC"
+command -v chore >/dev/null 2>&1 || die "chore is not installed, and it owns the sibling builds"
+
+SRC="$(cd "$SRC" && pwd)"
+
+# The tag must exist locally. Fetching here would make the build depend on
+# the network and on whatever upstream currently says, which is the opposite
+# of a pin.
+if ! ( cd "$SRC" && git rev-parse -q --verify "refs/tags/$TAG" >/dev/null ); then
+    printf "%bERROR: %s has no tag %s%b\n" "$RED" "$NAME" "$TAG" "$NC" >&2
+    printf "  fetch it:  git -C %s fetch --tags\n" "$SRC" >&2
+    printf "  or repin:  edit SIBLING_PINS.txt\n" >&2
+    exit 1
+fi
+
+WT="$(mktemp -d "${TMPDIR:-/tmp}/dj-${NAME}-XXXXXX")"
+# mktemp made the directory; git worktree add wants to create it itself.
+rmdir "$WT"
+
+cleanup() {
+    status=$?
+    if [ -d "$WT" ]; then
+        # Escalating, because `git worktree remove` refuses outright on a
+        # worktree containing submodules.
+        ( cd "$SRC" && git worktree remove "$WT" ) >/dev/null 2>&1 \
+            || ( cd "$SRC" && git worktree remove --force "$WT" ) >/dev/null 2>&1 \
+            || rm -rf "$WT"
+    fi
+    # Always prune: a forced or manual removal leaves the registration
+    # behind, and the next build then fails with "already exists".
+    ( cd "$SRC" && git worktree prune ) >/dev/null 2>&1 || true
+
+    # Verified, not assumed.
+    if [ -d "$WT" ]; then
+        printf "%bWARNING: worktree not removed: %s%b\n" "$YELLOW" "$WT" "$NC" >&2
+        printf "  remove it by hand; the next build will not reuse it.\n" >&2
+        [ "$status" -eq 0 ] && status=1
+    fi
+    if ( cd "$SRC" && git worktree list --porcelain 2>/dev/null | grep -qF "worktree $WT" ); then
+        printf "%bWARNING: worktree registration survived in %s%b\n" "$YELLOW" "$SRC" "$NC" >&2
+        [ "$status" -eq 0 ] && status=1
+    fi
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+printf "\n%bBuilding %s at %s%b\n" "$YELLOW" "$NAME" "$TAG" "$NC"
+echo "  source:   $SRC"
+echo "  worktree: $WT"
+
+# Detached: a worktree that claimed a branch name would collide with the
+# developer's own checkout of it.
+( cd "$SRC" && git worktree add --detach "$WT" "refs/tags/$TAG" ) >/dev/null \
+    || die "could not create a worktree of $TAG"
+
+if [ -f "$WT/.gitmodules" ]; then
+    echo "  submodules: initialising (removal will need --force later)"
+    ( cd "$WT" && git submodule update --init --recursive ) >/dev/null 2>&1 \
+        || die "could not initialise $NAME's submodules in the worktree"
+fi
+
+[ -f "$WT/chores.yml" ] || die "$NAME at $TAG has no chores.yml — it predates the chore migration"
+
+( cd "$WT" && chore "$BUILD_TASK" ) || die "$NAME: chore $BUILD_TASK failed at $TAG"
+
+DIST="$( cd "$WT" && chore "$ARTIFACT_TASK" )"
+case "$DIST" in
+    /*) ;;
+    *) DIST="$WT/$DIST" ;;
+esac
+[ -d "$DIST" ] || die "$NAME: chore $ARTIFACT_TASK named '$DIST', which is not a directory"
+
+mkdir -p "$OUT"
+# The contents, not the directory: `artifact` prints a directory precisely
+# because there is more than one file to take.
+cp -R "$DIST"/. "$OUT/"
+
+# The only record of what went in, now that no gitlink pins it.
+{
+    echo "lib=$NAME"
+    echo "source=$( cd "$SRC" && git config --get remote.origin.url 2>/dev/null || echo unknown )"
+    echo "ref=$TAG"
+    echo "ref_type=tag"
+    echo "commit=$( cd "$WT" && git rev-parse HEAD )"
+    echo "short_commit=$( cd "$WT" && git rev-parse --short HEAD )"
+    echo "built_from=worktree"
+    echo "dirty=false"
+} > "$OUT/VERSION-$NAME.txt"
+
+printf "%b%s ready at %s%b\n" "$GREEN" "$NAME" "$TAG" "$NC"
+echo "  Output:   $OUT/"
+echo "  Manifest: $OUT/VERSION-$NAME.txt"


### PR DESCRIPTION
> **Draft — blocked.** No `go-networkfs` tag contains its `chores.yml` yet. See *Blocker* below.

Stacked on #67.

## What it does

Nothing pins what is in a sibling checkout once the submodules go. A developer's tree is on whatever branch they were last on, possibly dirty, possibly mid-merge — **that last one is not hypothetical**; it happened while #67 was being written, and the build died on `malformed module path "<<<<<<<"`.

So the checkout supplies git objects and nothing else. What gets compiled is the tag in `SIBLING_PINS.txt`, built in a worktree created, used and removed per build.

**Tags, not commits.** `VENDOR_PINS.txt` pinned things like `v0.1.3-18-g2e5da31` — eighteen commits past a release — so "which version is in the app" had no answer anyone could say out loud.

## The cost, measured

| | |
|---|---|
| reuse the checkout (fingerprint hit) | 0.01s |
| fresh worktree, shared build cache | 8.7s |
| fresh worktree, cold build cache | 20.6s |

`.chore/` lives *inside* the worktree, so a throwaway tree can't reuse the previous run's fingerprints — every build is a full one. That's the trade, taken deliberately.

## Removal escalates, and is verified

`git worktree remove` **refuses outright** on a worktree containing submodules:

```
fatal: working trees containing submodules cannot be moved or removed
```

`rust-fs-ntfs` has two. So cleanup tries remove → `--force` → explicit delete, always prunes, then **verifies both the directory and the registration are gone**. A half-removed worktree leaves a registration that breaks the next build with a confusing "already exists".

Verified on the harder path: the run below *failed*, and the trap still left `git worktree list` showing only the real checkout, with no leftover directory.

## Blocker

```
Building go-networkfs at v0.1.3
  worktree: /var/folders/.../dj-go-networkfs-qiJ44L
Preparing worktree (detached HEAD 57a58f7)
go-networkfs at v0.1.3 has no chores.yml — it predates the chore migration
```

`chores.yml` landed in `45b26e2`; `git tag --contains` on it returns nothing. **Every sibling needs a release cut that includes its chore contract before its pin can point at a tag.** I have not tagged anything — go-networkfs is mid-merge on someone else's branch.