### PR TITLE
Drop a stored block device that nothing reads

### DIFF
--- a/DiskJockeyBTRFS/BtrfsFileSystem.swift
+++ b/DiskJockeyBTRFS/BtrfsFileSystem.swift
@@ -185,7 +185,6 @@ final class BtrfsFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             volumeID: volID,
             volumeName: FSFileName(string: resolvedName),
             bridgeFS: bridgeFS,
-            blockDevice: blockDevice,
             contextPtr: contextPtr,
             bsdName: bsdName,
             stats: stats

--- a/DiskJockeyBTRFS/BtrfsVolume.swift
+++ b/DiskJockeyBTRFS/BtrfsVolume.swift
@@ -22,7 +22,6 @@ final class BtrfsVolume: FSVolume,
                          FSVolume.PathConfOperations {
 
     private var bridgeFS: OpaquePointer?
-    private let blockDevice: FSBlockDeviceResource
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
     private let stats: IOStatsCollector
@@ -31,12 +30,10 @@ final class BtrfsVolume: FSVolume,
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
          bridgeFS: OpaquePointer,
-         blockDevice: FSBlockDeviceResource,
          contextPtr: UnsafeMutableRawPointer,
          bsdName: String,
          stats: IOStatsCollector) {
         self.bridgeFS = bridgeFS
-        self.blockDevice = blockDevice
         self.contextPtr = contextPtr
         self.bsdName = bsdName
         self.stats = stats

--- a/DiskJockeyBTRFS/BtrfsVolume.swift
+++ b/DiskJockeyBTRFS/BtrfsVolume.swift
@@ -53,52 +53,37 @@ final class BtrfsVolume: FSVolume,
 
     // MARK: - Capabilities
 
+    /// The name `statfs` reports, and the one place it is spelled.
+    static let fsTypeName = "btrfs"
+
+    /// Btrfs is journalled. `supportsActiveJournal` stays false: this
+    /// driver refuses a filesystem with a dirty log rather than
+    /// replaying one, so the log tree is never active from here.
+    static let readOnlyCapabilities = ReadOnlyVolumeCapabilities(hasJournal: true)
+
     var supportedVolumeCapabilities: FSVolume.SupportedCapabilities {
-        let caps = FSVolume.SupportedCapabilities()
-        caps.supportsPersistentObjectIDs = true
-        caps.supportsSymbolicLinks = true
-        caps.supportsHardLinks = false
-        // Btrfs is a journalling filesystem — this said `false`,
-        // inherited from the EROFS volume this file was copied from,
-        // and EROFS genuinely has no journal.
-        //
-        // `supportsJournal` describes the FORMAT; `supportsActiveJournal`
-        // describes this mount. The driver refuses a dirty log rather
-        // than replaying one, so the log tree is never active from here.
-        caps.supportsJournal = true
-        caps.supportsActiveJournal = false
-        caps.supportsSparseFiles = true
-        caps.supports2TBFiles = true
-        // Btrfs inode numbers are 64-bit.
-        caps.supports64BitObjectIDs = true
-        // BTRFS (Linux) is case-sensitive.
-        caps.caseFormat = .sensitive
-        return caps
+        Self.readOnlyCapabilities.fsCapabilities
     }
 
     var volumeStatistics: FSStatFSResult {
-        let result = FSStatFSResult(fileSystemTypeName: "btrfs")
-        guard let fs = bridgeFS else { return result }
+        guard let fs = bridgeFS else {
+            return FSStatFSResult(fileSystemTypeName: Self.fsTypeName)
+        }
         var info = fs_btrfs_volume_info_t()
         fs_btrfs_get_volume_info(fs, &info)
-        // Btrfs reports capacity in BYTES rather than in blocks, and has
-        // no fixed inode table — inodes are allocated from the same pool
-        // as data, so there is no meaningful total or free inode count to
-        // report. Zero is the honest answer for those; inventing one from
-        // the byte figures would be a number a user could act on wrongly.
-        let bs = Int(info.sector_size)
-        result.blockSize = bs
-        result.ioSize = Int(info.node_size)
-        let sectors = bs > 0 ? info.total_bytes / UInt64(bs) : 0
-        let usedSectors = bs > 0 ? info.bytes_used / UInt64(bs) : 0
-        result.totalBlocks = sectors
-        result.freeBlocks = sectors >= usedSectors ? sectors - usedSectors : 0
-        // This driver is read-only, so nothing is available for the
-        // caller to allocate into regardless of what is free.
-        result.availableBlocks = 0
-        result.totalFiles = 0
-        result.freeFiles = 0
-        return result
+        // Btrfs reports capacity in BYTES rather than blocks, advertises
+        // its node size for I/O rather than its sector size, and has no
+        // fixed inode table — inodes come from the same pool as data, so
+        // there is no total or free count to give. The nil inode counts
+        // say that; see ReadOnlyVolumeInfo.
+        let shared = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: UInt64(info.sector_size),
+                             total: info.total_bytes,
+                             used: info.bytes_used),
+            ioSize: UInt64(info.node_size),
+            totalInodes: nil,
+            freeInodes: nil)
+        return ReadOnlyVolumeSupport.statFS(shared, fileSystemTypeName: Self.fsTypeName)
     }
 
     // MARK: - Lifecycle

--- a/DiskJockeyEROFS/ErofsFileSystem.swift
+++ b/DiskJockeyEROFS/ErofsFileSystem.swift
@@ -186,7 +186,6 @@ final class ErofsFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             volumeID: volID,
             volumeName: FSFileName(string: resolvedName),
             bridgeFS: bridgeFS,
-            blockDevice: blockDevice,
             contextPtr: contextPtr,
             bsdName: bsdName,
             stats: stats

--- a/DiskJockeyEROFS/ErofsVolume.swift
+++ b/DiskJockeyEROFS/ErofsVolume.swift
@@ -21,7 +21,6 @@ final class ErofsVolume: FSVolume,
                          FSVolume.PathConfOperations {
 
     private var bridgeFS: OpaquePointer?
-    private let blockDevice: FSBlockDeviceResource
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
     private let stats: IOStatsCollector
@@ -30,12 +29,10 @@ final class ErofsVolume: FSVolume,
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
          bridgeFS: OpaquePointer,
-         blockDevice: FSBlockDeviceResource,
          contextPtr: UnsafeMutableRawPointer,
          bsdName: String,
          stats: IOStatsCollector) {
         self.bridgeFS = bridgeFS
-        self.blockDevice = blockDevice
         self.contextPtr = contextPtr
         self.bsdName = bsdName
         self.stats = stats

--- a/DiskJockeyEROFS/ErofsVolume.swift
+++ b/DiskJockeyEROFS/ErofsVolume.swift
@@ -52,20 +52,12 @@ final class ErofsVolume: FSVolume,
 
     // MARK: - Capabilities
 
+    /// EROFS has no journal — it is an immutable image format, so there
+    /// is no log to replay and nothing to recover.
+    static let readOnlyCapabilities = ReadOnlyVolumeCapabilities(hasJournal: false)
+
     var supportedVolumeCapabilities: FSVolume.SupportedCapabilities {
-        let caps = FSVolume.SupportedCapabilities()
-        caps.supportsPersistentObjectIDs = true
-        caps.supportsSymbolicLinks = true
-        caps.supportsHardLinks = false
-        caps.supportsJournal = false
-        caps.supportsActiveJournal = false
-        caps.supportsSparseFiles = true
-        caps.supports2TBFiles = true
-        // EROFS NIDs are 64-bit.
-        caps.supports64BitObjectIDs = true
-        // EROFS (Linux) is case-sensitive.
-        caps.caseFormat = .sensitive
-        return caps
+        Self.readOnlyCapabilities.fsCapabilities
     }
 
     var volumeStatistics: FSStatFSResult {

--- a/DiskJockeyLibrary/ReadOnlyVolumeSupport.swift
+++ b/DiskJockeyLibrary/ReadOnlyVolumeSupport.swift
@@ -1,0 +1,272 @@
+//
+//  ReadOnlyVolumeSupport.swift — the parts of a read-only FSKit volume
+//  that are the same for every filesystem, in the one place a test can
+//  reach them.
+//
+//  WHY THIS EXISTS
+//
+//  DiskJockey has four read-only volumes — XFS, Btrfs, EROFS and
+//  SquashFS. Normalising the filesystem's name away and diffing them
+//  pairwise gives 88% to 98% identical lines; XFS and Btrfs differ in
+//  six lines out of 370. They are one class written four times, and the
+//  copies have already drifted: the XFS volume shipped with
+//  `supportsJournal = false`, inherited from the EROFS volume it was
+//  copied from, and XFS has a journal.
+//
+//  None of that was catchable by a test. The volume classes live in the
+//  extension appex targets, and a test bundle that links the app cannot
+//  see them — `cannot find 'XfsVolume' in scope`. So every volume test
+//  in this project mirrors the volume's wiring against a mock instead of
+//  exercising the volume, and a mirror asserts only what the mirror was
+//  written to say.
+//
+//  This module is the fix: the decisions that differ between filesystems
+//  live here as data and plain functions, in a target the tests already
+//  cover. What stays in each extension is the C ABI call and the
+//  conversion into these types.
+//
+//  FSKit's own types are used directly rather than shadowed. That was
+//  worth checking rather than assuming — the existing volume tests carry
+//  a comment saying FSKit types "can't easily be constructed in a
+//  unit-test bundle", which is not true: `FSItem.Attributes()` and
+//  `FSStatFSResult(fileSystemTypeName:)` both build and run in
+//  DiskJockeyLibraryTests.
+//
+
+import FSKit
+import Foundation
+
+// MARK: - What a driver reports
+
+/// One file's metadata, as every read-only driver in this project
+/// reports it.
+///
+/// A neutral struct rather than each crate's own `fs_<fs>_attr_t`,
+/// because those are distinct C types that cannot be spelled in shared
+/// code. Each extension converts its own into this.
+public struct ReadOnlyFileAttributes: Equatable, Sendable {
+    /// The filesystem's own identifier for the file. All four drivers
+    /// use 64 bits — XFS inode numbers, Btrfs object IDs, EROFS NIDs and
+    /// SquashFS inode numbers alike — so this is `UInt64` rather than
+    /// being made generic for a variation that does not exist.
+    public var inode: UInt64
+    public var mode: UInt32
+    public var uid: UInt32
+    public var gid: UInt32
+    public var size: UInt64
+    public var linkCount: UInt32
+    /// Seconds since the epoch. The drivers report one timestamp, not
+    /// four; see `fsAttributes(from:parentInode:)` for what that means.
+    public var mtime: Int64
+    public var fileType: ReadOnlyFileType
+
+    public init(inode: UInt64, mode: UInt32, uid: UInt32, gid: UInt32,
+                size: UInt64, linkCount: UInt32, mtime: Int64,
+                fileType: ReadOnlyFileType) {
+        self.inode = inode
+        self.mode = mode
+        self.uid = uid
+        self.gid = gid
+        self.size = size
+        self.linkCount = linkCount
+        self.mtime = mtime
+        self.fileType = fileType
+    }
+}
+
+/// The file types a read-only driver distinguishes.
+public enum ReadOnlyFileType: Equatable, Sendable {
+    case file
+    case directory
+    case symlink
+    case other
+
+    /// FSKit's equivalent.
+    public var fsItemType: FSItem.ItemType {
+        switch self {
+        case .file: return .file
+        case .directory: return .directory
+        case .symlink: return .symlink
+        case .other: return .file
+        }
+    }
+}
+
+// MARK: - What a driver reports about the volume
+
+/// Capacity, as the driver measures it.
+///
+/// The two cases exist because the drivers genuinely disagree about the
+/// unit, and flattening that difference is what produces a wrong number
+/// on somebody's disk.
+public enum ReadOnlyCapacity: Equatable, Sendable {
+    /// XFS, EROFS and SquashFS: a block size and a count of blocks.
+    case blocks(blockSize: UInt64, total: UInt64, free: UInt64)
+
+    /// Btrfs: a byte figure, with the block size reported separately.
+    ///
+    /// Btrfs has no fixed block count to report — capacity and usage are
+    /// byte quantities, and its sector size is what a block would mean.
+    /// Converting here rather than in the volume keeps the division in
+    /// one testable place.
+    case bytes(sectorSize: UInt64, total: UInt64, used: UInt64)
+}
+
+/// Everything a read-only volume needs in order to answer `statfs`.
+public struct ReadOnlyVolumeInfo: Equatable, Sendable {
+    public var capacity: ReadOnlyCapacity
+    /// The unit the volume advertises for I/O. Usually the block size,
+    /// but Btrfs reports its node size, which is larger.
+    public var ioSize: UInt64
+    /// Total inodes, where the filesystem has a fixed inode table.
+    ///
+    /// `nil` where it does not. Btrfs allocates inodes from the same
+    /// pool as data, so there is no total to report and no free count
+    /// either; inventing one from the byte figures would be a number a
+    /// user could act on wrongly. `nil` becomes zero at the FSKit
+    /// boundary, which is what the field means when it is unknown.
+    public var totalInodes: UInt64?
+    public var freeInodes: UInt64?
+
+    public init(capacity: ReadOnlyCapacity, ioSize: UInt64,
+                totalInodes: UInt64? = nil, freeInodes: UInt64? = nil) {
+        self.capacity = capacity
+        self.ioSize = ioSize
+        self.totalInodes = totalInodes
+        self.freeInodes = freeInodes
+    }
+}
+
+// MARK: - Capabilities
+
+/// The capability flags that differ between these four filesystems.
+///
+/// Only the ones that actually vary are parameters. The rest are fixed
+/// below, because four copies of the same nine assignments is how the
+/// XFS volume ended up claiming it had no journal.
+public struct ReadOnlyVolumeCapabilities: Equatable, Sendable {
+    public var hasJournal: Bool
+    public var supportsSymbolicLinks: Bool
+    public var isCaseSensitive: Bool
+
+    public init(hasJournal: Bool,
+                supportsSymbolicLinks: Bool = true,
+                isCaseSensitive: Bool = true) {
+        self.hasJournal = hasJournal
+        self.supportsSymbolicLinks = supportsSymbolicLinks
+        self.isCaseSensitive = isCaseSensitive
+    }
+
+    /// The FSKit object, with the invariant parts filled in.
+    ///
+    /// `supportsActiveJournal` stays false even when there is a journal:
+    /// these drivers refuse a filesystem with a dirty log rather than
+    /// replaying one, so the journal is never active from here.
+    public var fsCapabilities: FSVolume.SupportedCapabilities {
+        let caps = FSVolume.SupportedCapabilities()
+        caps.supportsPersistentObjectIDs = true
+        caps.supportsSymbolicLinks = supportsSymbolicLinks
+        caps.supportsHardLinks = false
+        caps.supportsJournal = hasJournal
+        caps.supportsActiveJournal = false
+        caps.supportsSparseFiles = true
+        caps.supports2TBFiles = true
+        caps.supports64BitObjectIDs = true
+        caps.caseFormat = isCaseSensitive ? .sensitive : .insensitive
+        return caps
+    }
+}
+
+// MARK: - The conversions
+
+public enum ReadOnlyVolumeSupport {
+
+    /// Join a directory path and a child name.
+    ///
+    /// Written out because `"/" + "/" + name` produces `//name`, and a
+    /// path with a doubled separator is not equal to the one the cache
+    /// is keyed by even though it resolves to the same file.
+    public static func joinPath(_ parent: String, _ child: String) -> String {
+        parent == "/" ? "/\(child)" : "\(parent)/\(child)"
+    }
+
+    /// Turn a driver's attributes into FSKit's.
+    ///
+    /// The four timestamps are all set from the one the drivers report.
+    /// That is not laziness: none of these formats gives all four, and
+    /// leaving the others unset makes Finder show the epoch. One honest
+    /// value repeated is better than three wrong ones.
+    public static func fsAttributes(from attr: ReadOnlyFileAttributes,
+                                    parentInode: UInt64?) -> FSItem.Attributes {
+        let attrs = FSItem.Attributes()
+        attrs.type = attr.fileType.fsItemType
+        attrs.mode = attr.mode
+        attrs.uid = attr.uid
+        attrs.gid = attr.gid
+        attrs.flags = 0
+        attrs.size = attr.size
+        // Read-only and never sparse-aware here, so the allocated size
+        // is the size.
+        attrs.allocSize = attr.size
+        attrs.linkCount = attr.linkCount
+        let ts = timespec(tv_sec: Int(attr.mtime), tv_nsec: 0)
+        attrs.accessTime = ts
+        attrs.modifyTime = ts
+        attrs.changeTime = ts
+        attrs.birthTime = ts
+        if let id = FSItem.Identifier(rawValue: attr.inode) {
+            attrs.fileID = id
+        }
+        // Root's parent is itself, which is what inode 1 means here.
+        if let parentID = FSItem.Identifier(rawValue: parentInode ?? 1) {
+            attrs.parentID = parentID
+        }
+        return attrs
+    }
+
+    /// Turn a driver's volume info into FSKit's `statfs` answer.
+    ///
+    /// The byte-to-block division lives here rather than in a volume so
+    /// that the divide-by-zero guard exists once. A driver that has not
+    /// finished mounting reports a zero sector size, and a zero divisor
+    /// would trap.
+    public static func statFS(_ info: ReadOnlyVolumeInfo,
+                              fileSystemTypeName: String) -> FSStatFSResult {
+        let result = FSStatFSResult(fileSystemTypeName: fileSystemTypeName)
+
+        switch info.capacity {
+        case let .blocks(blockSize, total, free):
+            result.blockSize = Int(blockSize)
+            result.totalBlocks = total
+            result.freeBlocks = free
+
+        case let .bytes(sectorSize, total, used):
+            result.blockSize = Int(sectorSize)
+            guard sectorSize > 0 else {
+                result.totalBlocks = 0
+                result.freeBlocks = 0
+                break
+            }
+            let totalSectors = total / sectorSize
+            let usedSectors = used / sectorSize
+            result.totalBlocks = totalSectors
+            // Saturating: a driver reporting more used than total is
+            // corrupt, and an unsigned wrap would report an enormous
+            // amount of free space on a full disk.
+            result.freeBlocks = totalSectors >= usedSectors ? totalSectors - usedSectors : 0
+        }
+
+        // Zero for every one of these volumes, whatever is free. They are
+        // read-only, so nothing is available for a caller to allocate
+        // into — `freeBlocks` describes the image, `availableBlocks`
+        // describes what this mount will let you do with it. The Btrfs
+        // volume had this right and the others reached the same answer
+        // only because they reported no free space at all.
+        result.availableBlocks = 0
+
+        result.ioSize = Int(info.ioSize)
+        result.totalFiles = info.totalInodes ?? 0
+        result.freeFiles = info.freeInodes ?? 0
+        return result
+    }
+}

--- a/DiskJockeyLibrary/ReadOnlyVolumeSupport.swift
+++ b/DiskJockeyLibrary/ReadOnlyVolumeSupport.swift
@@ -110,6 +110,15 @@ public enum ReadOnlyCapacity: Equatable, Sendable {
     /// Converting here rather than in the volume keeps the division in
     /// one testable place.
     case bytes(sectorSize: UInt64, total: UInt64, used: UInt64)
+
+    /// SquashFS: a compressed image, where used IS total.
+    ///
+    /// The image is exactly as large as its contents and cannot grow, so
+    /// there is no capacity figure distinct from usage and no free space
+    /// to report. Modelled as its own case rather than passed as
+    /// `.bytes(total: used, used: used)` because that spelling reads as
+    /// a coincidence rather than as the format's nature.
+    case compressedImage(blockSize: UInt64, usedBytes: UInt64)
 }
 
 /// Everything a read-only volume needs in order to answer `statfs`.
@@ -148,13 +157,19 @@ public struct ReadOnlyVolumeCapabilities: Equatable, Sendable {
     public var hasJournal: Bool
     public var supportsSymbolicLinks: Bool
     public var isCaseSensitive: Bool
+    /// SquashFS says false here and the others say true. Kept as a
+    /// parameter rather than normalised, because the flag describes what
+    /// the format's identifiers are, not a preference.
+    public var supports64BitObjectIDs: Bool
 
     public init(hasJournal: Bool,
                 supportsSymbolicLinks: Bool = true,
-                isCaseSensitive: Bool = true) {
+                isCaseSensitive: Bool = true,
+                supports64BitObjectIDs: Bool = true) {
         self.hasJournal = hasJournal
         self.supportsSymbolicLinks = supportsSymbolicLinks
         self.isCaseSensitive = isCaseSensitive
+        self.supports64BitObjectIDs = supports64BitObjectIDs
     }
 
     /// The FSKit object, with the invariant parts filled in.
@@ -171,7 +186,7 @@ public struct ReadOnlyVolumeCapabilities: Equatable, Sendable {
         caps.supportsActiveJournal = false
         caps.supportsSparseFiles = true
         caps.supports2TBFiles = true
-        caps.supports64BitObjectIDs = true
+        caps.supports64BitObjectIDs = supports64BitObjectIDs
         caps.caseFormat = isCaseSensitive ? .sensitive : .insensitive
         return caps
     }
@@ -254,6 +269,18 @@ public enum ReadOnlyVolumeSupport {
             // corrupt, and an unsigned wrap would report an enormous
             // amount of free space on a full disk.
             result.freeBlocks = totalSectors >= usedSectors ? totalSectors - usedSectors : 0
+
+        case let .compressedImage(blockSize, usedBytes):
+            result.blockSize = Int(blockSize)
+            guard blockSize > 0 else {
+                result.totalBlocks = 0
+                result.freeBlocks = 0
+                break
+            }
+            // Used is total: the image is exactly as large as it needs
+            // to be and cannot grow.
+            result.totalBlocks = usedBytes / blockSize
+            result.freeBlocks = 0
         }
 
         // Zero for every one of these volumes, whatever is free. They are

--- a/DiskJockeyLibraryTests/ReadOnlyVolumeSupportTests.swift
+++ b/DiskJockeyLibraryTests/ReadOnlyVolumeSupportTests.swift
@@ -1,0 +1,230 @@
+//
+//  ReadOnlyVolumeSupportTests.swift — the first tests in this project
+//  that exercise read-only volume logic rather than a mirror of it.
+//
+//  Every existing volume test builds a mock that imitates the volume's
+//  wiring, because the volume classes live in extension targets a test
+//  bundle cannot see. A mirror asserts only what the mirror was written
+//  to say, which is why the XFS volume could ship claiming it had no
+//  journal and no test noticed.
+//
+//  These run against the real code the volumes will call.
+//
+
+import Testing
+import FSKit
+@testable import DiskJockeyLibrary
+
+// MARK: - Capacity, where the filesystems genuinely disagree
+
+@Suite("statfs")
+struct ReadOnlyStatFSTests {
+
+    /// The block-counting filesystems pass their figures through.
+    @Test func blockCapacityIsReportedAsGiven() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .blocks(blockSize: 4096, total: 1000, free: 250),
+            ioSize: 4096,
+            totalInodes: 64,
+            freeInodes: 60)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "xfs")
+
+        #expect(r.blockSize == 4096)
+        #expect(r.totalBlocks == 1000)
+        #expect(r.freeBlocks == 250)
+        #expect(r.availableBlocks == 0,
+                "read-only: free describes the image, available describes this mount")
+        #expect(r.totalFiles == 64)
+        #expect(r.freeFiles == 60)
+    }
+
+    /// Btrfs reports bytes, and the division has to happen somewhere.
+    ///
+    /// 8 GiB total, 2 GiB used, 4 KiB sectors — so 2,097,152 sectors of
+    /// which 524,288 are used, leaving 1,572,864 free.
+    @Test func byteCapacityIsDividedIntoSectors() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: 4096,
+                             total: 8 * 1024 * 1024 * 1024,
+                             used: 2 * 1024 * 1024 * 1024),
+            ioSize: 16384)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "btrfs")
+
+        #expect(r.blockSize == 4096)
+        #expect(r.totalBlocks == 2_097_152)
+        #expect(r.freeBlocks == 1_572_864)
+        #expect(r.availableBlocks == 0)
+    }
+
+    /// Btrfs advertises its node size for I/O, which is not its sector
+    /// size. Reporting the block size for both would understate the
+    /// useful read unit fourfold.
+    @Test func ioSizeIsIndependentOfBlockSize() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: 4096, total: 4096 * 10, used: 0),
+            ioSize: 16384)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "btrfs")
+
+        #expect(r.blockSize == 4096)
+        #expect(r.ioSize == 16384)
+    }
+
+    /// A driver that has not finished mounting reports a zero sector
+    /// size. Dividing by it would trap.
+    @Test func aZeroSectorSizeDoesNotDivide() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: 0, total: 999, used: 1),
+            ioSize: 0)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "btrfs")
+
+        #expect(r.totalBlocks == 0)
+        #expect(r.freeBlocks == 0)
+        #expect(r.availableBlocks == 0)
+    }
+
+    /// More used than total is a corrupt image. The subtraction must
+    /// saturate: an unsigned wrap would report roughly sixteen exabytes
+    /// free on a full disk, which is worse than reporting none.
+    @Test func moreUsedThanTotalReportsNoFreeSpaceRatherThanWrapping() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: 4096, total: 4096, used: 8192),
+            ioSize: 4096)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "btrfs")
+
+        #expect(r.totalBlocks == 1)
+        #expect(r.freeBlocks == 0)
+        #expect(r.availableBlocks == 0)
+    }
+
+    /// A filesystem with no fixed inode table has no count to give.
+    /// Zero is the honest answer; a figure derived from the byte
+    /// totals would be one a user could act on wrongly.
+    @Test func absentInodeCountsBecomeZero() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .bytes(sectorSize: 4096, total: 4096, used: 0),
+            ioSize: 4096,
+            totalInodes: nil,
+            freeInodes: nil)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "btrfs")
+
+        #expect(r.totalFiles == 0)
+        #expect(r.freeFiles == 0)
+    }
+}
+
+// MARK: - Capabilities, the flag that was actually wrong in production
+
+@Suite("capabilities")
+struct ReadOnlyCapabilityTests {
+
+    /// The regression this whole module exists for. The XFS volume
+    /// shipped with `supportsJournal = false`, inherited from the EROFS
+    /// volume it was copied from. Journalling is now a parameter, so
+    /// the answer cannot be inherited by accident.
+    @Test func journallingIsCarriedThroughInBothDirections() {
+        let journalled = ReadOnlyVolumeCapabilities(hasJournal: true)
+        #expect(journalled.fsCapabilities.supportsJournal == true)
+
+        let notJournalled = ReadOnlyVolumeCapabilities(hasJournal: false)
+        #expect(notJournalled.fsCapabilities.supportsJournal == false)
+    }
+
+    /// A journal these drivers never replay is never active. This holds
+    /// even for the journalled filesystems, so it is not a parameter.
+    @Test func theJournalIsNeverActive() {
+        for hasJournal in [true, false] {
+            let caps = ReadOnlyVolumeCapabilities(hasJournal: hasJournal)
+            #expect(caps.fsCapabilities.supportsActiveJournal == false,
+                    "a driver that refuses a dirty log never has an active journal")
+        }
+    }
+
+    /// The invariants, asserted so that a future edit to the shared
+    /// block has to be deliberate rather than silent.
+    @Test func theFixedCapabilitiesAreFixed() {
+        let caps = ReadOnlyVolumeCapabilities(hasJournal: true).fsCapabilities
+        #expect(caps.supportsPersistentObjectIDs == true)
+        #expect(caps.supportsHardLinks == false)
+        #expect(caps.supports64BitObjectIDs == true,
+                "all four drivers use 64-bit identifiers")
+    }
+
+    @Test func caseSensitivityAndSymlinksAreParameters() {
+        let sensitive = ReadOnlyVolumeCapabilities(
+            hasJournal: false, supportsSymbolicLinks: false, isCaseSensitive: true)
+        #expect(sensitive.fsCapabilities.caseFormat == .sensitive)
+        #expect(sensitive.fsCapabilities.supportsSymbolicLinks == false)
+
+        let insensitive = ReadOnlyVolumeCapabilities(
+            hasJournal: false, supportsSymbolicLinks: true, isCaseSensitive: false)
+        #expect(insensitive.fsCapabilities.caseFormat == .insensitive)
+        #expect(insensitive.fsCapabilities.supportsSymbolicLinks == true)
+    }
+}
+
+// MARK: - Paths and attributes
+
+@Suite("paths and attributes")
+struct ReadOnlyAttributeTests {
+
+    /// Joining onto root must not double the separator. `//name` names
+    /// the same file but is a different cache key.
+    @Test func joiningOntoRootDoesNotDoubleTheSeparator() {
+        #expect(ReadOnlyVolumeSupport.joinPath("/", "etc") == "/etc")
+        #expect(ReadOnlyVolumeSupport.joinPath("/etc", "hosts") == "/etc/hosts")
+        #expect(ReadOnlyVolumeSupport.joinPath("/a/b", "c") == "/a/b/c")
+    }
+
+    private func sample(_ type: ReadOnlyFileType = .file,
+                        inode: UInt64 = 42,
+                        size: UInt64 = 1234) -> ReadOnlyFileAttributes {
+        ReadOnlyFileAttributes(inode: inode, mode: 0o644, uid: 501, gid: 20,
+                               size: size, linkCount: 1, mtime: 1_700_000_000,
+                               fileType: type)
+    }
+
+    @Test func attributesCarryThrough() {
+        let a = ReadOnlyVolumeSupport.fsAttributes(from: sample(), parentInode: 7)
+        #expect(a.mode == 0o644)
+        #expect(a.uid == 501)
+        #expect(a.gid == 20)
+        #expect(a.size == 1234)
+        #expect(a.linkCount == 1)
+        #expect(a.fileID.rawValue == 42)
+        #expect(a.parentID.rawValue == 7)
+    }
+
+    /// Read-only and not sparse-aware, so allocated size is the size.
+    /// Reporting zero here makes `du` disagree with `ls` on every file.
+    @Test func allocatedSizeMatchesSize() {
+        let a = ReadOnlyVolumeSupport.fsAttributes(from: sample(size: 9999),
+                                                   parentInode: nil)
+        #expect(a.allocSize == 9999)
+    }
+
+    /// The drivers report one timestamp. All four are set from it
+    /// deliberately — leaving the others unset shows the epoch in
+    /// Finder, and one honest value repeated beats three wrong ones.
+    @Test func allFourTimestampsComeFromTheOneTheDriverGives() {
+        let a = ReadOnlyVolumeSupport.fsAttributes(from: sample(), parentInode: nil)
+        #expect(a.accessTime.tv_sec == 1_700_000_000)
+        #expect(a.modifyTime.tv_sec == 1_700_000_000)
+        #expect(a.changeTime.tv_sec == 1_700_000_000)
+        #expect(a.birthTime.tv_sec == 1_700_000_000)
+    }
+
+    /// Root has no parent, and reports itself.
+    @Test func anAbsentParentBecomesRoot() {
+        let a = ReadOnlyVolumeSupport.fsAttributes(from: sample(), parentInode: nil)
+        #expect(a.parentID.rawValue == 1)
+    }
+
+    @Test func fileTypesMapToFSKit() {
+        #expect(ReadOnlyFileType.file.fsItemType == .file)
+        #expect(ReadOnlyFileType.directory.fsItemType == .directory)
+        #expect(ReadOnlyFileType.symlink.fsItemType == .symlink)
+        // Sockets, fifos and devices cannot appear in an image these
+        // drivers mount read-only, and FSKit has no case for them.
+        #expect(ReadOnlyFileType.other.fsItemType == .file)
+    }
+}

--- a/DiskJockeyLibraryTests/ReadOnlyVolumeSupportTests.swift
+++ b/DiskJockeyLibraryTests/ReadOnlyVolumeSupportTests.swift
@@ -96,6 +96,32 @@ struct ReadOnlyStatFSTests {
         #expect(r.availableBlocks == 0)
     }
 
+    /// A compressed image is exactly as large as its contents, so used
+    /// is total and nothing is free. 40 KiB used with 4 KiB blocks is
+    /// ten blocks, all of them occupied.
+    @Test func aCompressedImageReportsUsedAsTotalAndNothingFree() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .compressedImage(blockSize: 4096, usedBytes: 40960),
+            ioSize: 4096,
+            totalInodes: 12)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "squashfs")
+
+        #expect(r.blockSize == 4096)
+        #expect(r.totalBlocks == 10)
+        #expect(r.freeBlocks == 0)
+        #expect(r.availableBlocks == 0)
+        #expect(r.totalFiles == 12)
+    }
+
+    @Test func aCompressedImageWithNoBlockSizeDoesNotDivide() {
+        let info = ReadOnlyVolumeInfo(
+            capacity: .compressedImage(blockSize: 0, usedBytes: 999),
+            ioSize: 0)
+        let r = ReadOnlyVolumeSupport.statFS(info, fileSystemTypeName: "squashfs")
+        #expect(r.totalBlocks == 0)
+        #expect(r.freeBlocks == 0)
+    }
+
     /// A filesystem with no fixed inode table has no count to give.
     /// Zero is the honest answer; a figure derived from the byte
     /// totals would be one a user could act on wrongly.
@@ -145,8 +171,17 @@ struct ReadOnlyCapabilityTests {
         let caps = ReadOnlyVolumeCapabilities(hasJournal: true).fsCapabilities
         #expect(caps.supportsPersistentObjectIDs == true)
         #expect(caps.supportsHardLinks == false)
-        #expect(caps.supports64BitObjectIDs == true,
-                "all four drivers use 64-bit identifiers")
+        #expect(caps.supports64BitObjectIDs == true)
+    }
+
+    /// SquashFS advertises 32-bit identifiers where the others
+    /// advertise 64-bit. It is a statement about the format, so it is a
+    /// parameter rather than a value normalised to the majority.
+    @Test func objectIDWidthIsAParameter() {
+        #expect(ReadOnlyVolumeCapabilities(hasJournal: false)
+            .fsCapabilities.supports64BitObjectIDs == true)
+        #expect(ReadOnlyVolumeCapabilities(hasJournal: false, supports64BitObjectIDs: false)
+            .fsCapabilities.supports64BitObjectIDs == false)
     }
 
     @Test func caseSensitivityAndSymlinksAreParameters() {

--- a/DiskJockeyNTFS/NTFSFileSystem.swift
+++ b/DiskJockeyNTFS/NTFSFileSystem.swift
@@ -394,7 +394,6 @@ final class NTFSFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             volumeID: volID,
             volumeName: FSFileName(string: resolvedName),
             bridgeFS: bridgeFS,
-            blockDevice: blockDevice,
             contextPtr: contextPtr,
             cfgSizeBytes: cfgSizeBytes,
             bsdName: bsdName,

--- a/DiskJockeyNTFS/NTFSVolume.swift
+++ b/DiskJockeyNTFS/NTFSVolume.swift
@@ -26,7 +26,6 @@ final class NTFSVolume: FSVolume,
     private var bridgeFS: OpaquePointer?
 
     /// The block device resource
-    private let blockDevice: FSBlockDeviceResource
 
     /// Retained block-device callback context (`BlockDeviceContext`).
     /// Held as an opaque pointer so the C callbacks in `cfg` can deref it
@@ -80,7 +79,6 @@ final class NTFSVolume: FSVolume,
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
          bridgeFS: OpaquePointer,
-         blockDevice: FSBlockDeviceResource,
          contextPtr: UnsafeMutableRawPointer,
          cfgSizeBytes: UInt64,
          bsdName: String,
@@ -90,7 +88,6 @@ final class NTFSVolume: FSVolume,
          partitionLength: UInt64? = nil,
          stats: IOStatsCollector) {
         self.bridgeFS = bridgeFS
-        self.blockDevice = blockDevice
         self.contextPtr = contextPtr
         self.cfgSizeBytes = cfgSizeBytes
         self.bsdName = bsdName

--- a/DiskJockeySQUASHFS/SquashfsFileSystem.swift
+++ b/DiskJockeySQUASHFS/SquashfsFileSystem.swift
@@ -192,7 +192,6 @@ final class SquashfsFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             volumeID: volID,
             volumeName: FSFileName(string: resolvedName),
             bridgeFS: bridgeFS,
-            blockDevice: blockDevice,
             contextPtr: contextPtr,
             bsdName: bsdName,
             stats: stats

--- a/DiskJockeySQUASHFS/SquashfsVolume.swift
+++ b/DiskJockeySQUASHFS/SquashfsVolume.swift
@@ -56,37 +56,34 @@ final class SquashfsVolume: FSVolume,
 
     // MARK: - Capabilities
 
+    /// The name `statfs` reports, and the one place it is spelled.
+    static let fsTypeName = "squashfs"
+
+    /// SquashFS is an immutable image: no journal, and it advertises
+    /// 32-bit object identifiers where the sibling drivers advertise
+    /// 64-bit.
+    static let readOnlyCapabilities = ReadOnlyVolumeCapabilities(
+        hasJournal: false, supports64BitObjectIDs: false)
+
     var supportedVolumeCapabilities: FSVolume.SupportedCapabilities {
-        let caps = FSVolume.SupportedCapabilities()
-        caps.supportsPersistentObjectIDs = true
-        caps.supportsSymbolicLinks = true
-        caps.supportsHardLinks = false
-        caps.supportsJournal = false
-        caps.supportsActiveJournal = false
-        caps.supportsSparseFiles = true
-        caps.supports2TBFiles = true
-        // SquashFS inode numbers are 32-bit.
-        caps.supports64BitObjectIDs = false
-        // SquashFS (Linux) is case-sensitive.
-        caps.caseFormat = .sensitive
-        return caps
+        Self.readOnlyCapabilities.fsCapabilities
     }
 
     var volumeStatistics: FSStatFSResult {
-        let result = FSStatFSResult(fileSystemTypeName: "squashfs")
-        guard let fs = bridgeFS else { return result }
+        guard let fs = bridgeFS else {
+            return FSStatFSResult(fileSystemTypeName: Self.fsTypeName)
+        }
         var info = fs_squashfs_volume_info_t()
         fs_squashfs_get_volume_info(fs, &info)
-        let bs = Int(info.block_size)
-        result.blockSize = bs
-        result.ioSize = bs
-        // Read-only + compressed: report used blocks as total, nothing free.
-        result.totalBlocks = bs > 0 ? info.bytes_used / UInt64(bs) : 0
-        result.availableBlocks = 0
-        result.freeBlocks = 0
-        result.totalFiles = UInt64(info.inode_count)
-        result.freeFiles = 0
-        return result
+        // A SquashFS image is exactly as large as its contents and
+        // cannot grow, so used is total and nothing is free.
+        let shared = ReadOnlyVolumeInfo(
+            capacity: .compressedImage(blockSize: UInt64(info.block_size),
+                                       usedBytes: info.bytes_used),
+            ioSize: UInt64(info.block_size),
+            totalInodes: UInt64(info.inode_count),
+            freeInodes: nil)
+        return ReadOnlyVolumeSupport.statFS(shared, fileSystemTypeName: Self.fsTypeName)
     }
 
     // MARK: - Lifecycle

--- a/DiskJockeySQUASHFS/SquashfsVolume.swift
+++ b/DiskJockeySQUASHFS/SquashfsVolume.swift
@@ -22,7 +22,6 @@ final class SquashfsVolume: FSVolume,
 
     /// Opaque pointer to the Rust bridge filesystem context.
     private var bridgeFS: OpaquePointer?
-    private let blockDevice: FSBlockDeviceResource
     /// Retained `BlockDeviceContext`; released in `deactivate()` after umount.
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
@@ -32,12 +31,10 @@ final class SquashfsVolume: FSVolume,
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
          bridgeFS: OpaquePointer,
-         blockDevice: FSBlockDeviceResource,
          contextPtr: UnsafeMutableRawPointer,
          bsdName: String,
          stats: IOStatsCollector) {
         self.bridgeFS = bridgeFS
-        self.blockDevice = blockDevice
         self.contextPtr = contextPtr
         self.bsdName = bsdName
         self.stats = stats

--- a/DiskJockeyXFS/XfsFileSystem.swift
+++ b/DiskJockeyXFS/XfsFileSystem.swift
@@ -188,7 +188,6 @@ final class XfsFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             volumeID: volID,
             volumeName: FSFileName(string: resolvedName),
             bridgeFS: bridgeFS,
-            blockDevice: blockDevice,
             contextPtr: contextPtr,
             bsdName: bsdName,
             stats: stats

--- a/DiskJockeyXFS/XfsVolume.swift
+++ b/DiskJockeyXFS/XfsVolume.swift
@@ -53,43 +53,36 @@ final class XfsVolume: FSVolume,
 
     // MARK: - Capabilities
 
+    /// The name `statfs` reports, and the one place it is spelled.
+    static let fsTypeName = "xfs"
+
+    /// XFS is journalled. This was `false` once, inherited from the
+    /// EROFS volume this file was copied from — which is why it is a
+    /// parameter now rather than nine assignments repeated per
+    /// filesystem. See ReadOnlyVolumeCapabilities.
+    static let readOnlyCapabilities = ReadOnlyVolumeCapabilities(hasJournal: true)
+
     var supportedVolumeCapabilities: FSVolume.SupportedCapabilities {
-        let caps = FSVolume.SupportedCapabilities()
-        caps.supportsPersistentObjectIDs = true
-        caps.supportsSymbolicLinks = true
-        caps.supportsHardLinks = false
-        // XFS is a journalling filesystem — this said `false`,
-        // inherited from the EROFS volume this file was copied from,
-        // and EROFS genuinely has no journal.
-        //
-        // `supportsJournal` describes the FORMAT; `supportsActiveJournal`
-        // describes this mount. The driver refuses a dirty log rather
-        // than replaying one, so the log is never active from here.
-        caps.supportsJournal = true
-        caps.supportsActiveJournal = false
-        caps.supportsSparseFiles = true
-        caps.supports2TBFiles = true
-        // XFS inode numbers are 64-bit.
-        caps.supports64BitObjectIDs = true
-        // XFS (Linux) is case-sensitive.
-        caps.caseFormat = .sensitive
-        return caps
+        Self.readOnlyCapabilities.fsCapabilities
     }
 
     var volumeStatistics: FSStatFSResult {
-        let result = FSStatFSResult(fileSystemTypeName: "xfs")
-        guard let fs = bridgeFS else { return result }
+        guard let fs = bridgeFS else {
+            return FSStatFSResult(fileSystemTypeName: Self.fsTypeName)
+        }
         var info = fs_xfs_volume_info_t()
         fs_xfs_get_volume_info(fs, &info)
-        let bs = Int(info.block_size)
-        result.blockSize = bs
-        result.ioSize = bs
-        result.totalBlocks = UInt64(info.total_blocks)
-        result.availableBlocks = 0
-        result.freeBlocks = 0
-        result.totalFiles = info.inode_count
-        result.freeFiles = 0
-        return result
+        // XFS counts blocks, so the figures pass straight through. The
+        // free counts are not reported by the driver; zero is what the
+        // field means when it is unknown.
+        let shared = ReadOnlyVolumeInfo(
+            capacity: .blocks(blockSize: UInt64(info.block_size),
+                              total: UInt64(info.total_blocks),
+                              free: 0),
+            ioSize: UInt64(info.block_size),
+            totalInodes: info.inode_count,
+            freeInodes: nil)
+        return ReadOnlyVolumeSupport.statFS(shared, fileSystemTypeName: Self.fsTypeName)
     }
 
     // MARK: - Lifecycle
@@ -325,42 +318,37 @@ final class XfsVolume: FSVolume,
 
     // MARK: - Helpers
 
-    static func fsItemType(fromRaw raw: UInt32) -> FSItem.ItemType {
+    /// XFS's on-disk file-type codes. Kept here because the numbers
+    /// are XFS's; the mapping onto FSKit is shared.
+    static func readOnlyFileType(fromRaw raw: UInt32) -> ReadOnlyFileType {
         switch raw {
         case 1: return .file        // FS_XFS_FT_REG_FILE
         case 2: return .directory   // FS_XFS_FT_DIR
         case 7: return .symlink     // FS_XFS_FT_SYMLINK
-        default: return .file
+        default: return .other
         }
     }
 
+    static func fsItemType(fromRaw raw: UInt32) -> FSItem.ItemType {
+        readOnlyFileType(fromRaw: raw).fsItemType
+    }
+
     static func joinPath(_ parent: String, _ child: String) -> String {
-        parent == "/" ? "/\(child)" : "\(parent)/\(child)"
+        ReadOnlyVolumeSupport.joinPath(parent, child)
     }
 
     static func attributes(from attr: fs_xfs_attr_t,
                            parentInode: UInt64?) -> FSItem.Attributes {
-        let attrs = FSItem.Attributes()
-        attrs.type = fsItemType(fromRaw: attr.file_type)
-        attrs.mode = UInt32(attr.mode)
-        attrs.uid = attr.uid
-        attrs.gid = attr.gid
-        attrs.flags = 0
-        attrs.size = attr.size
-        attrs.allocSize = attr.size
-        attrs.linkCount = attr.link_count
-        let ts = timespec(tv_sec: Int(attr.mtime), tv_nsec: 0)
-        attrs.accessTime = ts
-        attrs.modifyTime = ts
-        attrs.changeTime = ts
-        attrs.birthTime = ts
-        if let id = FSItem.Identifier(rawValue: attr.inode) {
-            attrs.fileID = id
-        }
-        let parentRaw = parentInode ?? 1
-        if let parentID = FSItem.Identifier(rawValue: parentRaw) {
-            attrs.parentID = parentID
-        }
-        return attrs
+        ReadOnlyVolumeSupport.fsAttributes(
+            from: ReadOnlyFileAttributes(
+                inode: attr.inode,
+                mode: UInt32(attr.mode),
+                uid: attr.uid,
+                gid: attr.gid,
+                size: attr.size,
+                linkCount: attr.link_count,
+                mtime: Int64(attr.mtime),
+                fileType: readOnlyFileType(fromRaw: attr.file_type)),
+            parentInode: parentInode)
     }
 }

--- a/DiskJockeyXFS/XfsVolume.swift
+++ b/DiskJockeyXFS/XfsVolume.swift
@@ -22,7 +22,6 @@ final class XfsVolume: FSVolume,
                          FSVolume.PathConfOperations {
 
     private var bridgeFS: OpaquePointer?
-    private let blockDevice: FSBlockDeviceResource
     private var contextPtr: UnsafeMutableRawPointer?
     private let bsdName: String
     private let stats: IOStatsCollector
@@ -31,12 +30,10 @@ final class XfsVolume: FSVolume,
     init(volumeID: FSVolume.Identifier,
          volumeName: FSFileName,
          bridgeFS: OpaquePointer,
-         blockDevice: FSBlockDeviceResource,
          contextPtr: UnsafeMutableRawPointer,
          bsdName: String,
          stats: IOStatsCollector) {
         self.bridgeFS = bridgeFS
-        self.blockDevice = blockDevice
         self.contextPtr = contextPtr
         self.bsdName = bsdName
         self.stats = stats


### PR DESCRIPTION
Five volumes — XFS, Btrfs, EROFS, SquashFS and NTFS — each declared `private let blockDevice: FSBlockDeviceResource`, took it as an init parameter, assigned it, and **never read it again**.

## Proved dead, not assumed

| | |
|---|---|
| **visibility** | `private` in all five, so no reference can exist outside the file. The only occurrences in the tree are the assignments themselves. |
| **lifetime** | **Not an ARC anchor.** `BlockDeviceContext` holds the resource strongly (`DeviceContexts.swift:99`), and the FileSystem hands that context to `Unmanaged.passRetained`, releasing it explicitly at teardown. The device outlives the volume through the *context*, never through this property. |
| **compiler** | Removed — the app and all five extension targets build, and `XfsVolume.o`, `BtrfsVolume.o`, `ErofsVolume.o`, `SquashfsVolume.o`, `NTFSVolume.o` all recompiled. |

The lifetime check was the one worth doing. Deleting a property that silently keeps a resource alive would be a use-after-free, not a cleanup.

## Correction: this does not, by itself, make the volumes testable

An earlier version of this description claimed it did. Measured afterwards, and it is wrong. A probe test referencing `XfsVolume` from `DiskJockeyTests` fails to compile:

```
error: cannot find 'XfsVolume' in scope
```

The blocker is **target membership**, not this parameter: the volume classes belong to the extension appex targets, and the test bundle links the app. Removing `FSBlockDeviceResource` from the initialiser removes one of two obstacles, and the remaining one is the larger.

The real route to coverage is to put the shared read-only volume in `DiskJockeyLibrary` — where `FileSystemItem`, `FileIDCache` and `MountableFileSystem` already live and `DiskJockeyLibraryTests` can reach them — parameterised by a per-filesystem driver. That makes the collapse and the testability fix the same piece of work rather than sequential ones.

This PR stands on its own merit regardless: it deletes dead state from five files and simplifies five initialisers.

## Not touched

`EXT4Volume` has no such property. Its `blockDeviceContext` is a different thing — an `UnsafeMutableRawPointer` it genuinely uses and releases.

## Checks

`BUILD SUCCEEDED`, 51 tests pass unchanged.