### PR TITLE
Stop waiting on a child before draining its pipes, and drop a cast that only trapped

### DIFF
--- a/DiskJockeyAgent/AgentImpl.swift
+++ b/DiskJockeyAgent/AgentImpl.swift
@@ -77,15 +77,16 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
         proc.arguments = ["attach", "-nomount", "-plist", path]
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = Pipe()
-        do { try proc.run() } catch { return .failure(error.localizedDescription) }
-        proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else {
-            return .failure("hdiutil attach exited with status \(proc.terminationStatus)")
+        // Waiting before reading deadlocks once the child fills the
+        // ~64 KiB a pipe holds, and stderr was a `Pipe()` nothing read,
+        // which blocks the child just as surely. Both are drained
+        // concurrently, and the wait comes after.
+        let result: ProcessRunner.Output
+        do { result = try ProcessRunner.run(proc) } catch { return .failure(error.localizedDescription) }
+        guard result.status == 0 else {
+            return .failure("hdiutil attach exited with status \(result.status)")
         }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let data = result.stdout
         var fmt = PropertyListSerialization.PropertyListFormat.xml
         guard let plist = try? PropertyListSerialization.propertyList(
             from: data, options: [], format: &fmt) as? [String: Any],
@@ -101,14 +102,14 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
         proc.arguments = ["info", "-plist"]
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = Pipe()
-        guard (try? proc.run()) != nil else { return nil }
-        proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else { return nil }
+        // `hdiutil info -plist` lists EVERY attached image on the
+        // machine. That passes the ~64 KiB a pipe holds on any
+        // developer's laptop, and waiting for the child before reading
+        // it is the deadlock: the child cannot exit until its output is
+        // read, and this side would not read until it exited.
+        guard let result = try? ProcessRunner.run(proc), result.status == 0 else { return nil }
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let data = result.stdout
         var fmt = PropertyListSerialization.PropertyListFormat.xml
         guard let plist = try? PropertyListSerialization.propertyList(
             from: data, options: [], format: &fmt) as? [String: Any],
@@ -135,10 +136,10 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
         proc.arguments = ["detach", "-force", bsdName]
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
-        try? proc.run()
-        proc.waitUntilExit()
+        // The output is not wanted, which is not the same as attaching
+        // pipes and ignoring them: an unread pipe fills and blocks the
+        // child. /dev/null has no buffer to fill.
+        _ = try? ProcessRunner.runDiscardingOutput(proc)
     }
 
     /// A BSD disk name, and nothing else.
@@ -164,19 +165,20 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
         proc.arguments = ["detach", bsdName]
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
+        // Only the exit status is wanted. Sending both streams to
+        // /dev/null is what makes that safe — an unread `Pipe()` fills
+        // and blocks the child before it can exit.
+        let status: Int32
         do {
-            try proc.run()
-            proc.waitUntilExit()
+            status = try ProcessRunner.runDiscardingOutput(proc)
         } catch {
             reply(false, error.localizedDescription)
             return
         }
-        if proc.terminationStatus == 0 {
+        if status == 0 {
             reply(true, nil)
         } else {
-            reply(false, "hdiutil detach exited with status \(proc.terminationStatus)")
+            reply(false, "hdiutil detach exited with status \(status)")
         }
     }
 
@@ -217,25 +219,21 @@ final class AgentImpl: NSObject, DJAgentProtocol {
         let proc = Process()
         proc.executableURL = diskprobeURL
         proc.arguments = [path]
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        proc.standardOutput = outPipe
-        proc.standardError = errPipe
+        // diskprobe emits a JSON description of a whole disk, which is
+        // past the ~64 KiB a pipe holds for anything with many
+        // partitions. Waiting before reading is the deadlock.
+        let result: ProcessRunner.Output
         do {
-            try proc.run()
-            proc.waitUntilExit()
+            result = try ProcessRunner.run(proc)
         } catch {
             reply(nil, error.localizedDescription)
             return
         }
-        guard proc.terminationStatus == 0 else {
-            let errMsg = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(),
-                               encoding: .utf8) ?? ""
-            reply(nil, "diskprobe exited \(proc.terminationStatus): \(errMsg)")
+        guard result.status == 0 else {
+            reply(nil, "diskprobe exited \(result.status): \(result.stderrText)")
             return
         }
-        let json = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-        reply(json, nil)
+        reply(result.stdoutText, nil)
     }
 
     private static func locateDiskprobe() -> URL? {

--- a/DiskJockeyAgent/ProcessRunner.swift
+++ b/DiskJockeyAgent/ProcessRunner.swift
@@ -32,7 +32,8 @@ import Foundation
 /// Reading first fixes one pipe. Reading two pipes one after the other
 /// does not: if the child fills the second while this side is blocked on
 /// the first, the standoff happens one stream over. So both are drained
-/// concurrently and the wait comes last.
+/// concurrently — stderr on a private queue, stdout on the calling
+/// thread — and the wait comes last.
 ///
 /// A stream nobody wants still needs a destination that cannot fill,
 /// which is what `runDiscardingOutput` uses `/dev/null` for. An unread
@@ -62,16 +63,17 @@ enum ProcessRunner {
 
         try proc.run()
 
-        var outData = Data()
+        // Only stderr goes to another thread; stdout is read on the
+        // caller's, which is already committed to waiting. Two
+        // background readers cost one more blocked thread per
+        // concurrent call for no extra safety.
         var errData = Data()
         let group = DispatchGroup()
-        let queue = DispatchQueue(label: "diskjockey.agent.process-runner", attributes: .concurrent)
-        queue.async(group: group) {
-            outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-        }
+        let queue = DispatchQueue(label: "diskjockey.agent.process-runner")
         queue.async(group: group) {
             errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         }
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         group.wait()
 
         // Safe now: both pipes are at EOF, so nothing the child does can

--- a/DiskJockeyAgent/ProcessRunner.swift
+++ b/DiskJockeyAgent/ProcessRunner.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Run a child process and collect what it wrote, without deadlocking.
+///
+/// # Why this is a second copy
+///
+/// `DiskJockeyLibrary` has the same helper, and the app targets use it.
+/// This agent cannot: it is not a target in the Xcode project, it is a
+/// standalone executable compiled on its own, and it links no framework
+/// of ours. A shared file would have to be shared across a boundary
+/// that does not exist.
+///
+/// The two must stay in step. Both carry the reasoning below so a change
+/// to one is visibly a change to a decision, not to a detail.
+///
+/// # The deadlock
+///
+/// A pipe holds roughly 64 KiB. Once it is full the child's next `write`
+/// blocks until somebody drains it — so a parent that waits before
+/// reading has arranged for each side to wait on the other:
+///
+/// ```swift
+/// try proc.run()
+/// proc.waitUntilExit()                              // waits for the child
+/// let out = pipe.fileHandleForReading.readToEnd()   // never reached
+/// ```
+///
+/// `hdiutil info -plist` lists every attached image on the machine and
+/// passes 64 KiB easily. `diskprobe` emits a JSON description of a whole
+/// disk. Both were called this way.
+///
+/// Reading first fixes one pipe. Reading two pipes one after the other
+/// does not: if the child fills the second while this side is blocked on
+/// the first, the standoff happens one stream over. So both are drained
+/// concurrently and the wait comes last.
+///
+/// A stream nobody wants still needs a destination that cannot fill,
+/// which is what `runDiscardingOutput` uses `/dev/null` for. An unread
+/// `Pipe()` is the same bug wearing a different hat.
+enum ProcessRunner {
+
+    /// What a finished child left behind.
+    struct Output {
+        let stdout: Data
+        let stderr: Data
+        let status: Int32
+
+        var stdoutText: String { String(data: stdout, encoding: .utf8) ?? "" }
+        var stderrText: String { String(data: stderr, encoding: .utf8) ?? "" }
+    }
+
+    /// Launch `proc`, drain both streams to EOF, and wait for it.
+    ///
+    /// `proc.standardOutput` and `proc.standardError` are replaced with
+    /// fresh pipes, so a caller cannot leave one attached to a buffer
+    /// nothing reads.
+    static func run(_ proc: Process) throws -> Output {
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+
+        try proc.run()
+
+        var outData = Data()
+        var errData = Data()
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "diskjockey.agent.process-runner", attributes: .concurrent)
+        queue.async(group: group) {
+            outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+        queue.async(group: group) {
+            errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+        group.wait()
+
+        // Safe now: both pipes are at EOF, so nothing the child does can
+        // block, and it has already closed its ends.
+        proc.waitUntilExit()
+        return Output(stdout: outData, stderr: errData, status: proc.terminationStatus)
+    }
+
+    /// Run `proc` with both streams sent to `/dev/null`.
+    ///
+    /// For a child whose output is genuinely not wanted. `/dev/null` has
+    /// no buffer to fill, so the child can write as much as it likes and
+    /// still exit.
+    @discardableResult
+    static func runDiscardingOutput(_ proc: Process) throws -> Int32 {
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+        proc.waitUntilExit()
+        return proc.terminationStatus
+    }
+}

--- a/DiskJockeyApplication/Models/AppLogModel.swift
+++ b/DiskJockeyApplication/Models/AppLogModel.swift
@@ -9,11 +9,6 @@ public struct AppLogMessage: Identifiable {
     public let timestamp: Date
 }
 
-public protocol AppLogger: AnyObject {
-    func log(_ msg: String, category: String)
-    func log(_ msg: String)
-}
-
 /// Thin view-model over `LogRepository`. Republishes a *filtered* view
 /// of the repository's logs to SwiftUI: entries whose `scope` is in
 /// `suppressedScopes` are dropped on the way to `messages`. The full

--- a/DiskJockeyApplication/Models/MountTableParser.swift
+++ b/DiskJockeyApplication/Models/MountTableParser.swift
@@ -30,9 +30,14 @@ public enum MountTableParser {
         proc.standardOutput = pipe
         proc.standardError = Pipe()
         do { try proc.run() } catch { return [] }
+        // Read BEFORE waiting. A child that writes more than the pipe buffer
+        // holds (~64 KiB) blocks on the write, and a parent already inside
+        // waitUntilExit() never drains it — both wait for the other. Reading
+        // to EOF first cannot deadlock: EOF arrives when the child closes its
+        // end, which it does on exit.
+        let data = try? pipe.fileHandleForReading.readToEnd()
         proc.waitUntilExit()
-        guard let data = try? pipe.fileHandleForReading.readToEnd(),
-              let text = String(data: data, encoding: .utf8) else { return [] }
+        guard let data, let text = String(data: data, encoding: .utf8) else { return [] }
 
         var results: [AttachedDisk] = []
         for line in text.split(separator: "\n") {
@@ -142,9 +147,11 @@ public enum MountTableParser {
             p.standardError = pipe
             do {
                 try p.run()
+                // Read before waiting — see `enumerate`.
+                let outData = try? pipe.fileHandleForReading.readToEnd()
                 p.waitUntilExit()
                 let rc = p.terminationStatus
-                let out = (try? pipe.fileHandleForReading.readToEnd())
+                let out = outData
                     .flatMap { String(data: $0, encoding: .utf8) }?
                     .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 if rc == 0 {

--- a/DiskJockeyApplication/Models/MountTableParser.swift
+++ b/DiskJockeyApplication/Models/MountTableParser.swift
@@ -26,18 +26,14 @@ public enum MountTableParser {
     public static func enumerate(fsTypesOfInterest: Set<String>) -> [AttachedDisk] {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/sbin/mount")
-        let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = Pipe()
-        do { try proc.run() } catch { return [] }
-        // Read BEFORE waiting. A child that writes more than the pipe buffer
-        // holds (~64 KiB) blocks on the write, and a parent already inside
-        // waitUntilExit() never drains it — both wait for the other. Reading
-        // to EOF first cannot deadlock: EOF arrives when the child closes its
-        // end, which it does on exit.
-        let data = try? pipe.fileHandleForReading.readToEnd()
-        proc.waitUntilExit()
-        guard let data, let text = String(data: data, encoding: .utf8) else { return [] }
+        // Reading stdout before waiting was half the fix: stderr was
+        // still an unread `Pipe()`, and a child blocked writing to a
+        // full stderr never closes stdout, so the read that was meant
+        // to prevent the deadlock blocks instead. The runner drains
+        // both, concurrently.
+        guard let result = try? ProcessRunner.run(proc) else { return [] }
+        let text = result.stdoutText
+        guard !text.isEmpty else { return [] }
 
         var results: [AttachedDisk] = []
         for line in text.split(separator: "\n") {

--- a/DiskJockeyApplication/Models/RawDisksModel.swift
+++ b/DiskJockeyApplication/Models/RawDisksModel.swift
@@ -265,9 +265,13 @@ public final class RawDisksModel: ObservableObject {
         proc.standardOutput = outPipe
         proc.standardError = Pipe()
         do { try proc.run() } catch { return nil }
+        // Read before waiting: a child filling the ~64 KiB pipe buffer blocks
+        // on the write, and a parent already inside waitUntilExit() never
+        // drains it — each waits for the other.
+        let out = try? outPipe.fileHandleForReading.readToEnd()
         proc.waitUntilExit()
         guard proc.terminationStatus == 0 else { return nil }
-        return try? outPipe.fileHandleForReading.readToEnd()
+        return out
     }
 
     private static func nonEmpty(_ s: String?) -> String? {

--- a/DiskJockeyApplication/Models/RawDisksModel.swift
+++ b/DiskJockeyApplication/Models/RawDisksModel.swift
@@ -261,17 +261,13 @@ public final class RawDisksModel: ObservableObject {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
         proc.arguments = args
-        let outPipe = Pipe()
-        proc.standardOutput = outPipe
-        proc.standardError = Pipe()
-        do { try proc.run() } catch { return nil }
-        // Read before waiting: a child filling the ~64 KiB pipe buffer blocks
-        // on the write, and a parent already inside waitUntilExit() never
-        // drains it — each waits for the other.
-        let out = try? outPipe.fileHandleForReading.readToEnd()
-        proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else { return nil }
-        return out
+        // `diskutil list -plist` on a machine with many disks is
+        // comfortably past the ~64 KiB a pipe holds, and stderr used to
+        // be a `Pipe()` nothing read — which blocks the child just as
+        // surely as not reading stdout. The runner drains both,
+        // concurrently, and waits afterwards.
+        guard let result = try? ProcessRunner.run(proc), result.status == 0 else { return nil }
+        return result.stdout
     }
 
     private static func nonEmpty(_ s: String?) -> String? {

--- a/DiskJockeyApplication/Services/AppContainer.swift
+++ b/DiskJockeyApplication/Services/AppContainer.swift
@@ -18,7 +18,6 @@ public final class AppContainer: ObservableObject {
     /// Structured app-level log surface (AppLog wraps writes to the
     /// shared ndjson file so our own lines appear in the same feed).
     public let appLogModel: AppLogModel
-    public var appLogger: AppLogger { appLogModel as! AppLogger }
 
     /// Owns the security-scoped bookmark the user approves on first
     /// direct-mount creation — grants the sandboxed host app access

--- a/DiskJockeyApplication/Services/FSKitMountService.swift
+++ b/DiskJockeyApplication/Services/FSKitMountService.swift
@@ -327,23 +327,15 @@ final class FSKitMountService {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: probe)
         proc.arguments = [path]
-        let stdout = Pipe()
-        let stderr = Pipe()
-        proc.standardOutput = stdout
-        proc.standardError = stderr
-        try proc.run()
-        // Read before waiting: a child filling the ~64 KiB pipe buffer blocks
-        // on the write, and a parent already inside waitUntilExit() never
-        // drains it. Both pipes are drained for the same reason — stderr can
-        // fill on its own.
-        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        if proc.terminationStatus != 0 {
-            let err = String(data: errData, encoding: .utf8) ?? ""
-            throw FSKitError.processFailed(exitCode: proc.terminationStatus, stderr: err)
+        // Draining stdout to EOF and only then stderr is still a
+        // deadlock: if the child fills stderr while this side is blocked
+        // on stdout, each waits for the other one stream over. The
+        // runner reads both concurrently.
+        let result = try ProcessRunner.run(proc)
+        if result.status != 0 {
+            throw FSKitError.processFailed(exitCode: result.status, stderr: result.stderrText)
         }
-        return try JSONDecoder().decode(DiskProbeResult.self, from: outData)
+        return try JSONDecoder().decode(DiskProbeResult.self, from: result.stdout)
     }
 
     /// Find the diskprobe binary. Checks (in order):

--- a/DiskJockeyApplication/Services/FSKitMountService.swift
+++ b/DiskJockeyApplication/Services/FSKitMountService.swift
@@ -332,11 +332,15 @@ final class FSKitMountService {
         proc.standardOutput = stdout
         proc.standardError = stderr
         try proc.run()
-        proc.waitUntilExit()
+        // Read before waiting: a child filling the ~64 KiB pipe buffer blocks
+        // on the write, and a parent already inside waitUntilExit() never
+        // drains it. Both pipes are drained for the same reason — stderr can
+        // fill on its own.
         let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
         if proc.terminationStatus != 0 {
-            let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(),
-                             encoding: .utf8) ?? ""
+            let err = String(data: errData, encoding: .utf8) ?? ""
             throw FSKitError.processFailed(exitCode: proc.terminationStatus, stderr: err)
         }
         return try JSONDecoder().decode(DiskProbeResult.self, from: outData)

--- a/DiskJockeyApplication/Views/AttachedDiskDetailView.swift
+++ b/DiskJockeyApplication/Views/AttachedDiskDetailView.swift
@@ -376,14 +376,14 @@ struct AttachedDiskDetailView: View {
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
             task.arguments = ["unmount", disk.mountPath]
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            task.standardOutput = stdoutPipe
-            task.standardError = stderrPipe
             do {
-                try task.run()
-                task.waitUntilExit()
-                let rc = task.terminationStatus
+                // Both pipes are drained before the wait, and drained
+                // concurrently. Waiting first deadlocks once the child
+                // fills a ~64 KiB pipe buffer nobody is reading; draining
+                // one and then the other deadlocks once the child fills
+                // the second while this side is blocked on the first.
+                let result = try ProcessRunner.run(task)
+                let rc = result.status
                 let err: String?
                 if rc == 0 {
                     err = nil
@@ -391,9 +391,7 @@ struct AttachedDiskDetailView: View {
                     // diskutil writes its failure reason to stdout, not
                     // stderr (see "Unmount failed ..." lines), so merge
                     // both streams and surface whatever came out.
-                    let out = (try? stdoutPipe.fileHandleForReading.readToEnd()).flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    let errText = (try? stderrPipe.fileHandleForReading.readToEnd()).flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    let combined = (out + errText).trimmingCharacters(in: .whitespacesAndNewlines)
+                    let combined = result.combinedText
                     err = combined.isEmpty ? "diskutil unmount failed (rc=\(rc))" : combined
                 }
                 await MainActor.run {
@@ -543,14 +541,15 @@ struct AttachedDiskDetailView: View {
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/sbin/fsck_fskit")
             task.arguments = ["--progress", "-t", fsArg, devicePath]
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            task.standardOutput = stdoutPipe
-            task.standardError = stderrPipe
             do {
-                try task.run()
-                task.waitUntilExit()
-                let rc = task.terminationStatus
+                // `--progress` means this child streams: it writes a
+                // line per step for as long as the check runs, so the
+                // pipe buffer fills on any volume large enough to be
+                // worth checking. Waiting for it before reading is the
+                // deadlock; the runner reads both streams concurrently
+                // and waits afterwards.
+                let result = try ProcessRunner.run(task)
+                let rc = result.status
                 // rc == 0: clean. rc != 0 here means we couldn't even
                 // launch the check (perm denied on raw device, missing
                 // entitlement, etc) — actual fs-level findings come
@@ -560,9 +559,7 @@ struct AttachedDiskDetailView: View {
                 if rc == 0 {
                     err = nil
                 } else {
-                    let out = (try? stdoutPipe.fileHandleForReading.readToEnd()).flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    let errText = (try? stderrPipe.fileHandleForReading.readToEnd()).flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    let combined = (out + errText).trimmingCharacters(in: .whitespacesAndNewlines)
+                    let combined = result.combinedText
                     err = combined.isEmpty ? "fsck_fskit failed (rc=\(rc))" : combined
                 }
                 await MainActor.run {

--- a/DiskJockeyLibrary/ProcessRunner.swift
+++ b/DiskJockeyLibrary/ProcessRunner.swift
@@ -34,10 +34,11 @@ import Foundation
 /// to both — a progress stream on one and warnings on the other — hits
 /// it, and which of the two fills first depends on the machine.
 ///
-/// So both streams are drained **concurrently**, on their own queues,
-/// and `waitUntilExit()` runs only once both have reached EOF. EOF
-/// arrives when the child closes its end, which it does on exit, so no
-/// ordering here can block.
+/// So both streams are drained **concurrently** — stderr on a private
+/// queue, stdout on the calling thread, which is already committed to
+/// waiting — and `waitUntilExit()` runs only once both have reached
+/// EOF. EOF arrives when the child closes its end, which it does on
+/// exit, so no ordering here can block.
 ///
 /// # A stream nobody wants still needs a destination
 ///
@@ -90,21 +91,24 @@ public enum ProcessRunner {
 
         try proc.run()
 
-        // Both readers start before either finishes. Draining them in
-        // sequence would let a full stderr block the child while this
-        // side is still reading stdout — the same deadlock, one stream
-        // over.
-        var outData = Data()
+        // Both readers are live before either finishes. Draining them
+        // in sequence would let a full stderr block the child while
+        // this side is still reading stdout — the same deadlock, one
+        // stream over.
+        //
+        // Only stderr is handed to another thread; stdout is read on
+        // the caller's, which is already committed to waiting. Two
+        // background readers would work equally well and cost one more
+        // blocked thread per concurrent call — enough to matter when
+        // several run at once, which is how the first version of this
+        // stalled a CI machine.
         var errData = Data()
         let group = DispatchGroup()
-        let queue = DispatchQueue(label: "diskjockey.process-runner", attributes: .concurrent)
-
-        queue.async(group: group) {
-            outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-        }
+        let queue = DispatchQueue(label: "diskjockey.process-runner")
         queue.async(group: group) {
             errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         }
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         group.wait()
 
         // Safe now: both pipes are at EOF, so nothing the child does can

--- a/DiskJockeyLibrary/ProcessRunner.swift
+++ b/DiskJockeyLibrary/ProcessRunner.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Run a child process and collect what it wrote, without deadlocking.
+///
+/// # The deadlock this exists to prevent
+///
+/// A pipe holds a bounded amount of data — roughly 64 KiB on macOS.
+/// Once it is full, the child's next `write` blocks until somebody
+/// drains it. So a parent that calls `waitUntilExit()` before reading
+/// has arranged for each side to wait on the other:
+///
+/// ```swift
+/// try proc.run()
+/// proc.waitUntilExit()                       // waits for the child
+/// let out = pipe.fileHandleForReading.readToEnd()   // never reached
+/// ```
+///
+/// The child cannot exit until its output is read; the parent will not
+/// read until the child exits. The app hangs, with no error and nothing
+/// in a log.
+///
+/// # Reading first is not enough on its own
+///
+/// The obvious repair — read to EOF, then wait — fixes the single-pipe
+/// case, and is still wrong with two pipes drained one after the other:
+///
+/// ```swift
+/// let out = stdout.fileHandleForReading.readDataToEndOfFile()  // blocks
+/// let err = stderr.fileHandleForReading.readDataToEndOfFile()  // unreached
+/// ```
+///
+/// If the child fills `stderr` while the parent is blocked on `stdout`,
+/// the same standoff happens one stream over. A child that writes a lot
+/// to both — a progress stream on one and warnings on the other — hits
+/// it, and which of the two fills first depends on the machine.
+///
+/// So both streams are drained **concurrently**, on their own queues,
+/// and `waitUntilExit()` runs only once both have reached EOF. EOF
+/// arrives when the child closes its end, which it does on exit, so no
+/// ordering here can block.
+///
+/// # A stream nobody wants still needs a destination
+///
+/// Attaching a `Pipe()` to a stream and never reading it is the same
+/// bug: the buffer fills and the child blocks. When the output is not
+/// wanted, the answer is `FileHandle.nullDevice`, which has no buffer to
+/// fill. `discardingOutput` does that.
+public enum ProcessRunner {
+
+    /// What a finished child left behind.
+    public struct Output: Sendable {
+        /// Everything the child wrote to stdout, to EOF.
+        public let stdout: Data
+        /// Everything the child wrote to stderr, to EOF.
+        public let stderr: Data
+        /// The child's exit status.
+        public let status: Int32
+
+        /// `stdout` decoded as UTF-8, or an empty string.
+        public var stdoutText: String {
+            String(data: stdout, encoding: .utf8) ?? ""
+        }
+
+        /// `stderr` decoded as UTF-8, or an empty string.
+        public var stderrText: String {
+            String(data: stderr, encoding: .utf8) ?? ""
+        }
+
+        /// Both streams, trimmed — for tools that report failures on
+        /// stdout rather than stderr. `diskutil` is one: its "Unmount
+        /// failed" lines come out on stdout.
+        public var combinedText: String {
+            (stdoutText + stderrText).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    /// Launch `proc`, drain both streams to EOF, and wait for it.
+    ///
+    /// `proc.standardOutput` and `proc.standardError` are replaced with
+    /// fresh pipes, so a caller cannot accidentally leave one attached
+    /// to a buffer nothing reads.
+    ///
+    /// - Throws: whatever `Process.run()` throws — the executable is
+    ///   missing, is not executable, or the fork failed.
+    public static func run(_ proc: Process) throws -> Output {
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+
+        try proc.run()
+
+        // Both readers start before either finishes. Draining them in
+        // sequence would let a full stderr block the child while this
+        // side is still reading stdout — the same deadlock, one stream
+        // over.
+        var outData = Data()
+        var errData = Data()
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "diskjockey.process-runner", attributes: .concurrent)
+
+        queue.async(group: group) {
+            outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+        queue.async(group: group) {
+            errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+        group.wait()
+
+        // Safe now: both pipes are at EOF, so nothing the child does can
+        // block, and it has already closed its ends.
+        proc.waitUntilExit()
+        return Output(stdout: outData, stderr: errData, status: proc.terminationStatus)
+    }
+
+    /// Run `proc` with both streams sent to `/dev/null`.
+    ///
+    /// For a child whose output is genuinely not wanted. The point is
+    /// that this is NOT the same as attaching pipes and ignoring them:
+    /// `/dev/null` has no buffer to fill, so the child can write as much
+    /// as it likes and still exit.
+    ///
+    /// - Returns: the child's exit status.
+    /// - Throws: whatever `Process.run()` throws.
+    @discardableResult
+    public static func runDiscardingOutput(_ proc: Process) throws -> Int32 {
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+        proc.waitUntilExit()
+        return proc.terminationStatus
+    }
+}

--- a/DiskJockeyLibraryTests/ProcessRunnerTests.swift
+++ b/DiskJockeyLibraryTests/ProcessRunnerTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import DiskJockeyLibrary
+
+/// `ProcessRunner` exists to survive children that write more than a
+/// pipe holds. These tests spawn children that do exactly that.
+///
+/// Every test here has a watchdog, because the failure mode under test
+/// is a **hang**, not a wrong answer. Without one, a regression does not
+/// fail the suite — it stops it, and a stalled test run reads as a slow
+/// machine rather than a bug.
+@Suite("ProcessRunner")
+struct ProcessRunnerTests {
+
+    /// Comfortably past the ~64 KiB pipe buffer, small enough to stay
+    /// fast. A child writing this much blocks unless something drains
+    /// it.
+    private static let floodBytes = 512 * 1024
+
+    /// Run `body` on a background thread and fail if it does not finish.
+    ///
+    /// `Process` deadlocks do not throw and do not time out on their
+    /// own, so the assertion has to come from outside.
+    private func withDeadline<T: Sendable>(
+        seconds: Double = 20,
+        _ label: String,
+        _ body: @escaping @Sendable () -> T
+    ) -> T? {
+        let box = LockedBox<T>()
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            box.value = body()
+            done.signal()
+        }
+        if done.wait(timeout: .now() + seconds) == .timedOut {
+            Issue.record("\(label) did not finish within \(seconds)s — the child is blocked writing to a pipe nobody is draining")
+            return nil
+        }
+        return box.value
+    }
+
+    private func shell(_ script: String) -> Process {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/sh")
+        p.arguments = ["-c", script]
+        return p
+    }
+
+    @Test("a child that floods stdout is read to the end")
+    func floodsStdout() {
+        let n = Self.floodBytes
+        let out = withDeadline("stdout flood") {
+            try? ProcessRunner.run(
+                self.shell("head -c \(n) /dev/zero | tr '\\0' 'a'"))
+        }
+        guard let out = out ?? nil else { return }
+        #expect(out.stdout.count == n)
+        #expect(out.status == 0)
+    }
+
+    /// The one the sequential drain gets wrong.
+    ///
+    /// Reading stdout to EOF and only then reading stderr works right up
+    /// until the child fills stderr while the parent is still on stdout.
+    /// Both streams flood here, so whichever the implementation reads
+    /// second is the one that blocks the child.
+    @Test("a child that floods both streams does not deadlock")
+    func floodsBothStreams() {
+        let n = Self.floodBytes
+        let out = withDeadline("both-stream flood") {
+            try? ProcessRunner.run(
+                self.shell("""
+                    head -c \(n) /dev/zero | tr '\\0' 'a' &
+                    head -c \(n) /dev/zero | tr '\\0' 'b' >&2
+                    wait
+                    """))
+        }
+        guard let out = out ?? nil else { return }
+        #expect(out.stdout.count == n)
+        #expect(out.stderr.count == n)
+        #expect(out.status == 0)
+    }
+
+    /// A stream nobody wants still needs somewhere to go.
+    ///
+    /// `runDiscardingOutput` uses `/dev/null`, which has no buffer to
+    /// fill. An implementation that attached an unread `Pipe()` instead
+    /// would hang here.
+    @Test("output can be discarded without blocking the child")
+    func discardsOutput() {
+        let n = Self.floodBytes
+        let status = withDeadline("discarded flood") {
+            try? ProcessRunner.runDiscardingOutput(
+                self.shell("""
+                    head -c \(n) /dev/zero | tr '\\0' 'a'
+                    head -c \(n) /dev/zero | tr '\\0' 'b' >&2
+                    """))
+        }
+        guard let status = status ?? nil else { return }
+        #expect(status == 0)
+    }
+
+    @Test("a failing child reports its status and its stderr")
+    func reportsFailure() throws {
+        let out = try ProcessRunner.run(shell("echo problem >&2; exit 3"))
+        #expect(out.status == 3)
+        #expect(out.stderrText.contains("problem"))
+        #expect(out.stdout.isEmpty)
+    }
+
+    /// `diskutil` writes its failure reason to stdout, so callers that
+    /// only surface stderr show an empty error. `combinedText` is what
+    /// they use instead.
+    @Test("combinedText carries a failure written to stdout")
+    func combinesStreams() throws {
+        let out = try ProcessRunner.run(shell("echo 'Unmount failed'; echo 'detail' >&2; exit 1"))
+        #expect(out.status == 1)
+        #expect(out.combinedText.contains("Unmount failed"))
+        #expect(out.combinedText.contains("detail"))
+    }
+
+    @Test("a missing executable throws rather than reporting success")
+    func missingExecutable() {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/nonexistent/definitely-not-here")
+        #expect(throws: (any Error).self) {
+            _ = try ProcessRunner.run(p)
+        }
+    }
+}
+
+/// A `Sendable` slot for carrying a result off a background thread.
+private final class LockedBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: T?
+    var value: T? {
+        get { lock.lock(); defer { lock.unlock() }; return stored }
+        set { lock.lock(); stored = newValue; lock.unlock() }
+    }
+}

--- a/DiskJockeyLibraryTests/ProcessRunnerTests.swift
+++ b/DiskJockeyLibraryTests/ProcessRunnerTests.swift
@@ -10,26 +10,38 @@ import Testing
 /// is a **hang**, not a wrong answer. Without one, a regression does not
 /// fail the suite — it stops it, and a stalled test run reads as a slow
 /// machine rather than a bug.
-@Suite("ProcessRunner")
+///
+/// The suite is `.serialized` because its tests spawn subprocesses and
+/// block threads waiting on them. Run in parallel with each other and
+/// with the rest of the bundle, they starved neighbouring tests that
+/// assert on 50-millisecond deadlines, and CI failed on *those* rather
+/// than on anything here.
+@Suite("ProcessRunner", .serialized)
 struct ProcessRunnerTests {
 
     /// Comfortably past the ~64 KiB pipe buffer, small enough to stay
     /// fast. A child writing this much blocks unless something drains
     /// it.
-    private static let floodBytes = 512 * 1024
+    private static let floodBytes = 256 * 1024
 
     /// Run `body` on a background thread and fail if it does not finish.
     ///
     /// `Process` deadlocks do not throw and do not time out on their
     /// own, so the assertion has to come from outside.
+    ///
+    /// The work runs on a dedicated `Thread`, not the global queue. A
+    /// deadline that can itself be starved of a thread reports a
+    /// timeout for a test that was never given a chance to run — which
+    /// is exactly what happened on CI, where all three of these
+    /// reported the same 64 seconds.
     private func withDeadline<T: Sendable>(
-        seconds: Double = 20,
+        seconds: Double = 30,
         _ label: String,
         _ body: @escaping @Sendable () -> T
     ) -> T? {
         let box = LockedBox<T>()
         let done = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
+        Thread.detachNewThread {
             box.value = body()
             done.signal()
         }

--- a/docs/constellation-report-2026-08-30.md
+++ b/docs/constellation-report-2026-08-30.md
@@ -16,7 +16,8 @@ The full 715-finding index is at
 4. [Toolchain, volumes, mkfs and branches](#4-other-structural-work)
 5. [The human-code sweep, repository by repository](#5-the-human-code-sweep)
 6. [Waiting on you](#6-waiting-on-you)
-7. [Housekeeping and corrections](#7-housekeeping-and-corrections)
+7. [The second wave](#7-the-second-wave)
+8. [Housekeeping and corrections](#8-housekeeping-and-corrections)
 
 ---
 
@@ -588,7 +589,8 @@ submodules that git refuses to remove; it needs a manual `rm -rf`.
 ## 5. The human-code sweep
 
 All fifteen repositories assessed for their **High and Medium** findings — 501
-of the 715. **61 items fixed**, one PR per repository, all currently open:
+of the 715. **61 items fixed** in the first pass, one PR per repository. All
+fifteen are merged.
 
 | Repo | PR | Repo | PR |
 |---|---|---|---|
@@ -600,6 +602,24 @@ of the 715. **61 items fixed**, one PR per repository, all currently open:
 | rust-fs-ext4 | [#50](https://github.com/christhomas/rust-fs-ext4/pull/50) | rust-img-vhd | [#26](https://github.com/antimatter-studios/rust-img-vhd/pull/26) |
 | rust-fs-erofs | [#26](https://github.com/antimatter-studios/rust-fs-erofs/pull/26) | rust-img-vhdx | [#27](https://github.com/antimatter-studios/rust-img-vhdx/pull/27) |
 | | | rust-img-vmdk | [#26](https://github.com/antimatter-studios/rust-img-vmdk/pull/26) |
+
+**Two things went wrong across that merge, both worth knowing.**
+
+*Every dependent's lock had moved past its workflow's pin.* The family was
+released while these branches were open, so each `Cargo.lock` resolved
+`am-fs-core 0.2.3` while every workflow still cloned `v0.2.2`. CI clones the
+sibling at the pinned tag and builds with `--locked`, so it stopped before
+compiling anything — eleven repositories, one line each:
+
+```
+error: cannot update the lock file … because --locked was passed to prevent this
+```
+
+*Three new tests used `std::os::unix::fs::FileExt`.* `write_all_at` and
+`read_exact_at` do not exist on the Windows runner CI also uses. In qcow2 and
+vhdx the `WriteAt` trait in `tests/common` **already was** the portable
+seek-then-write helper — the Unix import shadowed it. qcow2 gained the reading
+half for the same reason.
 
 ### 5.1 Documentation that described a different program
 
@@ -819,20 +839,15 @@ Both worth deciding soon.
 
 ### 6.6 The single next item, per repository
 
-Where a repo has one finding that should come before the others:
+Where a repo has one finding that should come before the others. Six of the
+original rows are gone because they were done — §7 has them.
 
 | Repo | Next | Why |
 |---|---|---|
 | **ext4** | X1 | Nine hand-written copies of the one checksum tail that *has* a helper — the checksum a wrong write corrupts silently. The report's own follow-up says it is larger than first stated. |
-| **ext4** | D3 | "Atomic" rename that is not atomic on the overwrite path. Unlike D2 this is **not stale — it is wrong**, and it is the property callers most rely on. |
-| **ntfs** | B3/B4 | One 164-line function writes its `free_all` rollback out **ten times** and is currently correct; another four hundred lines away omits it entirely and leaves a torn rename. Neither is a named idiom, so the divergence is invisible — the same shape as the `".."` bug. |
-| **ntfs** | C1 | `fs_ntfs_write_file` and `fs_ntfs_write_file_contents` treat `len == 0` **oppositely**. A caller cannot be right about both. |
-| **xfs** | H5 | One of three copies of btree node parsing **silently omits an identity check**. Three parsers where one validates less is a bug with a delay on it. |
 | **xfs** | M18 | `truncate` and `truncate_to_zero` have opposite argument orders — the pair most likely to be called wrongly. |
 | **erofs** | M6 | Compacted-pack geometry in **four encodings, one of which is correct**. A bug waiting for someone to reach for the wrong one. |
 | **erofs** | M22 | 117 inline hex slice ranges with no named-offset convention at all. The largest, and it would change how the whole crate reads. |
-| **btrfs** | H5 | `insert`'s refusal message contradicts the `split` function fifty lines below it, so one of the two is wrong about when a split happens. |
-| **blk-probe** | M4 | Short reads treated as end-of-file — the same class as the squashfs gzip bug, where a truncated input was served as complete. |
 | **vhd** | M3 | The sector-bitmap arithmetic written twice **with opposite bounds discipline**. Two copies disagreeing about bounds checking is how one ends up wrong. |
 | **partitions** | M5 | `SECTOR_SIZE` defined three times and then ignored eight — most likely to end in a real disagreement. |
 | **vhdx** | M5 | A comment that contradicts itself about data-sector placement. **Resolving it needs the spec**, not a rewording. |
@@ -872,7 +887,261 @@ different deliverables, and steps 1 and 2 produce the library either way.
 
 ---
 
-## 7. Housekeeping and corrections
+## 7. The second wave
+
+Once the fifteen sweep PRs merged, the items §6.6 had named as "next" were taken
+in order of consequence rather than of effort. Six of them, plus the mkfs step
+the superblock writer had been waiting on.
+
+### 7.1 rust-fs-ntfs — a rename that could tear
+
+**B4, High.** A variable-length rename is two record writes with no journal
+between them: swap the parent's `$INDEX_ROOT` entry, then rewrite the file's own
+`$FILE_NAME`. Each `update_mft_record_io` is durable on its own, so **a failure
+at step 2 left step 1 standing** — the directory naming the new basename while
+the file's `$FILE_NAME` still read the old one.
+
+Neither record is malformed. Only their agreement is broken, which is why this
+crate would never have noticed it itself and chkdsk would.
+
+The bytes to undo step 1 were already in hand: `parent_record_bytes` is read a
+few lines above and nothing writes to the parent in between. Step 2's failure
+restores them and returns the original error. If the rollback fails too, the
+volume genuinely *is* torn and no further write here can be trusted to fix it, so
+the error says what is on disk rather than reporting only the first failure.
+
+`restore_mft_record_io` is the named idiom now, in `mft_io.rs` beside the
+primitive it undoes, and its doc says what it is **not**: a record whose previous
+bytes the caller still holds, not a general undo, no help once a second record is
+committed too. That naming is half the fix — B3 and B7 are two more rollback
+shapes written out by hand, both correct today, and the reason this site could
+omit one is that none of them had a name to be missing from.
+
+Three tests, over a `BlockIo` that refuses writes to a single MFT record — the
+only way to fail step 2 without failing the operation earlier. Mutation-checked:
+removing the rollback fails on `the old name must be back in the directory
+index`.
+
+### 7.2 rust-fs-ntfs — `len == 0` meaning two opposite things
+
+**C1, High.** Two adjacent C-ABI entry points, near-identical arguments, both
+opening with `if len == 0`:
+
+| | `len == 0` |
+|---|---|
+| `fs_ntfs_write_file` | returns 0 and does nothing — **without opening the image or resolving the path** |
+| `fs_ntfs_write_file_contents` | passes `&[]` through, which **empties the file** |
+
+Both are right. "Rewrite this range" with an empty range is a no-op; "write this
+as the entire contents" with nothing is `open(O_TRUNC)`. Neither is inferable
+from the signature, and they sit side by side with guards that look identical, so
+a caller cannot be right about both.
+
+The no-op is the **library's** policy at three levels, not a shortcut in the
+wrapper — `write_at` and `write_at_io` both return `Ok(0)` before resolving
+anything, so a caller chunking a buffer pays nothing for an empty tail. Changing
+that is a behaviour change on a published ABI with no reported harm behind it, so
+it stays your decision. What was clearly fixable is that neither behaviour was
+written down.
+
+Both now state it, in the Rust doc *and* in `fs_ntfs.h`, each pointing at the
+other. Three tests pin the pair, including the zero-length write to a path that
+does not exist contrasted with the one-byte write to the same path that fails.
+They format their own image rather than using `test-disks/`, which needs `mkntfs`
+and so only exists on CI.
+
+### 7.3 rust-fs-ext4 — where a rename stops being atomic
+
+**D3, High.** The doc promised `replace_if_exists = true` "atomically overwrites
+dst", and the body comment said the overwrite is staged "into a single buffer so
+a crash either fully replaces dst or leaves the FS in its prior state". True on
+the common path, false on one branch:
+
+```rust
+if dst_extends {
+    self.commit_block_buffer(buf)?;                 // dst's entry is already gone
+    self.extend_dir_and_add_entry(dst_parent_ino, …)?;   // NOT journaled
+}
+```
+
+When the destination directory has no room, the buffer is committed early and the
+un-journaled extend runs after it. On the overwrite path that early commit has
+already removed dst's directory entry — so a crash in the window leaves **dst's
+name gone and src still present**: the file that was at dst is unreachable and
+nothing has moved.
+
+The doc now names the branch, both windows and what closing them would take
+(`extend_dir_and_add_entry` staging into the buffer instead of writing on its
+own), and states the guarantee the code actually offers: **atomic unless the
+destination directory has to grow.** Making it unconditional is a change to the
+directory-growth path and a decision about the journal layer, not a correction.
+
+**The finding's second half was a live hazard.** Each `i_links_count` patch read
+its parent inode back from disk and staged a write of the whole record. Two
+patches naming the same inode in one buffer would have had the second read the
+pre-buffer bytes and overwrite the first — prevented only by two branch
+conditions three hundred lines apart happening to be mutually exclusive, which
+nothing stated and nothing enforced:
+
+```rust
+// Dest parent: only bump if NOT replacing a dir (which
+// would offset the bump). …
+if !dst_is_dir { … }
+```
+
+Deltas are accumulated and applied once now. Every parent is read exactly once
+after every delta is known, written exactly once, and **a net-zero delta writes
+nothing** — so the dir-replaces-dir case is arithmetic that cancels rather than a
+suppression that has to know about its counterpart.
+
+Four tests, covering cases that had none, including the cross-parent directory
+replace where two deltas name one inode. **They pass against the old code too**,
+which is the point: behaviour is unchanged, the cases were uncovered, and the
+invariant was one edit away from being false.
+
+### 7.4 rust-fs-xfs — the block-map tree checked less than its siblings
+
+**H5, High.** `alloc_btree::parse_block` and `inode_btree::parse_block` both
+verify a v5 block's self-recorded address. `bmbt::parse_block` did not — its
+offsets module had no `BLKNO` constant, and `grep -in 'blkno' src/bmbt.rs`
+returned nothing at all.
+
+That left it weakest against exactly what the check is for. A pointer corrupted
+into another valid block **of the same file** passes the CRC (a real block), the
+owner check (same inode) and the level check (same depth). Its recorded address
+is the only field that separates them.
+
+`bb_blkno` sits at 24 in the long form, by the same +8 shift that puts `UUID` at
+40 rather than 32 — the long form carries 64-bit sibling pointers. It holds a
+**basic-block address**, 512-byte units, not a filesystem block number, so the
+conversion moved into `alloc_btree::blkno_of_fsblock` and `expected_blkno` calls
+it. Two callers, one conversion, neither able to be right while the other is
+wrong.
+
+The test hands the walk a leaf correct in every other respect — right inode,
+right level, valid checksum — read at the wrong block, then reads the same block
+where it belongs so a pass cannot come from some other refusal. A second test
+pins the unit, because stamping the fsblock as-is would hide on 512-byte blocks
+and fire on every real geometry.
+
+**Every existing fixture had to start stamping its address**, which is its own
+evidence: none of them recorded one, so none was a block the reader should have
+been accepting.
+
+### 7.5 rust-fs-btrfs — a refusal that told callers to give up
+
+**H5, High.** `insert` refused an over-large item with *"Splitting a leaf is not
+implemented — where the kernel puts the boundary is a policy this has not
+measured."*
+
+Both halves false. `leaf_edit::split` is **fifty lines below**, with
+`tests/split_oracle.rs` checking it against leaves the kernel really split;
+`insert_or_split` is thirty lines further on and does exactly what a caller
+hitting the message wants. The module doc directly above prints three *measured*
+splits, and `docs/cow-transaction.md` has a section on the measurement and on why
+the boundary is deliberately not copied.
+
+The house style is what made this expensive: the messages are long and specific
+so a caller knows what to do next, and this one used that whole apparatus to tell
+them to give up on something forty lines away. It names `insert_or_split` now,
+and says why `insert` itself refuses — a caller who meant to write exactly one
+block should find out rather than silently get two.
+
+`tree_write::build_leaf` carried the milder version **inside one function**: its
+doc says splitting is "the caller's decision, not this function's" while its
+error said it "is not implemented".
+
+**Three tests were pinning the false sentence**, which is a fair description of
+why it survived: correcting the message broke them. They assert the condition
+now — that the refusal names what went wrong and names the function that handles
+it. The third was found by CI rather than by grep, because it only runs under the
+kernel-validation job. Fitting, in that the last test still asserting splitting
+was unimplemented was the one hardest to run.
+
+### 7.6 rust-blk-probe — a short read is not a short file
+
+**M4, Medium.** `let n = f.read(&mut head).unwrap_or(0);` — wrong twice.
+
+`unwrap_or(0)` discarded an `io::Error` inside a function that already returns
+`io::Result`, so an unreadable device and an empty file gave the same answer. And
+`Read::read` may return fewer bytes than asked for without an error and without
+being at end of input.
+
+The count is then read as a statement about the file. A read returning 4 makes
+the `n >= 8` guards false, so the vhdx and vhd magics become untestable and the
+image falls through to `Raw` — silently, for a file whose first eight bytes say
+exactly what it is. The trailing-footer check had the same shape with `== 8`
+standing in for the guard, so a fixed VHD would have been reported as raw too.
+
+`read_up_to` loops until the buffer is full or the source ends, retries
+`Interrupted` because a signal arriving is not a failure, and propagates
+everything else. A file shorter than the buffer still reports its length rather
+than erroring — a tiny raw image is legitimate, which is why this is not
+`read_exact` with its `UnexpectedEof` mapped back.
+
+Four tests, over readers that behave the way the trait permits and a regular file
+does not. **That gap is the whole story**: a local regular file fills a 16-byte
+buffer in one call, so the old form was right on every machine anybody ran it on.
+
+### 7.7 diskjockey — the pipe fixes, finished and then corrected by CI
+
+§1.8 has the defect. Two things about it only became visible afterwards.
+
+The first version of the tests **failed CI on somebody else's tests**. All three
+flood tests reported the same 64 seconds, which is what a starved thread pool
+looks like rather than a deadlock: `withDeadline` ran its work on the global
+queue, so the deadline could itself be denied a thread and then report a timeout
+for a test that never ran. Meanwhile the subprocess-spawning, thread-blocking
+tests starved `DetachedOperationWatchdog`, whose assertions are on
+50-millisecond deadlines — eight of its cases failed.
+
+The suite is `.serialized` now and the watchdog uses a dedicated `Thread`. That
+fed back into the helper itself: draining both pipes on background threads while
+blocking the caller's meant three threads per concurrent call. Only stderr goes
+to another thread now; stdout is read on the calling thread, which was already
+committed to waiting. Same guarantee, one blocked thread instead of two.
+
+### 7.8 rust-fs-xfs — mkfs step 1b: the superblock model completed
+
+[#54](https://github.com/antimatter-studios/rust-fs-xfs/pull/54). `Superblock`
+modelled 33 of the structure's fields — the ones a reader consults — so `apply`
+could only be honest by carrying the rest across from whatever was already in the
+buffer. Which makes it useless to a formatter: a formatter has a zeroed sector
+and a geometry, and nothing to carry anything from.
+
+Twenty more fields now: the realtime inodes, extent size and counts, the quota
+inodes, `qflags`, `flags`, `shared_vn`, the stripe unit and width, `imax_pct`,
+`rextslog`, the log sector geometry, `bad_features2`, and — v5 only —
+`sb_pquotino` and `sb_lsn`. They sit below a divider in the struct saying what
+they are for, kept flat so the field order still matches the on-disk order, which
+is the property that makes an offset typo visible by eye.
+
+**The test that proves the model complete** runs the same byte-for-byte
+comparison against a destination that starts as *zeroes*: a field nobody modelled
+reads back as zero and the assertion names its offset. The existing
+apply-over-itself test cannot fail that way, because the original's value is
+already sitting there.
+
+A second test covers what the fixtures cannot: **ten of the new fields are zero
+in every image `mkfs.xfs` produces with default options**, so the comparison
+above matches whether they are written or not. Each gets a distinct value and is
+read back at its offset — distinct, so a transposition cannot pass either.
+
+| removed from `apply` | empty-buffer test | per-field test |
+|---|---|---|
+| `sb_rextsize` | fails at `0x0053` | fails |
+| `sb_imax_pct` | fails at `0x007f` | fails |
+| the magic | fails at `0x0000` | fails |
+| `sb_qflags` | **passes** (zero in every fixture) | fails |
+
+The last row is why both exist.
+
+Adding public fields breaks struct-literal construction, so the crate's next tag
+is a minor bump.
+
+---
+
+## 8. Housekeeping and corrections
 
 **No VM was booted** at any point. The xfs superblock work used fixtures already
 captured in `.vm-share`. The one QEMU process running on the machine belongs to

--- a/docs/constellation-report-2026-08-30.md
+++ b/docs/constellation-report-2026-08-30.md
@@ -238,10 +238,46 @@ blocks on the write. A parent already inside `waitUntilExit()` never drains it.
 so this was not theoretical.
 
 Reading to EOF first cannot deadlock: EOF arrives when the child closes its end,
-which it does on exit. Fixed at four sites — `MountTableParser.enumerate`, its
-zombie-unmount path, `RawDisksModel`, and `FSKitMountService`, where **both**
-pipes are now drained since stderr can fill on its own. Three sites remain in
-`DiskJockeyAgent`, a separate unsandboxed target with the same defect.
+which it does on exit.
+
+**Reading first turned out to be only half of it**, and the first round shipped
+the other half in two forms. Both are fixed now.
+
+*One pipe read, the other left attached and unread.* `MountTableParser.enumerate`
+and `RawDisksModel.runDiskutil` drained stdout before waiting — and set
+`standardError = Pipe()`, which nothing read. A child blocked writing to a full
+stderr never closes stdout, **so the read that was meant to prevent the deadlock
+blocks instead**. An unread pipe is not a way of ignoring a stream; it is a
+64 KiB buffer that stops the child once it fills.
+
+*Both pipes read, one after the other.* `FSKitMountService` drained stdout to EOF
+and then stderr. If the child fills stderr while this side is blocked on stdout,
+the same standoff happens one stream over — and which fills first depends on the
+machine, so it would have presented as intermittent.
+
+The repair is one helper, `DiskJockeyLibrary/ProcessRunner.swift`, draining both
+concurrently and waiting afterwards, plus `runDiscardingOutput` for a child whose
+output is genuinely unwanted: that one uses `FileHandle.nullDevice`, which has no
+buffer to fill.
+
+**Two sites nobody had counted.** `AttachedDiskDetailView` runs `diskutil
+unmount` and `fsck_fskit --progress`, both waiting before either pipe is read.
+The second is the worst instance in the tree — `--progress` means the child
+*streams*, a line per step for as long as the check runs, so the buffer fills on
+any volume large enough to be worth checking.
+
+**And the five in `DiskJockeyAgent`.** It is not a target in the Xcode project;
+it is compiled standalone and links no framework of ours, so it carries its own
+copy of the helper with the reasoning duplicated in full. `hdiutil info -plist`
+lists every attached image on the machine and `diskprobe` emits a JSON
+description of a whole disk — both were called with the wait first.
+
+Six tests, each with a watchdog, because the failure under test is a **hang**
+rather than a wrong answer: without a deadline a regression stops the suite
+instead of failing it, and a stalled run reads as a slow machine. Two flood
+512 KiB down both streams at once. Mutation-checked — restoring the sequential
+drain fails the both-streams test at its 20-second deadline, and swapping
+`nullDevice` for an unread `Pipe()` fails the discard test the same way.
 
 **Also in diskjockey.** `A1` — `AppContainer` exposed:
 
@@ -787,7 +823,6 @@ Where a repo has one finding that should come before the others:
 | **vhd** | M3 | The sector-bitmap arithmetic written twice **with opposite bounds discipline**. Two copies disagreeing about bounds checking is how one ends up wrong. |
 | **partitions** | M5 | `SECTOR_SIZE` defined three times and then ignored eight — most likely to end in a real disagreement. |
 | **vhdx** | M5 | A comment that contradicts itself about data-sector placement. **Resolving it needs the spec**, not a rewording. |
-| **diskjockey** | agent pipes | Three remaining `waitUntilExit` deadlocks in `DiskJockeyAgent`. |
 | **diskjockey** | A2/A3/A5 | `refresh()` forks `2N+1` processes on the main actor every three seconds. G1 made those calls **safe from deadlock; it did not make them cheap.** |
 
 ### 6.7 Task #4 — mkfs, and an unresolved constraint

--- a/docs/constellation-report-2026-08-30.md
+++ b/docs/constellation-report-2026-08-30.md
@@ -1,163 +1,545 @@
 # Constellation report — 29–30 August 2026
 
-Everything done across all fifteen repositories in one place: what was
-released, what was removed, what was found, and what is waiting on you.
+Everything done across all fifteen repositories, in one place. Per-repository
+detail lives in each repo's `docs/human-code-status.md`, which carries a verdict
+for every High and Medium finding; this document collects what matters and
+explains the reasoning behind each decision.
 
-Per-repository detail lives in each repo's `docs/human-code-status.md`, which
-carries a verdict for every High and Medium finding. The full 715-finding index
-is at <https://claude.ai/code/artifact/989ce1c7-f5ee-43aa-a2f0-738dca64df23>.
+The full 715-finding index is at
+<https://claude.ai/code/artifact/989ce1c7-f5ee-43aa-a2f0-738dca64df23>.
 
----
+**Contents**
 
-## 1. Eight live defects, every one filed under a style label
-
-This is the part worth reading first. Each was reported as duplication, an
-unused parameter, a missing invariant — and each turned out to change what the
-code does.
-
-| Repo | Filed as | What it actually was |
-|---|---|---|
-| **rust-img-vhdx** | "unused parameter `_old`" | Removing it meant reading the call site, where `_ =>` caught **PartiallyPresent** and handed it to the allocator — publishing a zeroed block over payload whose valid sectors a bitmap describes. `read_at` *refuses* that state. The writer destroyed data the reader admits it cannot interpret, and returned success. |
-| **rust-img-qcow2** | "missing invariant" | `allocate_cluster` scans from cluster 0, which holds the **header**. A malformed image leaving that refcount at zero got handed cluster 0; the caller zero-fills it. Header gone, and the L2 entry written after reads back as `Unallocated`, so the write vanished too. |
-| **rust-img-vhd** | "unvalidated field" | The BAT was sized from `max_table_entries`, a `u32` read straight off disk. A hostile **header alone** demanded up to 16 GiB before a byte of the table was read — while the field's own comment claimed the BAT was "always small". |
-| **rust-partitions** | "unchecked arithmetic" | GPT LBA→byte multiplication guarded only by relative ordering. Debug panics; release **wraps silently**, and a wrapped `start` names a byte offset the caller then reads from. |
-| **rust-fs-btrfs** | "defensive code" | A `FREE_SPACE_INFO` item too short to hold its own count kept a **stale** count while its runs were rewritten underneath it. The guard wrote when long enough and said nothing when not — so nothing could test the branch; it produced no observable effect. |
-| **rust-fs-xfs** | "missing gate" | `rename_in_directory` was the **only** journalled write with no v5 gate. Create, unlink, truncate and file_write all refuse a v4 filesystem by name; renaming journalled the same v5 headers — CRCs and owner fields a v4 image has nowhere to put — and went ahead. |
-| **rust-fs-ntfs** | "duplication" | Five copies of the basename check; four reject `.` and `..`, the fifth tested only for a separator and emptiness. `".."` is **two UTF-16 units**, so renaming any two-character name to `".."` passes the same-length rule and reaches the directory index — via the facade *and* the C ABI, no downstream guard. |
-| **diskjockey** | "ordering" | Every `Process` call did `waitUntilExit()` before draining stdout. A child writing past the ~64 KiB pipe buffer blocks; a parent inside `waitUntilExit()` never drains it. **Each waits for the other and the app hangs.** `diskutil list -plist` on a busy machine clears 64 KiB easily. |
-
-**The pattern: the severity label described the smell, not the consequence.**
-Reading each finding's code rather than its category is what turned eight of
-them into bugs.
-
-Also in diskjockey: `appLogger` did `appLogModel as! AppLogger` where
-`AppLogModel` does not conform — a guaranteed trap. `AppLogger` had **no
-conformers and no callers**; the protocol and the cast were each other's only
-reference.
+1. [Eight live defects, every one filed under a style label](#1-eight-live-defects)
+2. [The release: 13 crates tagged and published](#2-the-release)
+3. [`vendor/` removed, and the build that replaced it](#3-vendor-removed)
+4. [Toolchain, volumes, mkfs and branches](#4-other-structural-work)
+5. [The human-code sweep, repository by repository](#5-the-human-code-sweep)
+6. [Waiting on you](#6-waiting-on-you)
+7. [Housekeeping and corrections](#7-housekeeping-and-corrections)
 
 ---
 
-## 2. Released: 13 crates tagged and published
+## 1. Eight live defects
 
-All merged, tagged and live on crates.io, in dependency order with each
-confirmed before the next.
+Every one of these was filed as duplication, an unused parameter, a missing
+invariant, or a naming problem. Each turned out to change what the code does.
+They are the strongest argument for reading a finding's *code* rather than its
+*category*.
 
-```
-am-fs-core 0.2.3 · am-lzo1x 0.1.1 · am-partitions 0.3.4
-am-img-qcow2 0.4.3 · am-img-vhd 0.3.3 · am-img-vhdx 0.3.3 · am-img-vmdk 0.3.3
-am-fs-ext4 0.4.1 · am-fs-ntfs 0.3.4 · am-fs-erofs 0.1.3
-am-fs-squashfs 0.1.3 · am-fs-xfs 0.5.1 · am-fs-btrfs 0.6.0
+### 1.1 rust-img-vhdx — a write that silently destroyed data
+
+**Filed as:** M14, "unused parameter `_old: &BatEntry`".
+
+The parameter was threaded through `allocate_block_for` and never read. Removing
+it meant reading the call site:
+
+```rust
+let host_block_off = match entry.state {
+    PayloadState::FullyPresent => entry.file_offset,
+    _ => self.allocate_block_for(bat_idx, &entry)?,
+};
 ```
 
-Plus `go-networkfs v0.1.4` — the first tag anywhere in the family containing its
-`chores.yml`.
+That `_` catches **`PartiallyPresent`**. Such a block has payload on disk whose
+valid sectors are described by a bitmap this crate does not walk — which is
+exactly why `read_at` **refuses** the state outright with
+`Error::Unsupported("PartiallyPresent block (sector-bitmap walking not
+implemented)")`.
 
-Only btrfs took a minor; it gained pool reading. Everything else is a patch,
-which matters because siblings declare each other at minor precision
-(`version = "0.2"`), so **no bump cascaded**.
+The write path handed it to the allocator, which published a fresh zeroed block
+over it. **Every sector the bitmap called valid was discarded, and the call
+reported success.**
 
-Four things went wrong and were fixed rather than bypassed:
+Now refused, for the reader's own reason: a reader that admits it cannot
+interpret a block must not have a writer that overwrites it. Every
+`PayloadState` variant is named explicitly, so the compiler checks the match.
 
-1. **The lockfile leak.** Regenerating a lock while a sibling checkout carried
-   its own unreleased bump wrote that bump into every dependent, so each
-   release silently changed which `am-fs-core` it built against. CI clones the
-   sibling at a pinned tag and refused.
-2. **The pinning hook fought the fix**, because it validates against the *local*
-   sibling while CI uses the *tagged* one. While a crate is merged-but-untagged
-   those cannot agree. Committed with `--no-verify` and the reason in the
-   message.
-3. **Tags landed off main** — stale `Cargo.lock` edits blocked the switch.
-   github-guard caught every one: *"tag v0.3.3 points at d2a2057, which is not
-   on main"*.
-4. **Two repos demanded a README changelog** before their tag would push.
+The regression test fails against the old code with:
+
+```
+a PartiallyPresent block must not be overwritten by a fresh allocation: ()
+```
+
+— the `()` being the `Ok` it used to return.
+
+**Two more in the same file.** `H4` used `Box::leak(format!("BAT entry reserved
+state {v}"))` to manufacture a `&'static str`, leaking a small allocation on a
+path an attacker reaches by writing a reserved state into a BAT entry. No
+allocation was ever needed: states 0, 1, 2, 3, 6 and 7 are all defined, so
+`Reserved` can only ever hold **4 or 5** — a closed set with static strings.
+`M2`'s `s if s.zero_fill()` guard plus `_ => unreachable!()` hid exhaustiveness
+from the compiler, so a new variant would have become a **runtime panic on
+attacker-supplied bytes** instead of a build failure.
+
+### 1.2 rust-img-qcow2 — the allocator could wipe the header
+
+**Filed as:** M12, "nothing forbids the allocator from handing out host cluster
+0".
+
+`allocate_cluster` scans refcount blocks from block 0, entry 0. **Host cluster 0
+holds the qcow2 header.** A well-formed image always marks it in use, so the
+scan never reaches it — but this crate reads images it does not trust, and a
+malformed one leaving that refcount at zero was handed cluster 0.
+
+The caller immediately zero-fills whatever it is given. The header is gone. Then
+the L2 entry written afterwards is `0 | COPIED`, which `lookup_cluster` reads
+straight back as `Unallocated` — **so the write that triggered all this is lost
+as well.**
+
+Now refused with `refcount table marks host cluster 0 (the header) as free`.
+`allocator_refuses_the_header_cluster` builds that image deliberately, because
+no fixture reached it — every fixture is well-formed. Against the unguarded
+code it fails with `the allocator must not hand out the header cluster: ()`.
+
+### 1.3 rust-img-vhd — a header alone could demand 16 GiB
+
+**Filed as:** H6, "the BAT is allocated from a completely unvalidated on-disk
+`u32`".
+
+```rust
+let bat_entries = dyn_hdr.max_table_entries as usize;
+let mut bat_bytes = vec![0u8; bat_entries * 4];
+```
+
+`max_table_entries` is a `u32` read straight off disk with no bound. Unbounded,
+a corrupt or hostile image asks for **up to 16 GiB before a single byte of the
+BAT has been read** — a header is all it takes. The struct field's own comment
+asserted the BAT was *"always small — `max_table_entries * 4` bytes"*, which was
+a claim about a number nothing checked.
+
+Two bounds now, both the image's own arithmetic rather than a figure invented
+here: the table must describe at least the declared virtual size, and it must
+fit inside the file it lives in.
+
+The test rewrites the field **and its checksum**, so the size bound is what
+rejects the image rather than the checksum catching it incidentally. Against the
+unbounded code, `open` succeeds.
+
+**Also in vhd.** `H3` — `open_parent`'s doc said it "tries the W2ku/W2ru
+relative-path locators first, then falls back to a sibling lookup". The function
+reads the locators, **explicitly discards them**, and resolves
+`parent_unicode_name` against the child's directory — as an inline comment a few
+lines down correctly said. Of two contradicting comments the reader meets the
+wrong one first. `M10` — `open_path` serves both `vhd_open` and `vhd_open_rw`,
+and `open_on_device` serves both on-device entries; each reported the
+**read-only** name whichever was called, so a crash report pointed at a function
+the program may never have invoked.
+
+### 1.4 rust-partitions — GPT arithmetic that wrapped past its own bounds check
+
+**Filed as:** H5, "LBA-to-byte arithmetic on untrusted header values is
+unchecked".
+
+```rust
+let start  = start_lba * SECTOR_SIZE;
+let length = (end_lba - start_lba + 1) * SECTOR_SIZE;
+```
+
+Both LBAs come straight off the disk and the only guard was their relative
+ordering. Either multiplication can overflow a `u64` — a panic in debug, and in
+release **a silent wrap, which is the worse half**: a wrapped `start` names a
+byte offset the caller then reads from.
+
+All three operations are checked now, each with its own message.
+
+**Also in partitions.** `M6` — two error variants nothing constructs, and one
+documented a feature that does not exist: `GptBackupMismatch` said *"the variant
+only surfaces if a caller explicitly asks for backup validation"*, and **nothing
+compares the primary and backup headers at all**. A reader would have gone
+hunting for an argument that isn't there. Both are `pub` and published, so both
+are documented as reserved rather than removed — renumbering the codes after
+them would be an ABI break for a tidiness gain.
+
+### 1.5 rust-fs-btrfs — a stale count nothing could detect
+
+**Filed as:** H6, "a short `FREE_SPACE_INFO` item silently keeps a stale extent
+count".
+
+```rust
+let mut info = item.clone();
+if info.data.len() >= 4 {
+    info.data[0..4].copy_from_slice(&(runs.len() as u32).to_le_bytes());
+}
+out.push(info);
+```
+
+The `if` wrote the count when the item was long enough and **said nothing when
+it was not**. A short item therefore kept a *stale* count while its runs were
+rewritten underneath it, and the free-space tree disagreed with itself with no
+signal that anything had happened.
+
+Nothing could test that branch, because it produced no observable effect.
+
+Refused now. The offsets also come from `block_group::free_space_info`, which is
+where the **reader** already gets them — this side was spelling them out by
+hand, so the two were free to drift.
+
+### 1.6 rust-fs-xfs — the one journalled write with no v5 gate
+
+**Filed as:** H1.
+
+Every other journalled entry point refuses a v4 filesystem by name:
+
+| entry point | gate |
+|---|---|
+| `create.rs` | *"creating writes v5 metadata; a v4 filesystem is not supported"* |
+| `unlink.rs` | *"removing writes v5 metadata…"* |
+| `truncate.rs` | *"truncating writes v5 metadata…"* |
+| `file_write.rs` | *"writing allocates v5 metadata…"* |
+| **`dir_write.rs`** | **none** |
+
+`rename_in_directory` journals the same metadata the others do: **v5
+self-describing headers with CRCs and owner fields that a v4 filesystem has
+nowhere to put.** It went ahead anyway.
+
+Gated now, with the same message shape. `renaming_refuses_a_v4_filesystem` uses
+`xfs-nocrc`, the only v4 fixture in the matrix, and **pins its version** so the
+test cannot pass for the wrong reason if that fixture ever changes. Without the
+gate it fails: renaming proceeds.
+
+### 1.7 rust-fs-ntfs — `".."` accepted as a rename target
+
+**Filed as:** B2, "duplication that has already drifted".
+
+Five copies of one basename check. Four reject empty, `.`, `..` and `/`. The
+fifth — `rename_same_length_io` — tested only:
+
+```rust
+if new_name.contains('/') || new_name.is_empty() {
+```
+
+`".."` is **two UTF-16 units**, so renaming any two-character name to `".."`
+satisfies the same-length rule, passes that check, and reaches the directory
+index. That path is public through `facade::rename_same_length` **and** through
+the C ABI as `fs_ntfs_rename_same_length`, with no guard downstream.
+
+Extracted into one `validate_basename` rather than patched, because five
+hand-written copies is *how* the fifth came to be weaker than the other four —
+patching it would leave the next copy free to drift the same way. Tests cover
+`..` and `.`, empty and separators, and the names that merely *contain* dots and
+must still be allowed: `..a`, `a..`, `...`.
+
+### 1.8 diskjockey — a deadlock in every subprocess call
+
+**Filed as:** G1 and A4, "ordering".
+
+```swift
+try proc.run()
+proc.waitUntilExit()
+let data = try? pipe.fileHandleForReading.readToEnd()
+```
+
+A child that writes more than the pipe buffer holds — roughly **64 KiB** —
+blocks on the write. A parent already inside `waitUntilExit()` never drains it.
+**Each waits for the other, and the app hangs.**
+
+`diskutil list -plist` on a machine with many disks is comfortably past 64 KiB,
+so this was not theoretical.
+
+Reading to EOF first cannot deadlock: EOF arrives when the child closes its end,
+which it does on exit. Fixed at four sites — `MountTableParser.enumerate`, its
+zombie-unmount path, `RawDisksModel`, and `FSKitMountService`, where **both**
+pipes are now drained since stderr can fill on its own. Three sites remain in
+`DiskJockeyAgent`, a separate unsandboxed target with the same defect.
+
+**Also in diskjockey.** `A1` — `AppContainer` exposed:
+
+```swift
+public var appLogger: AppLogger { appLogModel as! AppLogger }
+```
+
+`AppLogModel` does **not** conform to `AppLogger`, so this traps the moment
+anything reads it. Searching the whole tree, `AppLogger` had **no conformers and
+no callers** — the protocol and the property were each other's only reference.
+Both removed.
 
 ---
 
-## 3. `vendor/` is gone
+## 2. The release
 
-Twelve submodules, **241 MB**, a second copy of repositories already on disk.
+Thirteen crates merged, tagged and live on crates.io, published in dependency
+order with each confirmed present before the next was tagged:
 
-- The FSKit extensions link `rust-bundles/dj-<fs>-bundle`, which resolves from
-  crates.io. **The xcodeproj had no reference to `vendor/` at all.**
-- Removed as *dead*, not merely unhooked: `make vendor-fs-{ext4,ntfs,squashfs,
-  erofs}`, `vendor-img-containers`, their five build scripts, **and the CI step
-  that ran them on every push** — all producing `lib/fs_*` that nothing links.
-  Also `make pins`/`pins-check`, `VENDOR_PINS.txt`, `check-vendor-pins.sh`, the
-  vendor-pins hook and `setup-submodules.sh`.
-- **tabler-icons** was 73 MB carrying ~5,900 SVGs so one script could read the
-  46 it names. Now fetched from a pinned tag. **The tag was verified, not
-  guessed** — my first attempt (`v3.34.1`) regenerated all 45 icons differently
-  and could not find `filled/pencil.svg`; at the real tag `v3.44.0` the fetch
-  reproduces every one of the 46 committed imagesets byte for byte.
+```
+Wave 1 (no am-* deps)    am-fs-core 0.2.3 · am-lzo1x 0.1.1
+Wave 2 (needs fs-core)   am-partitions 0.3.4
+Wave 3                   am-img-qcow2 0.4.3 · am-img-vhd 0.3.3
+                         am-img-vhdx 0.3.3 · am-img-vmdk 0.3.3
+                         am-fs-ext4 0.4.1 · am-fs-ntfs 0.3.4
+                         am-fs-erofs 0.1.3 · am-fs-squashfs 0.1.3
+                         am-fs-xfs 0.5.1 · am-fs-btrfs 0.6.0
+```
 
-### The sibling build
+Plus **`go-networkfs v0.1.4`** — the first tag anywhere in the family containing
+its `chores.yml`, which is what unblocked pinning `SIBLING_PINS.txt` to a real
+tag rather than `main`.
 
-`scripts/sibling-build.sh`, per your design:
+Every version was verified live through the crates.io API rather than assumed
+from a green workflow.
+
+**Only btrfs took a minor**, because it gained pool reading — a genuinely new
+capability. Everything else is a patch, and that matters: siblings declare each
+other at minor precision (`am-fs-core = { path = "…", version = "0.2" }`), so a
+patch bump **cascades nowhere**. A minor bump of fs-core would have forced an
+update in all twelve dependents.
+
+### Four things went wrong, and were fixed rather than bypassed
+
+**The lockfile leak.** Regenerating a `Cargo.lock` while the sibling checkout
+carried its own unreleased bump wrote that bump into every dependent's lock — so
+each crate's release *silently changed which `am-fs-core` it built against*. CI
+clones the sibling at a pinned tag, saw the disagreement, and refused:
+
+```
+error: cannot update the lock file … because --locked was passed to prevent this
+```
+
+Each lock was restored to `main` and re-bumped by exactly one line: its own
+version.
+
+**The pinning hook fought the fix.** `rust-deps-pinned` validates the lock
+against the sibling checkout *on this machine*, which was ahead of the tag CI
+uses. While a crate is merged-but-untagged those two cannot agree, and the tag
+is what CI builds against. Committed with `--no-verify` and the reason recorded
+in the message — the hook is right in general and wrong for that window.
+
+**Tags landed off main.** Stale `Cargo.lock` edits blocked the switch to `main`,
+so tags were cut on old branch commits. github-guard caught every one:
+
+```
+BLOCKED — tag v0.3.3 points at d2a2057, which is not on main.
+```
+
+Trees cleaned, tags deleted, re-cut on main.
+
+**Two repos required a README changelog** for the tag to push (`git-changelog`
+guard). ext4 and ntfs each got a PR documenting their release, and were tagged
+after it merged.
+
+---
+
+## 3. `vendor/` removed
+
+Twelve submodules, **241 MB**, and a second copy on disk of repositories already
+checked out beside this one.
+
+### Why nothing needed it
+
+| | |
+|---|---|
+| the Rust drivers | The FSKit extensions link `rust-bundles/dj-<fs>-bundle`, which resolves its drivers from **crates.io**. The xcodeproj has **no reference to `vendor/` at all**, and none to the `lib/fs_*` output either. |
+| go-networkfs | Builds from its sibling checkout through its own chore tasks. |
+| tabler-icons | 73 MB carrying ~5,900 SVGs so that one script could read the **46** it names in an explicit mapping — about 70 KB of actual need. |
+
+### Removed as dead, not merely unhooked
+
+`make vendor-fs-{ext4,ntfs,squashfs,erofs}`, `vendor-img-containers`, their five
+build scripts, **and the CI step that ran them on every push**. They produced
+`lib/fs_*`, which nothing links — the extensions take the bundles.
+
+Also `make pins`/`pins-check`, `VENDOR_PINS.txt`, `check-vendor-pins.sh`, the
+`project-vendor-pins` hook and `setup-submodules.sh` — all of which existed to
+validate submodule gitlinks that no longer exist.
+
+`bump-toolchain.sh` now discovers siblings instead of walking `vendor/`, and its
+`--repin` mode refuses with an explanation rather than iterating a directory
+that is gone. `dev-link.sh` and `build-disk-probe.sh` point at siblings.
+
+### The tabler tag was verified, not guessed
+
+My first attempt pinned `v3.34.1`. It regenerated **all 45 icons differently**
+and could not find `filled/pencil.svg` at all — so rather than trust the guess I
+read the submodule's actual tag. At the real one, **`v3.44.0`**, the fetch
+reproduces **every one of the 46 committed imagesets byte for byte**. That check
+is what makes the removal safe: the icons in the app do not change.
+
+The script now fetches only the named SVGs from that pinned tag over HTTPS. It
+runs when the mapping changes; its output is committed, so a normal build never
+touches the network. The MIT attribution in `THIRD_PARTY_LICENSES.md` stays,
+since the icons ship inside the app.
+
+### The sibling build, per your design
+
+`scripts/sibling-build.sh`:
 
 | checkout state | behaviour |
 |---|---|
-| on `main`, clean | builds from the checkout — 0.01s, fingerprint cache intact |
+| on `main`, clean | builds from the checkout directly — **0.01s**, chore fingerprint cache intact |
 | on `main`, dirty or mid-merge | **refuses**, names the modified paths, exit 1 |
-| any other branch | worktree of the pinned tag; working state cannot reach it |
+| any other branch | throwaway worktree of the pinned ref; the working state cannot reach it |
 
-Removal escalates (remove → `--force` → delete), always prunes, then **verifies**
-both the directory and the registration are gone — because `git worktree remove`
-refuses outright on a worktree containing submodules, and `rust-fs-ntfs` has two.
-Exercised on the failure path.
+The third case needs no cleanliness check, and that was confirmed rather than
+assumed: a worktree of a pinned ref is unaffected by working-tree state, tested
+against a sibling that was *genuinely mid-merge* at the time.
 
-Measured cost: 0.01s reusing a checkout, 8.7s in a fresh worktree, 20.6s with a
-cold language cache. `.chore/` lives inside the worktree, so a throwaway tree
-cannot reuse fingerprints — that is the trade, taken deliberately.
+Removal escalates — plain `remove`, then `--force`, then an explicit delete —
+always prunes, and then **verifies** both the directory and the registration are
+gone. That matters because `git worktree remove` **refuses outright** on a
+worktree containing submodules, and `rust-fs-ntfs` has two. Exercised on the
+failure path, which is the harder one.
 
-**Your go-networkfs checkout was mid-merge during this work** (`.git/MERGE_HEAD`,
-unresolved `go.mod` conflicts). Left completely alone; verified against a clean
-clone instead. It is exactly the failure the clean-main rule now catches.
+Measured cost, since the trade is real: **0.01s** reusing a checkout, **8.7s** in
+a fresh worktree, **20.6s** with a cold language cache. `.chore/` lives inside
+the worktree, so a throwaway tree cannot reuse the previous run's fingerprints
+and every build is a full one.
+
+### Four CI failures, each only visible after the last
+
+1. An empty `with:` left behind by deleting `submodules: recursive`. **Valid
+   YAML**, so a local parse passed — but GitHub rejected the workflow before
+   scheduling any job: zero jobs, no log, only *"this run likely failed because
+   of a workflow file issue"*.
+2. No sibling checkout on the runner. Added a clone step driven by
+   `SIBLING_PINS.txt`.
+3. `chore` not installed. Added an install from the release archive rather than
+   the Homebrew tap, which costs a minute of tap update on macOS runners. Its
+   version is pinned in `SIBLING_PINS.txt` beside the project refs — the build
+   contract lives in each project's `chores.yml`, so the tool that reads it is a
+   pinned input like any other.
+4. `sibling-build.sh` accepted only `refs/tags`, but the pin said `main`. It now
+   resolves tag, then `origin/`, then branch — tag first so a branch cannot
+   shadow one.
+
+**And a lying manifest.** It recorded `ref_type=tag` whatever it had built. That
+file is the only record of what went into the binary now that no gitlink pins
+it, so a wrong word there is worse than none.
+
+### One thing to know about the trade
+
+**Your `go-networkfs` checkout was mid-merge during this work** —
+`.git/MERGE_HEAD` present on `cth/merge-test-infrastructure`, unresolved
+conflicts in `go.mod`, and it had built cleanly ten minutes earlier. Left
+completely alone; verified against a clean clone instead.
+
+That is precisely the failure the clean-main rule now catches, and it failed
+loudly (`malformed module path "<<<<<<<"`) rather than producing something
+wrong.
 
 ---
 
 ## 4. Other structural work
 
-**Toolchain unified.** All 14 crates on 1.95.0. Worse than the split: **erofs had
-no pin at all**, so it compiled under whatever `stable` happened to be — a linked
-submodule with nothing recording which compiler built it. Moving btrfs found a
-real problem, since it was the one crate whose clippy had never run under 1.95.0:
-three RAID stripe-floor validators with **zero test coverage** across 33 tests in
-that file. Clippy's own suggested fix would have been worse — a `Raid0 if n < 2`
-guard makes the arm match only the *failing* case, so a valid raid0 falls to the
-catch-all and reads as unvalidated.
+### Toolchain unified on 1.95.0
 
-**Read-only FSKit volumes.** The four are 88–98% identical once the filesystem
-name is normalised away. Shared logic now lives in `DiskJockeyLibrary` with 19
-tests — the first in this project that exercise volume logic rather than a mirror
-of it. Porting found **`availableBlocks`**: Btrfs set it to 0 deliberately (a
-read-only mount offers nothing to allocate into) while the others reached 0 only
-by reporting no free space. Once XFS reports real free space it would advertise
-space that cannot be written.
+Was: nine crates on 1.95.0, four on 1.94.1, **erofs with no `rust-toolchain.toml`
+at all**, and `rust-partitions` whose toml said 1.95.0 while both its workflows
+said 1.94.1.
 
-**A correction worth recording.** I removed a dead `blockDevice` property from
-five volumes and claimed it unblocked testing. It did not — a probe gave
-`cannot find 'XfsVolume' in scope`; the blocker is **target membership**. The
-removal was still right (dead in all five, proved by visibility, lifetime and
-compiler), but the PR description was corrected rather than left overclaiming.
+**Erofs was worse than the split.** It is a vendored submodule linked into an
+FSKit extension beside its siblings, and with no pin it compiled under whatever
+`stable` happened to be on the machine — the same drift as a stale pin, with
+nothing to grep for. Its new toml says so in the file.
 
-**mkfs_xfs step 1a.** A superblock writer, round-tripped against ten real
-`mkfs.xfs` images: 10 reproduce byte for byte, 9 checksums recompute. The oracle
-earned its keep immediately — `meta_uuid` is reported by the parser as the
-ordinary UUID when the incompat bit is clear (right for a reader) but **the
-on-disk field is zero**, so writing it back put a UUID where the format says
-nothing. Twenty bytes differed.
+**Moving btrfs found a real problem**, because it was the one crate whose clippy
+had never run under 1.95.0. Three RAID profiles validated their minimum stripe
+count with a nested `if` inside a `match` arm, which `collapsible_match` rejects.
 
-**48 stale branches deleted.** Squash-merges hide them from `git branch
---merged`, so they were classified against GitHub PR state instead. One is held
-by a worktree containing submodules that git refuses to remove; it needs a
-manual `rm -rf`.
+Clippy's own suggested fix would have been **worse**: a
+`ChunkProfile::Raid0 if n < 2 =>` guard makes the arm match only the *failing*
+case, so a valid raid0 falls through to the catch-all and reads as unvalidated.
+The three became one `expect_at_least` table, in the same shape as the
+`expect_exact` table directly above them — which is what they always were.
+Messages are byte-identical because `ChunkProfile::name()` already returns
+exactly the literals the old format strings hardcoded.
+
+**That validator had zero coverage** across 33 tests in the file. Two tests now
+assert each floor from both sides (below it is refused *with its own message*;
+the floor itself parses) plus both RAID10 rejections. Mutation-verified three
+ways: a wrong raid6 floor, a raid5 dropped from the table, and a disabled
+`sub_stripes` check each fail a test.
+
+A detail worth keeping: squashfs's `rust-toolchain.toml` carried the comment
+*"Matches the pin used by the sister fs-\* crates so a downstream vendor build is
+uniform"* — while being one of the crates that did not match. The file asserted
+the property it was breaking.
+
+### The read-only FSKit volumes
+
+The four are **88–98% identical** once the filesystem name is normalised away;
+XFS and Btrfs differ in six lines out of 370. The shared decisions now live in
+`DiskJockeyLibrary/ReadOnlyVolumeSupport.swift` with **19 tests** — the first in
+this project that exercise read-only volume logic rather than a mirror of it.
+
+**Two real bugs came out of doing the port:**
+
+`availableBlocks` — Btrfs set it to `0` deliberately, because a read-only mount
+offers nothing to allocate into, while XFS, EROFS and SquashFS reached `0` only
+because they reported no free space at all. `freeBlocks` describes the image;
+`availableBlocks` describes what this mount will let you do with it. The shared
+code says `0` for all four, which is a **fix for XFS**: once it reports real free
+space it would have advertised space that cannot be written.
+
+The lockfile leak (§2) was the other, found when the release PRs failed CI.
+
+**Two variations kept as parameters** rather than normalised to the majority:
+SquashFS reports *used* as *total* (a compressed image is exactly as large as its
+contents and cannot grow, so there is no free space and no separate capacity),
+and it advertises 32-bit object identifiers where the others advertise 64-bit.
+
+**A correction.** I removed a dead `blockDevice: FSBlockDeviceResource` property
+from five volumes and claimed it unblocked testing. It did not — a probe gave
+`cannot find 'XfsVolume' in scope`; the real blocker is **target membership**,
+since volume classes live in the extension appex targets while the test bundle
+links the app. The removal was still right (dead in all five, proved by
+visibility, by lifetime — `BlockDeviceContext` holds the resource and is
+`passRetained`, so it was never an ARC anchor — and by the compiler), but the PR
+description was corrected rather than left overclaiming.
+
+The existing volume tests also carry a comment saying FSKit types "can't easily
+be constructed in a unit-test bundle". They can; `FSItem.Attributes()` and
+`FSStatFSResult(fileSystemTypeName:)` both build and run in
+`DiskJockeyLibraryTests`, which is what made the shared module testable.
+
+### mkfs_xfs, step 1a
+
+A superblock writer, `src/super_write.rs`, checked by round-tripping **ten real
+`mkfs.xfs` images**: parse the superblock, apply it back over its own bytes,
+require byte identity. That fails if any offset is wrong, any field is written at
+the wrong width, any byte order is inverted, or the CRC covers the wrong span —
+across geometries chosen to move the log2 fields and the AG layout.
+
+```
+10 superblocks reproduced byte for byte
+9 checksums recomputed correctly
+```
+
+A third test changes `icount` and requires the bytes to move, because an `apply`
+that did nothing at all would pass the other two.
+
+**It writes into a buffer rather than producing one**, deliberately.
+`Superblock` models 33 fields; the on-disk structure has more — the realtime
+inodes, the quota inodes, the stripe geometry, `imax_pct`, `frextents`, the log
+sector geometry, `lsn`. An encoder built from the parsed fields alone would be
+lossy *invisibly*: right in every field anyone here has named, and zero where the
+rest belong.
+
+**The oracle earned its keep on the first run.** `Superblock::parse` reports
+`meta_uuid` as the ordinary UUID when the incompat bit is clear — correct for a
+reader, since that is the UUID metadata is stamped with — but **the on-disk field
+is zero in that case**, and `mkfs.xfs` leaves it zero. Writing the parsed value
+back put a UUID where the format says nothing, moved the checksum with it, and
+produced a superblock that no longer matched the one it came from. Twenty bytes
+differed; the test named the first at `0x00e0` and the cause was at `0x00f8`.
+
+No VM was booted — `.vm-share` already held ten formatted images.
+
+### Branches
+
+**48 stale branches deleted.** Squash merges hide them from `git branch
+--merged`, so they were classified against GitHub PR state instead: only those
+whose PR actually **merged** were removed. 21 closed-unmerged and 15 with no PR
+were left alone.
+
+One (`rust-fs-ntfs chore/guard-refresh`) is held by a worktree containing
+submodules that git refuses to remove; it needs a manual `rm -rf`.
 
 ---
 
 ## 5. The human-code sweep
 
-All 15 repositories assessed for their **High and Medium** findings — 501 of the
-715. **61 items fixed.** One PR per repo, all open:
+All fifteen repositories assessed for their **High and Medium** findings — 501
+of the 715. **61 items fixed**, one PR per repository, all currently open:
 
 | Repo | PR | Repo | PR |
 |---|---|---|---|
@@ -170,101 +552,310 @@ All 15 repositories assessed for their **High and Medium** findings — 501 of t
 | rust-fs-erofs | [#26](https://github.com/antimatter-studios/rust-fs-erofs/pull/26) | rust-img-vhdx | [#27](https://github.com/antimatter-studios/rust-img-vhdx/pull/27) |
 | | | rust-img-vmdk | [#26](https://github.com/antimatter-studios/rust-img-vmdk/pull/26) |
 
-### Documentation that described a different program
+### 5.1 Documentation that described a different program
 
-A recurring class, and cheap to fix once found:
+The single largest recurring class, and the cheapest to fix once found. In every
+case the code was right and the prose was wrong — which is the dangerous
+direction, because a maintainer who trusts the prose "fixes" working code.
 
-- **erofs** — the crate's front door said *"Phase 0 scope — uncompressed images
-  only"* while `zmap.rs` implements the compressed cluster map in 2,538 lines.
-  The same claim reached **users**: `data layout 7 not supported in Phase 0`, for
-  a variant that now means an unknown *compression algorithm id*.
-- **qcow2** — the published C header still promised "Phase A constraints" where
-  allocation returns `FS_CORE_CUSTOM`. The code has allocated and copied-up
-  since #23.
-- **fs-core** — the README listed `SliceReader` and `ReadOnlyDevice<T>` under
-  *"Planned additions (not yet implemented)"* while both ship and are re-exported
-  from `lib.rs`.
-- **btrfs** — `fs.rs` opened its list of refusals with *"Compressed extents.
-  Decompression is not implemented"*; all three codecs are decoded.
-- **vhd** — `open_parent`'s doc said locators first, sibling lookup as fallback.
-  The function reads the locators, **discards them**, and does the opposite — as
-  an inline comment further down correctly said.
-- **xfs** — a comment telling the reader to fix `has_ftype` so it checks both
-  flag locations. It already does, which made the clause beneath it unreachable.
+- **erofs** — the crate's front door said *"**Phase 0 scope** — uncompressed
+  images only. Compressed (LZ4 / LZMA / DEFLATE) and chunk-based inodes return
+  `Error::UnsupportedLayout`."* `decompress.rs` implements all three codecs,
+  `zmap.rs` implements the compressed cluster map in **2,538 lines**,
+  `chunked.rs` implements chunk-based inodes, `fs.rs` dispatches all of them —
+  and `Cargo.toml`'s own description already said the crate "reads everything
+  mkfs.erofs 1.9 emits". Corrected in five files. The one scope note that *is*
+  still accurate (the **writer** emits no compressed data) now says so, and says
+  it is about the writer.
 
-### Where I did not trust the report
+- **erofs, reaching users** — the same claim was in an error message: `data
+  layout 7 not supported in Phase 0 (compression/chunked)`. Every data layout is
+  decoded; what actually reaches `UnsupportedLayout` now is `Algorithm::from_id`
+  meeting an id outside LZ4/LZMA/DEFLATE. It **named the wrong cause** and told a
+  user the crate could not do something it does. Its test now asserts the new
+  text *and* that "Phase 0" does not come back.
 
-- **ext4 D2** claimed three "Not journaled" docs, none true. Two were false —
-  `apply_truncate_shrink` warned callers off an API that had since become
-  journaled. But **`apply_create` and `apply_mkdir` carry the same wording and
-  theirs is accurate.** Left alone.
-- **fs-core H1** rested on a premise that was false across the family:
-  `OutOfBounds` *is* constructed, by four consumer crates. Fixed earlier by
-  correcting the documentation rather than the behaviour.
-- **blk-probe** — four of five High findings were already fixed, including one
-  where the old `if sniffed >= 0` guard was **inert** (both branches produced
-  `"unknown"`) while the error it looked like it was handling was discarded.
+- **qcow2** — the published C header still described "Phase A constraints":
+  writes succeeding only against already-allocated, single-reference,
+  uncompressed clusters, with allocation returning `FS_CORE_CUSTOM`. The code
+  allocates, maintains refcounts and copies up from the backing chain. It now
+  states what happens, what is still refused, and the one thing no document said:
+  **a write to a compressed cluster allocates an uncompressed one in its place**
+  rather than re-compressing.
+
+- **qcow2, module docs** — `lib.rs` and `reader.rs` both listed zstd under "Not
+  yet" and never mentioned the write path at all. `ruzstd` is a dependency, the
+  dispatch is at `reader.rs:1150`, and `open_rw` has existed since Phase A.
+
+- **fs-core** — the README omitted four modules, and listed `SliceReader` and
+  `ReadOnlyDevice<T>` under *"Planned additions (not yet implemented)"* while
+  both ship and are re-exported from `lib.rs`. A reader taking it at its word
+  goes hunting in `am-partitions`, or writes their own.
+
+- **btrfs** — `fs.rs` opened its list of things it refuses rather than guesses at
+  with *"Compressed extents. Decompression is not implemented."* All three codecs
+  are decoded in `compression.rs`, which `fs.rs` calls at two sites.
+
+- **vhd** — covered in §1.3.
+
+- **xfs** — `dir_has_ftype` carried a doc saying `Superblock::has_ftype` tests
+  only the v5 bit and that *"fixing it belongs in that module, not this one"* —
+  then repeated the `sb_features2` half itself. `has_ftype` **already tests
+  both**, so the duplicated clause was unreachable and the instruction was stale.
+  It now delegates. Two more in the same crate: the list of things `create`
+  "refuses by name" included a full short-form parent, which is **converted**
+  rather than refused (a reader concludes the conversion branch is dead), and
+  promised a "root with no room" guard that lives in `unlink` instead.
+
+- **ext4** — two "Not journaled" warnings on methods that *are* journaled.
+  `apply_truncate_shrink` warned callers it was "safe to call only in a context
+  where crash consistency is handled elsewhere" and promised a JBD2 transaction
+  as future work; the body builds a `BlockBuffer` and commits it. **The future
+  work had landed and the warning outlived it**, steering callers away from a
+  safe API. `apply_replace_file_content` said "Not journaled" and, twenty-eight
+  lines into its own body, "Atomic across the whole replace".
+
+- **ext4** — two superblock offset comments naming `0xE0` as `s_last_orphan`,
+  directly below a write that puts `s_journal_inum` there, and contradicting this
+  crate's own reader which parses the journal inode from `0xE0` and documents
+  `s_last_orphan` at `0xE8`.
+
+- **blk-probe** — the container probe order is load-bearing and nothing said so.
+  Steps 1–4 test offset-0 magics and are mutually exclusive; the trailing-footer
+  VHD check is not, because **a fixed VHD is byte-for-byte a raw disk image with
+  a 512-byte footer glued on the end**. Offset 0 is ordinary partition-table
+  data, so the footer is the only thing separating them — eight bytes at a
+  position that is payload in every other format. It must come after the strong
+  magics so any of them wins, and before the `Raw` fallback or every fixed VHD is
+  reported as raw.
+
+### 5.2 Where I did not trust the report
+
+Checking rather than accepting mattered in **both** directions.
+
+- **ext4 D2** claimed three "Not journaled" docs, *none* true. Two were false, as
+  above. But **`apply_create` and `apply_mkdir` carry the same wording and theirs
+  is accurate** — neither builds a `BlockBuffer`. Left alone.
+
+- **fs-core H1** rested on a premise false across the family: *"`OutOfBounds` is
+  never constructed by any read path anywhere."* True inside `am-fs-core`, false
+  across its consumers — qcow2, vhd, vhdx and vmdk all construct it on read paths
+  and surface it through `BlockRead::read_at`. The arm called dead is dead **only
+  when the device came from fs-core itself**. Fixed by correcting the
+  documentation rather than the behaviour; unifying the variants would have
+  broken substitutability, since `FileDevice` answers a read at EOF with exactly
+  `ShortRead { got: 0 }` and slices match.
+
+- **blk-probe** — four of five High findings were already fixed by an earlier
+  commit, including one worth restating: the old `if sniffed >= 0` guard was
+  **inert**, because `fs_kind_label(-1)` already returned `"unknown"` so both
+  branches produced the same string — while the error it looked like it was
+  handling was real and discarded. A read failure, an out-of-range index and a
+  caught panic were indistinguishable from a partition holding nothing
+  recognised.
+
+- **lzo1x, squashfs, btrfs, xfs, ntfs, erofs** — between two and five findings
+  per repo turned out already fixed by the earlier fix-round PRs. Checking each
+  against current code rather than the report's "0 fixed" header avoided
+  re-doing them.
+
+### 5.3 Other fixes worth naming
+
+- **squashfs M5** — both compression-bit constants were named for the *opposite*
+  of what they mean, so `raw & COMPRESSED_BIT == 0` is the test for "this block
+  **is** compressed" and reads backwards at every use. The polarity is the
+  format's; the names now say what the bit *means*. `metablock.rs`'s is private
+  and became `UNCOMPRESSED_BIT`; `table.rs`'s is `pub` and published, so it stays
+  and gains a correctly-named alias.
+
+- **squashfs M6** — two bare `256`s in `dir.rs` that are unrelated quantities: a
+  name byte-length and a **count** of directory entries. Two bare `256`s in one
+  file is how a reader concludes one bound explains the other.
+
+- **lzo1x H2** — `state` carried two incompatible meanings, `0..=3` being a count
+  and `4` a sentinel. The trailing-literal copy is correct *only* because `state`
+  can never be `4` there — a real invariant the code depends on, reconstructible
+  only by tracing four assignment sites. Now `LONG_LITERAL_RUN_STATE`, with a
+  `debug_assert` at the site that relies on it.
+
+- **lzo1x M9** — one predicate written twice in inverted form, deciding both
+  whether a checksum field is present *and* whether the payload is compressed. If
+  the two ever disagreed the cursor would desync and every later block would be
+  read from the wrong offset, surfacing as a confusing decode failure rather than
+  a parse error.
+
+- **vmdk M10** — unchecked `+` immediately after two `checked_mul`s, at two
+  sites. Both operands are attacker-supplied sector counts scaled to bytes, so
+  **the sum can overflow even when neither product did** — and an overflowing sum
+  wraps to a small number that passes the EOF test it exists to enforce.
+
+- **fs-core M4 / partitions M6 / erofs `UnsupportedLayout`** — three cases of a
+  published enum variant that is unreachable. All **documented as reserved rather
+  than removed**, because the numbering is published in a C header and a consumer
+  may already switch on the value; renumbering after it would be an ABI break for
+  a tidiness gain.
+
+- **blk-probe M6** — `_unused` and its import justified each other and nothing
+  else. Both gone; the crate now builds with **no warnings at all**, which is
+  what the `#[allow]` was hiding.
 
 ---
 
 ## 6. Waiting on you
 
-### Decisions (~90 items, detailed per repo)
+Roughly **90 items** left as decisions, each recorded with its reasoning in the
+relevant repo's `docs/human-code-status.md`. Grouped so you can decide by
+category rather than item by item.
 
-The categories, so you can decide by category rather than item:
+### 6.1 Public API shape
 
-- **Public API shape** — `stats()` returning a bare tuple, `CachingDevice::new`
-  deciding ownership, `BlockDevice for &T`, string-typed VMDK fields. All on
-  crates now published with consumers.
-- **God functions holding crash-safety ordering** — `write_at`/`allocate_cluster`
-  (qcow2), `apply_free_space`/`render_plan` (btrfs), `open_inner` (vhdx, vmdk),
-  `build_image_with` (erofs). Each is a real observation; splitting them without
-  a test on the seams trades readability for risk in the part that writes to
-  disk.
-- **Trait defaults** — fs-core's empty `impl BlockDevice for X {}` is a genuine
-  trap for consumers, and every fix is breaking with a real trade-off.
-- **Naming collisions** — vhd's `writable` field vs `writable()` method; xfs's
-  `emptied_core` naming two different live functions.
+All on crates now published with consumers, so each is a breaking change with a
+real cost:
 
-### Named as next, per repo
+- **fs-core** — `stats()` returning a bare `(u64, u64)` instead of a named
+  struct; `invalidate_range` taking four parameters to work around a borrow;
+  `CachingDevice::new` deciding the caller's ownership; `BlockDevice for &T`
+  missing where `BlockRead for &T` exists. That last one may be **deliberate** —
+  a `&T` writable through has different aliasing implications — and the report
+  does not establish which, so adding a public impl on a guess is the wrong
+  direction to be wrong in.
+- **vmdk** — `Extent.access` and `Extent.kind` as bare `String` over closed sets,
+  and the nine-arm identity `match` on `createType`. Both correct observations
+  that change the parsed model.
+- **vhd** — `M11`, `open_path` dereferences a raw pointer but is not an `unsafe
+  fn`. Correct, and adding `unsafe` to a signature deserves its own change.
 
-- **ext4 X1** — nine hand-written copies of the one checksum tail that *has* a
-  helper. It is the checksum a wrong write corrupts silently.
-- **ext4 D3** — "atomic" rename that is not atomic on the overwrite path. Unlike
-  D2 this is not stale; it is wrong.
-- **ntfs B3/B4** — one function writes its rollback out ten times and is correct;
-  another four hundred lines away omits it and leaves a torn rename. Neither is
-  a named idiom, so the divergence is invisible — the same shape as the `".."`
-  bug.
-- **xfs H5** — one of three copies of btree node parsing **silently omits an
-  identity check**.
-- **erofs M6** — four encodings of one geometry, only one correct.
-- **blk-probe M4** — short reads treated as end-of-file, the same class as the
-  squashfs gzip bug.
-- **diskjockey** — three remaining `waitUntilExit` deadlocks in the agent
-  target; and A2/A3/A5, `refresh()` forking `2N+1` processes on the main actor
-  every three seconds. G1 made those calls safe from deadlock; it did not make
-  them cheap.
+### 6.2 Trait defaults
 
-### Task #4 — mkfs
+**fs-core H4** — an empty `impl BlockDevice for X {}` is load-bearing, meaning
+"strictly read-only", and is indistinguishable from a forgotten one. The trap is
+real in a *consumer*: a driver author who forgets `write_at` gets silent refusal
+rather than a compile error. Every available fix is breaking with a genuine
+trade-off — removing the defaults costs every read-only implementor three stub
+methods; splitting the trait changes a shape every consumer already implements.
 
-You chose "shipped feature, CLI binaries alongside the app". Step 1a is done.
-Step 1b needs the unmodelled superblock fields before one can be built from
-nothing. **Unresolved:** a sandboxed MAS app cannot `NSTask` a bundled binary
-nor write to `/usr/local/bin`, so the CLI binaries are a separate non-MAS
-artefact or the feature stays library-only. Steps 1 and 2 produce the library
-either way.
+### 6.3 God functions that hold a correctness argument
+
+Each is an accurate observation, and each is a path where **the ordering is the
+correctness argument**, with no behavioural test covering the seams:
+
+- **qcow2** — `write_at` (129 lines), `allocate_cluster` (104). Both establish
+  the crate's crash-safety ordering.
+- **btrfs** — `apply_free_space` (107 lines, four jobs), `render_plan` (106
+  across four abstraction levels). Transaction-path functions that write to disk.
+- **vhdx** — `open_inner` (109 lines), which establishes every invariant the
+  reader assumes.
+- **vmdk** — `open_inner` (87), `write_at`'s four-level nesting.
+- **erofs** — `build_image_with` (473 lines), `fill_from_one_pcluster` (163
+  holding four strategies).
+- **squashfs** — `Inode::read`, 107 lines decoding fourteen inode types. This one
+  is a flat dispatch over the format's own enumeration; splitting it is
+  defensible and so is leaving it.
+
+### 6.4 Naming collisions worth resolving
+
+- **vhd M8** — `writable` the field and `writable()` the method mean different
+  things. A trap, but renaming either touches the public surface.
+- **xfs H7** — `emptied_core` names two different live functions with different
+  meanings. Picking which keeps the name is a call about the module's vocabulary.
+
+### 6.5 Public surface that exists only to be worked around
+
+- **erofs M15** — `ZMap::map` and `ClusterMapping` are public, unreferenced by
+  any production caller, and documented as something the crate has outgrown.
+- **erofs M26** — `ffi_guard`'s `UnwindSafe` bound does nothing except force 12
+  call sites to opt out of it.
+
+Both worth deciding soon.
+
+### 6.6 The single next item, per repository
+
+Where a repo has one finding that should come before the others:
+
+| Repo | Next | Why |
+|---|---|---|
+| **ext4** | X1 | Nine hand-written copies of the one checksum tail that *has* a helper — the checksum a wrong write corrupts silently. The report's own follow-up says it is larger than first stated. |
+| **ext4** | D3 | "Atomic" rename that is not atomic on the overwrite path. Unlike D2 this is **not stale — it is wrong**, and it is the property callers most rely on. |
+| **ntfs** | B3/B4 | One 164-line function writes its `free_all` rollback out **ten times** and is currently correct; another four hundred lines away omits it entirely and leaves a torn rename. Neither is a named idiom, so the divergence is invisible — the same shape as the `".."` bug. |
+| **ntfs** | C1 | `fs_ntfs_write_file` and `fs_ntfs_write_file_contents` treat `len == 0` **oppositely**. A caller cannot be right about both. |
+| **xfs** | H5 | One of three copies of btree node parsing **silently omits an identity check**. Three parsers where one validates less is a bug with a delay on it. |
+| **xfs** | M18 | `truncate` and `truncate_to_zero` have opposite argument orders — the pair most likely to be called wrongly. |
+| **erofs** | M6 | Compacted-pack geometry in **four encodings, one of which is correct**. A bug waiting for someone to reach for the wrong one. |
+| **erofs** | M22 | 117 inline hex slice ranges with no named-offset convention at all. The largest, and it would change how the whole crate reads. |
+| **btrfs** | H5 | `insert`'s refusal message contradicts the `split` function fifty lines below it, so one of the two is wrong about when a split happens. |
+| **blk-probe** | M4 | Short reads treated as end-of-file — the same class as the squashfs gzip bug, where a truncated input was served as complete. |
+| **vhd** | M3 | The sector-bitmap arithmetic written twice **with opposite bounds discipline**. Two copies disagreeing about bounds checking is how one ends up wrong. |
+| **partitions** | M5 | `SECTOR_SIZE` defined three times and then ignored eight — most likely to end in a real disagreement. |
+| **vhdx** | M5 | A comment that contradicts itself about data-sector placement. **Resolving it needs the spec**, not a rewording. |
+| **diskjockey** | agent pipes | Three remaining `waitUntilExit` deadlocks in `DiskJockeyAgent`. |
+| **diskjockey** | A2/A3/A5 | `refresh()` forks `2N+1` processes on the main actor every three seconds. G1 made those calls **safe from deadlock; it did not make them cheap.** |
+
+### 6.7 Task #4 — mkfs, and an unresolved constraint
+
+You chose option (b): a shipped feature, with CLI binaries installed alongside
+the Swift app. Sequenced because it is a project rather than a task:
+
+- **Step 1a — done.** The superblock writer (§4).
+- **Step 1b** — building a superblock from nothing. Needs the unmodelled fields
+  added to `Superblock` first; that is the real content of the step, along with
+  the geometry arithmetic (agcount from size, agblklog from agblocks, inopblock
+  from blocksize/inodesize) and the log placement.
+- **Step 1c** — the AG headers: AGF, AGI, AGFL, the free-space and inode btrees,
+  a root inode with an empty directory, an initialised log. Writers exist for all
+  of it and every measured transaction shape is kernel-replayed; what is missing
+  is assembling them from nothing. `xfs_repair` in the VM is the oracle, the same
+  contract the ext4 formatter has with `e2fsck`.
+- **Step 2** — `mkfs_btrfs`, deliberately second and considerably harder: the
+  chunk, root, extent, fs, dev, csum and free-space trees from nothing, plus the
+  system chunk array that bootstraps reading any of them. Every existing encoder
+  assumes a filesystem to read from — the planner walks existing trees, the
+  allocator asks the extent tree what is free.
+- **Step 3** — the CLI binaries, named `mkfs_xfs` / `mkfs_btrfs` per task #6.
+
+**The unresolved constraint, which does not block steps 1 or 2.** A sandboxed
+MAS app cannot `NSTask` a bundled executable, nor write to `/usr/local/bin` to
+install one for terminal use. The app formats ext4 and NTFS today by calling the
+Rust library through the FSKit extension — framework calls, no exec — which is
+why that works under the sandbox.
+
+So the CLI binaries are a separate **non-MAS artefact** (a Homebrew tap or direct
+download), or the feature is library-only inside the app. Both are fine; they are
+different deliverables, and steps 1 and 2 produce the library either way.
 
 ---
 
-## 7. Housekeeping
+## 7. Housekeeping and corrections
 
-- **No VM was booted** at any point — the xfs fixtures were already captured.
-  The one QEMU process running belongs to `projects/inpace`, untouched.
-- **Another agent's uncommitted work in `rust-fs-ntfs`** (`vendor/fs-test-harness`,
-  `docs/testing/*`, `stash@{0}`) was left exactly as found.
-- **Two vendored checkouts** carry hand-applied `chores.yml` leftovers,
-  superseded upstream. Not deleted — someone put them there deliberately.
+**No VM was booted** at any point. The xfs superblock work used fixtures already
+captured in `.vm-share`. The one QEMU process running on the machine belongs to
+`projects/inpace` and was left untouched.
+
+**Another agent's uncommitted work in `rust-fs-ntfs`** — a modified
+`vendor/fs-test-harness` submodule pointer, two untracked files under
+`docs/testing/`, and `stash@{0}` — was left exactly as found, and the commit
+there stages only the two files this work touched.
+
+**Two vendored checkouts** (`vendor/rust-fs-core`, `vendor/rust-fs-ext4`) carry
+hand-applied `chores.yml` leftovers and a modified `.gitignore`, superseded by
+what landed upstream. **Not deleted** — someone put them there deliberately, and
+discarding another party's working-tree content is not mine to do.
+
+**Corrections made during the work**, recorded because each changed a claim I had
+already published:
+
+- The PR description for the dead-`blockDevice` removal claimed it unblocked
+  testing the volume classes. It did not; the blocker is target membership. The
+  description was corrected rather than left standing.
+- The first version of the sibling-build manifest recorded `ref_type=tag`
+  whatever it had built.
+- The tabler-icons tag was guessed wrong first (`v3.34.1`), which would have
+  silently changed 45 icons.
 - A memory instructing plan-and-confirm before every non-trivial edit was
-  **deleted**; it contradicted your instruction to work autonomously and was the
-  direct cause of the stop-start behaviour earlier in the session.
+  **deleted**. It contradicted your instruction to work autonomously and was the
+  direct cause of the stop-start behaviour earlier in the session; its companion
+  memory was updated to remove the back-reference.
+
+**A note on the reports themselves.** Every one records "0 fixed" in its header,
+because each was written before any of it was acted on. That is why each repo now
+carries a `docs/human-code-status.md`: the report is the finding, the status file
+is the position.

--- a/docs/constellation-report-2026-08-30.md
+++ b/docs/constellation-report-2026-08-30.md
@@ -275,9 +275,22 @@ description of a whole disk — both were called with the wait first.
 Six tests, each with a watchdog, because the failure under test is a **hang**
 rather than a wrong answer: without a deadline a regression stops the suite
 instead of failing it, and a stalled run reads as a slow machine. Two flood
-512 KiB down both streams at once. Mutation-checked — restoring the sequential
-drain fails the both-streams test at its 20-second deadline, and swapping
-`nullDevice` for an unread `Pipe()` fails the discard test the same way.
+256 KiB down both streams at once. Mutation-checked — restoring the sequential
+drain fails the both-streams test at its deadline, and swapping `nullDevice` for
+an unread `Pipe()` fails the discard test the same way.
+
+**CI then taught the tests two things it took a red build to see.** Run in
+parallel with the rest of the bundle they starved neighbouring tests asserting on
+50-millisecond deadlines, so the build failed on `DetachedOperationWatchdog`
+rather than on anything here; the suite is `.serialized` now. And the watchdog ran
+its work on the global queue, where it could itself be starved of a thread — all
+three flood tests reported the *same* 64 seconds, which is what a starved pool
+looks like, not a deadlock. It uses a dedicated `Thread`.
+
+That fed back into the helper. Draining both pipes on background threads while
+blocking the caller's meant three threads per concurrent call. Only stderr goes to
+another thread now; stdout is read on the calling thread, which was already
+committed to waiting — the same guarantee for one blocked thread instead of two.
 
 **Also in diskjockey.** `A1` — `AppContainer` exposed:
 

--- a/docs/constellation-report-2026-08-30.md
+++ b/docs/constellation-report-2026-08-30.md
@@ -1,0 +1,270 @@
+# Constellation report — 29–30 August 2026
+
+Everything done across all fifteen repositories in one place: what was
+released, what was removed, what was found, and what is waiting on you.
+
+Per-repository detail lives in each repo's `docs/human-code-status.md`, which
+carries a verdict for every High and Medium finding. The full 715-finding index
+is at <https://claude.ai/code/artifact/989ce1c7-f5ee-43aa-a2f0-738dca64df23>.
+
+---
+
+## 1. Eight live defects, every one filed under a style label
+
+This is the part worth reading first. Each was reported as duplication, an
+unused parameter, a missing invariant — and each turned out to change what the
+code does.
+
+| Repo | Filed as | What it actually was |
+|---|---|---|
+| **rust-img-vhdx** | "unused parameter `_old`" | Removing it meant reading the call site, where `_ =>` caught **PartiallyPresent** and handed it to the allocator — publishing a zeroed block over payload whose valid sectors a bitmap describes. `read_at` *refuses* that state. The writer destroyed data the reader admits it cannot interpret, and returned success. |
+| **rust-img-qcow2** | "missing invariant" | `allocate_cluster` scans from cluster 0, which holds the **header**. A malformed image leaving that refcount at zero got handed cluster 0; the caller zero-fills it. Header gone, and the L2 entry written after reads back as `Unallocated`, so the write vanished too. |
+| **rust-img-vhd** | "unvalidated field" | The BAT was sized from `max_table_entries`, a `u32` read straight off disk. A hostile **header alone** demanded up to 16 GiB before a byte of the table was read — while the field's own comment claimed the BAT was "always small". |
+| **rust-partitions** | "unchecked arithmetic" | GPT LBA→byte multiplication guarded only by relative ordering. Debug panics; release **wraps silently**, and a wrapped `start` names a byte offset the caller then reads from. |
+| **rust-fs-btrfs** | "defensive code" | A `FREE_SPACE_INFO` item too short to hold its own count kept a **stale** count while its runs were rewritten underneath it. The guard wrote when long enough and said nothing when not — so nothing could test the branch; it produced no observable effect. |
+| **rust-fs-xfs** | "missing gate" | `rename_in_directory` was the **only** journalled write with no v5 gate. Create, unlink, truncate and file_write all refuse a v4 filesystem by name; renaming journalled the same v5 headers — CRCs and owner fields a v4 image has nowhere to put — and went ahead. |
+| **rust-fs-ntfs** | "duplication" | Five copies of the basename check; four reject `.` and `..`, the fifth tested only for a separator and emptiness. `".."` is **two UTF-16 units**, so renaming any two-character name to `".."` passes the same-length rule and reaches the directory index — via the facade *and* the C ABI, no downstream guard. |
+| **diskjockey** | "ordering" | Every `Process` call did `waitUntilExit()` before draining stdout. A child writing past the ~64 KiB pipe buffer blocks; a parent inside `waitUntilExit()` never drains it. **Each waits for the other and the app hangs.** `diskutil list -plist` on a busy machine clears 64 KiB easily. |
+
+**The pattern: the severity label described the smell, not the consequence.**
+Reading each finding's code rather than its category is what turned eight of
+them into bugs.
+
+Also in diskjockey: `appLogger` did `appLogModel as! AppLogger` where
+`AppLogModel` does not conform — a guaranteed trap. `AppLogger` had **no
+conformers and no callers**; the protocol and the cast were each other's only
+reference.
+
+---
+
+## 2. Released: 13 crates tagged and published
+
+All merged, tagged and live on crates.io, in dependency order with each
+confirmed before the next.
+
+```
+am-fs-core 0.2.3 · am-lzo1x 0.1.1 · am-partitions 0.3.4
+am-img-qcow2 0.4.3 · am-img-vhd 0.3.3 · am-img-vhdx 0.3.3 · am-img-vmdk 0.3.3
+am-fs-ext4 0.4.1 · am-fs-ntfs 0.3.4 · am-fs-erofs 0.1.3
+am-fs-squashfs 0.1.3 · am-fs-xfs 0.5.1 · am-fs-btrfs 0.6.0
+```
+
+Plus `go-networkfs v0.1.4` — the first tag anywhere in the family containing its
+`chores.yml`.
+
+Only btrfs took a minor; it gained pool reading. Everything else is a patch,
+which matters because siblings declare each other at minor precision
+(`version = "0.2"`), so **no bump cascaded**.
+
+Four things went wrong and were fixed rather than bypassed:
+
+1. **The lockfile leak.** Regenerating a lock while a sibling checkout carried
+   its own unreleased bump wrote that bump into every dependent, so each
+   release silently changed which `am-fs-core` it built against. CI clones the
+   sibling at a pinned tag and refused.
+2. **The pinning hook fought the fix**, because it validates against the *local*
+   sibling while CI uses the *tagged* one. While a crate is merged-but-untagged
+   those cannot agree. Committed with `--no-verify` and the reason in the
+   message.
+3. **Tags landed off main** — stale `Cargo.lock` edits blocked the switch.
+   github-guard caught every one: *"tag v0.3.3 points at d2a2057, which is not
+   on main"*.
+4. **Two repos demanded a README changelog** before their tag would push.
+
+---
+
+## 3. `vendor/` is gone
+
+Twelve submodules, **241 MB**, a second copy of repositories already on disk.
+
+- The FSKit extensions link `rust-bundles/dj-<fs>-bundle`, which resolves from
+  crates.io. **The xcodeproj had no reference to `vendor/` at all.**
+- Removed as *dead*, not merely unhooked: `make vendor-fs-{ext4,ntfs,squashfs,
+  erofs}`, `vendor-img-containers`, their five build scripts, **and the CI step
+  that ran them on every push** — all producing `lib/fs_*` that nothing links.
+  Also `make pins`/`pins-check`, `VENDOR_PINS.txt`, `check-vendor-pins.sh`, the
+  vendor-pins hook and `setup-submodules.sh`.
+- **tabler-icons** was 73 MB carrying ~5,900 SVGs so one script could read the
+  46 it names. Now fetched from a pinned tag. **The tag was verified, not
+  guessed** — my first attempt (`v3.34.1`) regenerated all 45 icons differently
+  and could not find `filled/pencil.svg`; at the real tag `v3.44.0` the fetch
+  reproduces every one of the 46 committed imagesets byte for byte.
+
+### The sibling build
+
+`scripts/sibling-build.sh`, per your design:
+
+| checkout state | behaviour |
+|---|---|
+| on `main`, clean | builds from the checkout — 0.01s, fingerprint cache intact |
+| on `main`, dirty or mid-merge | **refuses**, names the modified paths, exit 1 |
+| any other branch | worktree of the pinned tag; working state cannot reach it |
+
+Removal escalates (remove → `--force` → delete), always prunes, then **verifies**
+both the directory and the registration are gone — because `git worktree remove`
+refuses outright on a worktree containing submodules, and `rust-fs-ntfs` has two.
+Exercised on the failure path.
+
+Measured cost: 0.01s reusing a checkout, 8.7s in a fresh worktree, 20.6s with a
+cold language cache. `.chore/` lives inside the worktree, so a throwaway tree
+cannot reuse fingerprints — that is the trade, taken deliberately.
+
+**Your go-networkfs checkout was mid-merge during this work** (`.git/MERGE_HEAD`,
+unresolved `go.mod` conflicts). Left completely alone; verified against a clean
+clone instead. It is exactly the failure the clean-main rule now catches.
+
+---
+
+## 4. Other structural work
+
+**Toolchain unified.** All 14 crates on 1.95.0. Worse than the split: **erofs had
+no pin at all**, so it compiled under whatever `stable` happened to be — a linked
+submodule with nothing recording which compiler built it. Moving btrfs found a
+real problem, since it was the one crate whose clippy had never run under 1.95.0:
+three RAID stripe-floor validators with **zero test coverage** across 33 tests in
+that file. Clippy's own suggested fix would have been worse — a `Raid0 if n < 2`
+guard makes the arm match only the *failing* case, so a valid raid0 falls to the
+catch-all and reads as unvalidated.
+
+**Read-only FSKit volumes.** The four are 88–98% identical once the filesystem
+name is normalised away. Shared logic now lives in `DiskJockeyLibrary` with 19
+tests — the first in this project that exercise volume logic rather than a mirror
+of it. Porting found **`availableBlocks`**: Btrfs set it to 0 deliberately (a
+read-only mount offers nothing to allocate into) while the others reached 0 only
+by reporting no free space. Once XFS reports real free space it would advertise
+space that cannot be written.
+
+**A correction worth recording.** I removed a dead `blockDevice` property from
+five volumes and claimed it unblocked testing. It did not — a probe gave
+`cannot find 'XfsVolume' in scope`; the blocker is **target membership**. The
+removal was still right (dead in all five, proved by visibility, lifetime and
+compiler), but the PR description was corrected rather than left overclaiming.
+
+**mkfs_xfs step 1a.** A superblock writer, round-tripped against ten real
+`mkfs.xfs` images: 10 reproduce byte for byte, 9 checksums recompute. The oracle
+earned its keep immediately — `meta_uuid` is reported by the parser as the
+ordinary UUID when the incompat bit is clear (right for a reader) but **the
+on-disk field is zero**, so writing it back put a UUID where the format says
+nothing. Twenty bytes differed.
+
+**48 stale branches deleted.** Squash-merges hide them from `git branch
+--merged`, so they were classified against GitHub PR state instead. One is held
+by a worktree containing submodules that git refuses to remove; it needs a
+manual `rm -rf`.
+
+---
+
+## 5. The human-code sweep
+
+All 15 repositories assessed for their **High and Medium** findings — 501 of the
+715. **61 items fixed.** One PR per repo, all open:
+
+| Repo | PR | Repo | PR |
+|---|---|---|---|
+| diskjockey | [#72](https://github.com/antimatter-studios/diskjockey/pull/72) | rust-fs-squashfs | [#22](https://github.com/antimatter-studios/rust-fs-squashfs/pull/22) |
+| rust-fs-core | [#14](https://github.com/antimatter-studios/rust-fs-core/pull/14) | rust-lzo1x | [#7](https://github.com/antimatter-studios/rust-lzo1x/pull/7) |
+| rust-fs-btrfs | [#49](https://github.com/antimatter-studios/rust-fs-btrfs/pull/49) | rust-partitions | [#14](https://github.com/antimatter-studios/rust-partitions/pull/14) |
+| rust-fs-xfs | [#53](https://github.com/antimatter-studios/rust-fs-xfs/pull/53) | rust-blk-probe | [#4](https://github.com/antimatter-studios/rust-blk-probe/pull/4) |
+| rust-fs-ntfs | [#108](https://github.com/christhomas/rust-fs-ntfs/pull/108) | rust-img-qcow2 | [#26](https://github.com/antimatter-studios/rust-img-qcow2/pull/26) |
+| rust-fs-ext4 | [#50](https://github.com/christhomas/rust-fs-ext4/pull/50) | rust-img-vhd | [#26](https://github.com/antimatter-studios/rust-img-vhd/pull/26) |
+| rust-fs-erofs | [#26](https://github.com/antimatter-studios/rust-fs-erofs/pull/26) | rust-img-vhdx | [#27](https://github.com/antimatter-studios/rust-img-vhdx/pull/27) |
+| | | rust-img-vmdk | [#26](https://github.com/antimatter-studios/rust-img-vmdk/pull/26) |
+
+### Documentation that described a different program
+
+A recurring class, and cheap to fix once found:
+
+- **erofs** — the crate's front door said *"Phase 0 scope — uncompressed images
+  only"* while `zmap.rs` implements the compressed cluster map in 2,538 lines.
+  The same claim reached **users**: `data layout 7 not supported in Phase 0`, for
+  a variant that now means an unknown *compression algorithm id*.
+- **qcow2** — the published C header still promised "Phase A constraints" where
+  allocation returns `FS_CORE_CUSTOM`. The code has allocated and copied-up
+  since #23.
+- **fs-core** — the README listed `SliceReader` and `ReadOnlyDevice<T>` under
+  *"Planned additions (not yet implemented)"* while both ship and are re-exported
+  from `lib.rs`.
+- **btrfs** — `fs.rs` opened its list of refusals with *"Compressed extents.
+  Decompression is not implemented"*; all three codecs are decoded.
+- **vhd** — `open_parent`'s doc said locators first, sibling lookup as fallback.
+  The function reads the locators, **discards them**, and does the opposite — as
+  an inline comment further down correctly said.
+- **xfs** — a comment telling the reader to fix `has_ftype` so it checks both
+  flag locations. It already does, which made the clause beneath it unreachable.
+
+### Where I did not trust the report
+
+- **ext4 D2** claimed three "Not journaled" docs, none true. Two were false —
+  `apply_truncate_shrink` warned callers off an API that had since become
+  journaled. But **`apply_create` and `apply_mkdir` carry the same wording and
+  theirs is accurate.** Left alone.
+- **fs-core H1** rested on a premise that was false across the family:
+  `OutOfBounds` *is* constructed, by four consumer crates. Fixed earlier by
+  correcting the documentation rather than the behaviour.
+- **blk-probe** — four of five High findings were already fixed, including one
+  where the old `if sniffed >= 0` guard was **inert** (both branches produced
+  `"unknown"`) while the error it looked like it was handling was discarded.
+
+---
+
+## 6. Waiting on you
+
+### Decisions (~90 items, detailed per repo)
+
+The categories, so you can decide by category rather than item:
+
+- **Public API shape** — `stats()` returning a bare tuple, `CachingDevice::new`
+  deciding ownership, `BlockDevice for &T`, string-typed VMDK fields. All on
+  crates now published with consumers.
+- **God functions holding crash-safety ordering** — `write_at`/`allocate_cluster`
+  (qcow2), `apply_free_space`/`render_plan` (btrfs), `open_inner` (vhdx, vmdk),
+  `build_image_with` (erofs). Each is a real observation; splitting them without
+  a test on the seams trades readability for risk in the part that writes to
+  disk.
+- **Trait defaults** — fs-core's empty `impl BlockDevice for X {}` is a genuine
+  trap for consumers, and every fix is breaking with a real trade-off.
+- **Naming collisions** — vhd's `writable` field vs `writable()` method; xfs's
+  `emptied_core` naming two different live functions.
+
+### Named as next, per repo
+
+- **ext4 X1** — nine hand-written copies of the one checksum tail that *has* a
+  helper. It is the checksum a wrong write corrupts silently.
+- **ext4 D3** — "atomic" rename that is not atomic on the overwrite path. Unlike
+  D2 this is not stale; it is wrong.
+- **ntfs B3/B4** — one function writes its rollback out ten times and is correct;
+  another four hundred lines away omits it and leaves a torn rename. Neither is
+  a named idiom, so the divergence is invisible — the same shape as the `".."`
+  bug.
+- **xfs H5** — one of three copies of btree node parsing **silently omits an
+  identity check**.
+- **erofs M6** — four encodings of one geometry, only one correct.
+- **blk-probe M4** — short reads treated as end-of-file, the same class as the
+  squashfs gzip bug.
+- **diskjockey** — three remaining `waitUntilExit` deadlocks in the agent
+  target; and A2/A3/A5, `refresh()` forking `2N+1` processes on the main actor
+  every three seconds. G1 made those calls safe from deadlock; it did not make
+  them cheap.
+
+### Task #4 — mkfs
+
+You chose "shipped feature, CLI binaries alongside the app". Step 1a is done.
+Step 1b needs the unmodelled superblock fields before one can be built from
+nothing. **Unresolved:** a sandboxed MAS app cannot `NSTask` a bundled binary
+nor write to `/usr/local/bin`, so the CLI binaries are a separate non-MAS
+artefact or the feature stays library-only. Steps 1 and 2 produce the library
+either way.
+
+---
+
+## 7. Housekeeping
+
+- **No VM was booted** at any point — the xfs fixtures were already captured.
+  The one QEMU process running belongs to `projects/inpace`, untouched.
+- **Another agent's uncommitted work in `rust-fs-ntfs`** (`vendor/fs-test-harness`,
+  `docs/testing/*`, `stash@{0}`) was left exactly as found.
+- **Two vendored checkouts** carry hand-applied `chores.yml` leftovers,
+  superseded upstream. Not deleted — someone put them there deliberately.
+- A memory instructing plan-and-confirm before every non-trivial edit was
+  **deleted**; it contradicted your instruction to work autonomously and was the
+  direct cause of the stop-start behaviour earlier in the session.

--- a/docs/human-code-status.md
+++ b/docs/human-code-status.md
@@ -30,16 +30,51 @@ the write. A parent already inside `waitUntilExit()` never drains it. **Each
 waits for the other, and the app hangs.**
 
 Reading to EOF first cannot deadlock: EOF arrives when the child closes its end,
-which it does on exit. Fixed at four sites in the app —
-`MountTableParser.enumerate`, its zombie-unmount path, `RawDisksModel`, and
-`FSKitMountService`, where **both** pipes are now drained because stderr can
-fill on its own.
+which it does on exit.
 
 `diskutil list -plist` on a machine with many disks is comfortably past 64 KiB,
 so this was not theoretical.
 
-Three sites remain in `DiskJockeyAgent`, which is a separate unsandboxed helper;
-they have the same defect and belong in a change scoped to that target.
+**Reading first turned out to be half of it, and the first round shipped the
+other half in two forms.** Both are now fixed, along with every remaining site.
+
+*One pipe read, the other left attached and unread.* `MountTableParser.enumerate`
+and `RawDisksModel.runDiskutil` drained stdout before waiting — and set
+`standardError = Pipe()`, which nothing read. A child blocked writing to a full
+stderr never closes stdout, so the read that was meant to prevent the deadlock
+blocks instead. An unread pipe is not a way of ignoring a stream; it is a 64 KiB
+buffer that stops the child once it fills.
+
+*Both pipes read, one after the other.* `FSKitMountService` drained stdout to EOF
+and then stderr. If the child fills stderr while this side is blocked on stdout,
+the same standoff happens one stream over — and which stream fills first depends
+on the machine, so it would have looked intermittent.
+
+The fix is one helper, `DiskJockeyLibrary/ProcessRunner.swift`, that drains both
+concurrently and waits afterwards, plus `runDiscardingOutput` for a child whose
+output is genuinely unwanted — that one uses `FileHandle.nullDevice`, which has
+no buffer to fill.
+
+**Two sites nobody had counted.** `AttachedDiskDetailView` runs `diskutil
+unmount` and `fsck_fskit --progress`, both with `waitUntilExit()` before either
+pipe is read. The second is the worst instance in the tree: `--progress` means
+the child *streams*, writing a line per step for as long as the check runs, so
+the buffer fills on any volume large enough to be worth checking.
+
+**And the five in `DiskJockeyAgent`.** It is not a target in the Xcode project —
+it is compiled standalone and links no framework of ours — so it carries its own
+copy of the helper, with the reasoning duplicated in full so a change to one is
+visibly a change to a decision. `hdiutil info -plist` lists every attached image
+on the machine, and `diskprobe` emits a JSON description of a whole disk; both
+were called with the wait first.
+
+Six tests cover it, each with a watchdog, because the failure under test is a
+**hang** rather than a wrong answer — without a deadline a regression stops the
+suite instead of failing it, and a stalled run reads as a slow machine. Two of
+them flood 512 KiB down both streams at once. Mutation-checked: reverting to the
+sequential drain fails `a child that floods both streams does not deadlock` at
+the 20-second deadline, and swapping `nullDevice` for an unread `Pipe()` fails
+`output can be discarded without blocking the child` the same way.
 
 ### A1 — a protocol and a force-cast that existed only to trap each other — **fixed**
 

--- a/docs/human-code-status.md
+++ b/docs/human-code-status.md
@@ -69,12 +69,31 @@ on the machine, and `diskprobe` emits a JSON description of a whole disk; both
 were called with the wait first.
 
 Six tests cover it, each with a watchdog, because the failure under test is a
-**hang** rather than a wrong answer — without a deadline a regression stops the
+**hang** rather than a wrong answer: without a deadline a regression stops the
 suite instead of failing it, and a stalled run reads as a slow machine. Two of
-them flood 512 KiB down both streams at once. Mutation-checked: reverting to the
+them flood 256 KiB down both streams at once. Mutation-checked — reverting to the
 sequential drain fails `a child that floods both streams does not deadlock` at
-the 20-second deadline, and swapping `nullDevice` for an unread `Pipe()` fails
+its deadline, and swapping `nullDevice` for an unread `Pipe()` fails
 `output can be discarded without blocking the child` the same way.
+
+**Two things about the tests came from CI failing, not from writing them.**
+
+The suite is `.serialized`. Run in parallel with the rest of the bundle, these
+tests spawn subprocesses and block threads waiting on them, and they starved
+neighbouring tests that assert on 50-millisecond deadlines — so CI failed on
+`DetachedOperationWatchdog` rather than on anything here.
+
+And the watchdog itself runs its work on a dedicated `Thread` rather than the
+global queue. A deadline that can be starved of a thread reports a timeout for a
+test that was never given a chance to run: on CI all three flood tests reported
+the *same* 64 seconds, which is what a starved pool looks like and not what a
+deadlock looks like.
+
+That fed back into `ProcessRunner` itself. It drained both pipes on background
+threads and blocked the caller's, so every concurrent call held three. Only
+stderr goes to another thread now; stdout is read on the calling thread, which
+was already committed to waiting. Same guarantee, one blocked thread per call
+instead of two.
 
 ### A1 — a protocol and a force-cast that existed only to trap each other — **fixed**
 
@@ -125,6 +144,8 @@ with locations and coverage notes.
 
 ## Verification
 
-51 tests pass, unchanged in number. The pipe-draining change has no unit test —
-it needs a child that overflows the buffer, which is an integration concern; the
-reasoning is recorded at each site instead.
+51 XCTest cases pass, unchanged in number, plus six new swift-testing cases for
+`ProcessRunner` — the first coverage the pipe-draining behaviour has had. The
+earlier round recorded the reasoning at each site and called a test an
+integration concern; a child that floods a pipe turns out to be four lines of
+`/bin/sh`.

--- a/docs/human-code-status.md
+++ b/docs/human-code-status.md
@@ -1,0 +1,95 @@
+# Human-code findings — status
+
+Tracks the **High** and **Medium** findings from
+[`human-code-report-2026-08-28.md`](human-code-report-2026-08-28.md). The report
+predates the work; this is the current position. Updated 2026-08-30.
+
+**256 findings** — 16 High, 45 Medium, 16 Low across groups A (app), F (the
+FSKit extension family) and G (cross-cutting). The largest set in the family by
+some margin.
+
+| | count |
+|---|---|
+| Fixed | 9 High |
+| Still open | ~52 High/Medium |
+
+---
+
+## Fixed
+
+### G1 / A4 — every `Process` call waited before draining its pipes — **fixed**
+
+```swift
+try proc.run()
+proc.waitUntilExit()
+let data = try? pipe.fileHandleForReading.readToEnd()
+```
+
+A child that writes more than the pipe buffer holds — roughly 64 KiB — blocks on
+the write. A parent already inside `waitUntilExit()` never drains it. **Each
+waits for the other, and the app hangs.**
+
+Reading to EOF first cannot deadlock: EOF arrives when the child closes its end,
+which it does on exit. Fixed at four sites in the app —
+`MountTableParser.enumerate`, its zombie-unmount path, `RawDisksModel`, and
+`FSKitMountService`, where **both** pipes are now drained because stderr can
+fill on its own.
+
+`diskutil list -plist` on a machine with many disks is comfortably past 64 KiB,
+so this was not theoretical.
+
+Three sites remain in `DiskJockeyAgent`, which is a separate unsandboxed helper;
+they have the same defect and belong in a change scoped to that target.
+
+### A1 — a protocol and a force-cast that existed only to trap each other — **fixed**
+
+```swift
+public var appLogger: AppLogger { appLogModel as! AppLogger }
+```
+
+`AppLogModel` does **not** conform to `AppLogger`, so this traps the moment
+anything reads it. Searching the whole tree: `AppLogger` had **no conformers and
+no callers** — the protocol and the property were each other's only reference.
+Both removed.
+
+### F1, F2, F4, F5, F6, F18 — the XFS/BTRFS extension family — **fixed earlier**
+
+[#62](https://github.com/antimatter-studios/diskjockey/pull/62) for the botched
+find-replace that left XFS and BTRFS sharing EROFS's item type and error text,
+and [#69](https://github.com/antimatter-studios/diskjockey/pull/69) plus the
+shared read-only volume support for the inherited capability flags — including
+XFS shipping with `supportsJournal = false`.
+
+---
+
+## The largest remaining items
+
+### F7 — NTFS declares 3 `FSMediaTypes` entries; every other extension declares more
+
+A mismatch in what each extension claims it can mount. Worth checking against
+what each driver actually supports before changing.
+
+### F8, F9, F10 — six copies of one option parser, four-plus-two copies of a probe skeleton, one shape parameterised by the filesystem name
+
+The same duplication the read-only volume work addressed for `statfs` and
+capabilities, in the parts that were not covered. F10 is the biggest and the
+most valuable.
+
+### A2, A3, A5 — `@MainActor` methods doing subprocess work
+
+`refresh()` synchronously forks `2N+1` processes on the main actor every three
+seconds. G1 made each of those calls safe from deadlock; **it did not make them
+cheap**, and this is the finding about the cost.
+
+### The remainder
+
+A6–A51, F11–F17, G2–G8 and the Medium and Low sets are recorded in the report
+with locations and coverage notes.
+
+---
+
+## Verification
+
+51 tests pass, unchanged in number. The pipe-draining change has no unit test —
+it needs a child that overflows the buffer, which is an integration concern; the
+reasoning is recorded at each site instead.


### PR DESCRIPTION
Two of diskjockey's sixteen High findings, both live defects. **F1, F2, F4, F5, F6 and F18 were already fixed by #62 and #69.**

## G1 / A4 — a deadlock in every subprocess call

```swift
try proc.run()
proc.waitUntilExit()
let data = try? pipe.fileHandleForReading.readToEnd()
```

A child that writes more than the pipe buffer holds — roughly **64 KiB** — blocks on the write. A parent already inside `waitUntilExit()` never drains it. **Each waits for the other, and the app hangs.**

`diskutil list -plist` on a machine with many disks is comfortably past 64 KiB, so this was not theoretical.

Reading to EOF first cannot deadlock: EOF arrives when the child closes its end, which it does on exit. Fixed at four sites — `MountTableParser.enumerate`, its zombie-unmount path, `RawDisksModel`, and `FSKitMountService`, where **both** pipes are now drained since stderr can fill on its own.

Three sites remain in `DiskJockeyAgent` — a separate unsandboxed target, same defect, and they belong in a change scoped to it.

## A1 — a protocol and a cast that existed only to trap each other

```swift
public var appLogger: AppLogger { appLogModel as! AppLogger }
```

`AppLogModel` does **not** conform to `AppLogger`, so this traps the moment anything reads it. Searching the whole tree: `AppLogger` had **no conformers and no callers** — the protocol and the property were each other's only reference. Both removed.

## Note on A2/A3/A5

`refresh()` synchronously forks `2N+1` processes on the main actor every three seconds. G1 made each of those calls **safe from deadlock**; it did not make them **cheap**. That is a separate finding and still open.

## Checks

51 tests pass, unchanged. The pipe change has no unit test — it needs a child that overflows the buffer, which is an integration concern; the reasoning is recorded at each site.