### PR TITLE
Pin go-networkfs to a tag now one exists

### DIFF
--- a/SIBLING_PINS.txt
+++ b/SIBLING_PINS.txt
@@ -10,10 +10,9 @@
 # cannot reach the app's binary. A dirty main stops the build rather than
 # guessing what it meant.
 #
-# TAGS ARE THE INTENT, and main is a stopgap. No tag in the family yet contains
-# its crate's chores.yml — it landed after the last release everywhere — and the
-# build contract lives in that file. Once the crates are tagged, these become
-# tags and stay that way.
+# TAGS, not branches. The build contract lives in each project's chores.yml,
+# so a pin can only name a tag that contains one — which is why this said
+# `main` until 2026-08-29, when the whole family was released.
 #
 # The chore version CI installs. The build contract is expressed in each
 # project's chores.yml, so the tool that reads it is a pinned input like
@@ -22,4 +21,4 @@ chore               0.8.0
 
 # project           ref
 # -------           ---
-go-networkfs        main
+go-networkfs        v0.1.4


### PR DESCRIPTION
`SIBLING_PINS.txt` said `main` because **no tag in the family contained its project's `chores.yml`** — the build contract lives in that file, so there was nothing valid to point at.

The whole family has been released since (13 crates on crates.io), and **go-networkfs `v0.1.4`** is the first tag carrying its contract.

## Verified on the path that matters

With the sibling checkout deliberately moved off `main`, so the build cannot use it directly:

```
go-networkfs ready at v0.1.4
  ref=v0.1.4
  ref_type=tag
  built_from=worktree
```

The worktree is created, the archives build, and both the directory and its registration are gone afterwards. What goes into the app no longer depends on which branch anyone left lying around.

App builds, 51 tests pass.