### PR TITLE
The constellation duplication scan, its evidence, and a plan

### DIFF
--- a/docs/constellation/evidence-2026-08-30.md
+++ b/docs/constellation/evidence-2026-08-30.md
@@ -59,7 +59,7 @@ section each claim comes from:
 | **`catch_unwind` hand-rolled in 11 crates**, in two different shapes | §7 | `fs_core::ffi::ffi_guard` exists and fits only status-code returns, so everyone worked around it — **including fs-core itself, at seven sites in the same file**. Three of those were swallowing the panic entirely. Fixed in fs-core on 2026-08-30; the eleven downstream copies are untouched. |
 | **`Io`, `ReadOnly`, `OutOfBounds`, `NotFound`, `NotADirectory`, `Corrupt`** appear in 5–8 separate error enums | §8, §9 | Eleven error types, ~130 variants, with a shared core nobody shares. Whether that core *should* be shared is the interesting part: a driver's errors are its vocabulary, and a common supertype can make each one vaguer. |
 | **ext4 has 343 inline hex slice ranges; xfs has 13 named offset modules and zero** | §10 | Two crates in one family with opposite conventions for the same job. erofs has 91, ntfs 61. This is the largest readability gap and it is not a shared-code question at all — it is a house-style question. |
-| **`crc32c` in five crates, `crc32fast` in one** | §14 | Two CRC32 implementations in one dependency tree. partitions is the odd one out, and GPT's CRC32 is a different polynomial from ext4/xfs/btrfs's CRC32C — so this may be correct rather than accidental, and needs checking before it is "fixed". |
+| ~~`crc32c` in five crates, `crc32fast` in one~~ — **checked, not a problem** | §14 | GPT's CRC-32/ISO-HDLC and the filesystems' CRC-32C/Castagnoli are **different polynomials**. Both are correct; unifying them would be a bug. Left in the table as a worked example of a grep finding that does not survive being looked at. |
 | **`ruzstd 0.8` in squashfs and qcow2, `0.9.0` in btrfs** | §14 | Version skew inside the family. |
 | **ntfs depends on `vendor/rust-fs-core`; every other crate uses `../rust-fs-core`** | §14 | One crate resolves its sibling differently from the other twelve. |
 
@@ -76,6 +76,12 @@ about rather than measure:
   drifted — which argues for sharing. They also found cases where two
   copies differed for a good reason nobody had written down, which
   argues for naming the difference rather than erasing it.
+
+## What was decided from this
+
+[`plan-2026-08-30.md`](plan-2026-08-30.md), alongside. It concludes that
+the premise is half right: the duplication is real, and `am-fs-core` is
+not where most of it belongs.
 
 ---
 

--- a/docs/constellation/evidence-2026-08-30.md
+++ b/docs/constellation/evidence-2026-08-30.md
@@ -1,0 +1,462 @@
+# Constellation duplication scan — raw evidence
+
+Gathered 2026-08-30, to test one question:
+
+> Is there a layer of shared behaviour above `am-fs-core` that the
+> thirteen driver and image crates each re-implement, and would pulling
+> it up make the family easier to use and extend?
+
+**This file is evidence, not conclusions.** It is the unedited output of
+[`scan.sh`](scan.sh) in this directory, which is a set of greps across
+every crate's `src/` and `tests/`. Re-run it with:
+
+```sh
+CLAUDE_JOB_DIR=/tmp docs/constellation/scan.sh
+```
+
+It expects the sibling crates checked out beside this repository — the
+same layout `scripts/sibling-build.sh` assumes.
+
+**Re-running it will not reproduce this file exactly, and should not.**
+Several of the duplications counted below were removed on the same day
+the scan ran; a later run showing fewer is the scan working. The numbers
+here are a snapshot of 2026-08-30, before those merges. Where a section
+has already moved, the table below says so.
+
+The analysis and any plan that follows belong in their own document, so
+that a reader can check a claim against the numbers here rather than
+having to take the summary's word for it.
+
+## How to read it, and where it is wrong
+
+Greps count text, not meaning. Three sections need qualifying before
+anything is concluded from them:
+
+- **§2 (endian helpers) undercounts.** It matches definitions whose
+  signature fits one shape, so it finds ext4's four, xfs's four and
+  btrfs's six, and misses every crate that spells its readers
+  differently or inlines `from_le_bytes` at the call site. `ntfs`
+  reporting zero means "none in that shape", not "none".
+- **§6 (allocation bitmaps) is noise.** The pattern matched the word
+  `offset` and returned most of `ext4/src/inode.rs`. Ignore it; the
+  bitmap question needs a hand search.
+- **§13 (directory iteration) is a list of names, not of shapes.** Six
+  crates having a `read_dir` says they all have directories, which was
+  never in doubt. Whether the *bodies* share a structure is the actual
+  question and this does not answer it.
+
+Everything else is a straight count of declarations or call sites and
+can be taken at face value.
+
+## What already stands out
+
+Recorded here so the next reader does not have to re-derive it, with the
+section each claim comes from:
+
+| observation | section | why it matters |
+|---|---|---|
+| **31 in-memory test devices** across 11 repos | §4 | The single largest duplication in the family, and it is test scaffolding — which duplicates most readily because nobody reviews it. erofs alone had seven; six were merged into one on 2026-08-30. |
+| **`catch_unwind` hand-rolled in 11 crates**, in two different shapes | §7 | `fs_core::ffi::ffi_guard` exists and fits only status-code returns, so everyone worked around it — **including fs-core itself, at seven sites in the same file**. Three of those were swallowing the panic entirely. Fixed in fs-core on 2026-08-30; the eleven downstream copies are untouched. |
+| **`Io`, `ReadOnly`, `OutOfBounds`, `NotFound`, `NotADirectory`, `Corrupt`** appear in 5–8 separate error enums | §8, §9 | Eleven error types, ~130 variants, with a shared core nobody shares. Whether that core *should* be shared is the interesting part: a driver's errors are its vocabulary, and a common supertype can make each one vaguer. |
+| **ext4 has 343 inline hex slice ranges; xfs has 13 named offset modules and zero** | §10 | Two crates in one family with opposite conventions for the same job. erofs has 91, ntfs 61. This is the largest readability gap and it is not a shared-code question at all — it is a house-style question. |
+| **`crc32c` in five crates, `crc32fast` in one** | §14 | Two CRC32 implementations in one dependency tree. partitions is the odd one out, and GPT's CRC32 is a different polynomial from ext4/xfs/btrfs's CRC32C — so this may be correct rather than accidental, and needs checking before it is "fixed". |
+| **`ruzstd 0.8` in squashfs and qcow2, `0.9.0` in btrfs** | §14 | Version skew inside the family. |
+| **ntfs depends on `vendor/rust-fs-core`; every other crate uses `../rust-fs-core`** | §14 | One crate resolves its sibling differently from the other twelve. |
+
+Two things the scan does **not** find, and that any plan has to reason
+about rather than measure:
+
+- Whether the logical-to-physical mapping in ext4 extents, NTFS data
+  runs, XFS bmbt, btrfs, VHD BATs, qcow2 L1/L2 and VMDK grain tables is
+  one algorithm or seven that merely rhyme. §5 lists the entry points;
+  it says nothing about whether their bodies could share one.
+- Whether a shared abstraction would make each driver *clearer* or only
+  shorter. The fixes made across the family on 2026-08-30 repeatedly
+  found that the duplicated copy nobody tested was the one that had
+  drifted — which argues for sharing. They also found cases where two
+  copies differed for a good reason nobody had written down, which
+  argues for naming the difference rather than erasing it.
+
+---
+
+```text
+=== 1. SIZE ===
+repo                    src    tests
+rust-fs-ext4          25400    21687
+rust-fs-ntfs          26466    17278
+rust-fs-xfs           18823     9340
+rust-fs-btrfs         11976     7629
+rust-fs-erofs         12883     6799
+rust-fs-squashfs       2704     2096
+rust-img-qcow2         2344     1801
+rust-img-vhd           2245     1746
+rust-img-vhdx          2909     1073
+rust-img-vmdk          1365     1207
+rust-partitions        2284     1219
+rust-lzo1x              678      318
+rust-blk-probe         1153        0
+
+=== 2. ENDIAN HELPERS (per-crate fn definitions) ===
+rust-fs-ext4: 4
+    rust-fs-ext4/src/fs.rs:5179:    fn read_le32(buf: &[u8], off: usize) -> u32 {
+    rust-fs-ext4/src/fs.rs:5182:    fn read_le16(buf: &[u8], off: usize) -> u16 {
+    rust-fs-ext4/src/acl.rs:160:    fn le32(v: u32) -> [u8; 4] {
+    rust-fs-ext4/src/acl.rs:163:    fn le16(v: u16) -> [u8; 2] {
+rust-fs-ntfs: 0
+rust-fs-xfs: 4
+    rust-fs-xfs/src/endian.rs:40:pub fn be16(b: &[u8], off: usize) -> u16 {
+    rust-fs-xfs/src/endian.rs:50:pub fn be32(b: &[u8], off: usize) -> u32 {
+    rust-fs-xfs/src/endian.rs:60:pub fn be64(b: &[u8], off: usize) -> u64 {
+    rust-fs-xfs/src/endian.rs:83:pub fn le32(b: &[u8], off: usize) -> u32 {
+rust-fs-btrfs: 6
+    rust-fs-btrfs/src/block_group.rs:127:fn le32(b: &[u8], at: usize) -> u32 {
+    rust-fs-btrfs/src/block_group.rs:130:fn le64(b: &[u8], at: usize) -> u64 {
+    rust-fs-btrfs/src/superblock.rs:567:pub(crate) fn le16(b: &[u8], off: usize) -> u16 {
+    rust-fs-btrfs/src/superblock.rs:573:pub(crate) fn le32(b: &[u8], off: usize) -> u32 {
+    rust-fs-btrfs/src/superblock.rs:579:pub(crate) fn le64(b: &[u8], off: usize) -> u64 {
+    rust-fs-btrfs/src/fs.rs:142:fn le64(b: &[u8], off: usize) -> u64 {
+rust-fs-erofs: 0
+rust-fs-squashfs: 0
+rust-img-qcow2: 0
+rust-img-vhd: 0
+rust-img-vhdx: 0
+rust-img-vmdk: 0
+rust-partitions: 0
+rust-lzo1x: 0
+rust-blk-probe: 0
+
+=== 3. CHECKSUM IMPLEMENTATIONS ===
+rust-fs-ext4/src/checksum.rs:37:pub fn linux_crc32c(seed: u32, data: &[u8]) -> u32 {
+rust-fs-xfs/src/superblock.rs:826:pub(crate) fn crc32c_with_zeroed_crc(buf: &[u8], crc_off: usize) -> u32 {
+rust-fs-xfs/src/error.rs:139:    fn checksum_mismatch_names_the_structure_and_block() {
+rust-fs-btrfs/src/superblock.rs:1177:    fn checksum_covers_the_whole_structure_not_just_parsed_fields() {
+rust-fs-btrfs/src/superblock.rs:1190:    fn crc32c_ignores_the_unused_tail_of_the_csum_field() {
+rust-fs-btrfs/src/superblock.rs:1577:    fn checksum_digest_lengths_match_the_algorithms() {
+rust-fs-btrfs/src/superblock.rs:1601:    fn crc32c_digest_is_stored_little_endian() {
+rust-fs-btrfs/src/error.rs:172:    fn checksum_mismatch_names_the_structure_and_offset() {
+rust-img-vhd/src/footer.rs:107:pub fn compute_checksum(footer_bytes: &[u8]) -> u32 {
+rust-img-vhd/src/footer.rs:146:    fn checksum_round_trip_for_minimal_fixed_footer() {
+rust-img-vhd/src/dynamic.rs:131:pub fn compute_checksum(header_bytes: &[u8]) -> u32 {
+rust-img-vhd/src/dynamic.rs:176:    fn checksum_round_trip_for_minimal_dynamic_header() {
+
+=== 4. IN-MEMORY TEST DEVICES ===
+rust-fs-ext4/src/indirect_mut.rs:487:    struct MemDev {
+rust-fs-ext4/src/indirect.rs:222:    struct MemDev {
+rust-fs-ext4/tests/fuzz_smoke.rs:19:struct MemDevice {
+rust-fs-ext4/tests/uninit_group_flags_cleared.rs:38:struct MemDev {
+rust-fs-ext4/tests/mkfs_roundtrip.rs:16:struct MemDev {
+rust-fs-ext4/tests/extent_deep_insert.rs:65:struct MemDevice<'a> {
+rust-fs-ext4/tests/dir_block_checksums_after_writes.rs:37:struct MemDev {
+rust-fs-ntfs/src/mft_io.rs:442:    struct MemDev {
+rust-fs-ntfs/src/upcase.rs:248:    struct MemDev {
+rust-fs-ntfs/src/idx_block.rs:380:    struct MemDev(Vec<u8>);
+rust-fs-ntfs/src/write.rs:3814:    struct MemDev {
+rust-fs-ntfs/src/block_io.rs:272:    struct MemDev {
+rust-fs-ntfs/src/read.rs:936:    struct MemDev {
+rust-fs-ntfs/src/bitmap.rs:385:    struct MemDev {
+rust-fs-ntfs/src/fsck.rs:502:    struct MemDev {
+rust-fs-ntfs/src/mft_bitmap.rs:405:    struct MemDev {
+rust-fs-ntfs/tests/mkfs_roundtrip.rs:22:struct MemDev {
+rust-fs-xfs/src/log.rs:454:    struct MemDev(Mutex<Vec<u8>>);
+rust-fs-xfs/src/write.rs:513:    struct MemDev {
+rust-fs-erofs/src/chunked.rs:140:    pub(crate) struct MemDev(pub Mutex<Vec<u8>>);
+rust-fs-erofs/src/mkfs.rs:2773:    struct MemDev(Mutex<Vec<u8>>);
+rust-fs-erofs/src/superblock.rs:540:    struct MemDev(Vec<u8>);
+rust-fs-erofs/src/zmap.rs:1458:    struct MemDev(Mutex<Vec<u8>>);
+rust-fs-erofs/src/fs.rs:834:    struct MemDev(Mutex<Vec<u8>>);
+rust-fs-erofs/src/xattr.rs:559:    struct MemDev(Vec<u8>);
+rust-fs-erofs/tests/common/mod.rs:23:pub struct MemDev(Mutex<Vec<u8>>);
+rust-fs-squashfs/src/metablock.rs:158:    pub(crate) struct MemDev(pub Mutex<Vec<u8>>);
+rust-fs-squashfs/tests/common/mod.rs:23:pub struct MemDev(Mutex<Vec<u8>>);
+rust-img-vhdx/src/log.rs:657:    struct MemDevice(std::sync::Mutex<Vec<u8>>);
+rust-partitions/tests/mutation.rs:14:struct MemDev(Mutex<Vec<u8>>);
+rust-partitions/tests/bootable.rs:22:struct MemDev(Mutex<Vec<u8>>);
+
+=== 5. LOGICAL->PHYSICAL MAPPING (the extent/run/BAT/grain family) ===
+rust-fs-ext4/src/bgd.rs:144:pub fn locate_inode(
+rust-fs-ext4/src/extent.rs:388:pub fn map_logical(
+rust-fs-ext4/src/extent.rs:399:pub fn map_logical_verified(
+rust-fs-ext4/src/indirect.rs:100:pub fn map_logical_any(
+rust-fs-ntfs/src/write.rs:530:fn find_run_for_vcn(runs: &[DataRun], vcn: u64) -> Option<&DataRun> {
+rust-fs-ntfs/src/write.rs:4270:    fn find_run_for_vcn_returns_matching_run() {
+rust-fs-ntfs/src/write.rs:4278:    fn find_run_for_vcn_returns_none_when_past_end() {
+rust-fs-ntfs/src/write.rs:4285:    fn find_run_for_vcn_returns_none_on_empty_list() {
+rust-fs-ntfs/src/read.rs:178:fn locate_attribute<T: BlockIo + ?Sized>(
+rust-fs-ntfs/src/bitmap.rs:54:pub fn locate_bitmap(image: &Path) -> Result<BitmapLocation, String> {
+rust-fs-ntfs/src/bitmap.rs:59:pub fn locate_bitmap_io<T: BlockIo + ?Sized>(io: &mut T) -> Result<BitmapLocation, String> {
+rust-fs-ntfs/src/bitmap.rs:763:    fn locate_bitmap_io_on_formatted_volume_succeeds() {
+rust-fs-ntfs/src/bitmap.rs:771:    fn locate_bitmap_io_cluster_size_matches_format_params() {
+rust-fs-ntfs/src/bitmap.rs:778:    fn locate_bitmap_io_total_bits_covers_volume() {
+rust-fs-ntfs/src/fsck.rs:446:fn locate_volume_flags_io<T: FsckIo>(io: &mut T) -> Result<(u64, u16), String> {
+rust-fs-ntfs/src/fsck.rs:467:fn locate_logfile_data_io<T: FsckIo>(io: &mut T) -> Result<(u64, u64), String> {
+rust-fs-ntfs/src/fsck.rs:781:    fn locate_logfile_data_returns_nonzero_offset_and_length() {
+rust-fs-ntfs/src/mft_bitmap.rs:63:pub fn locate(image: &Path) -> Result<MftBitmap, String> {
+rust-fs-ntfs/src/mft_bitmap.rs:68:pub fn locate_io<T: BlockIo + ?Sized>(io: &mut T) -> Result<MftBitmap, String> {
+rust-fs-xfs/src/dir.rs:1897:    fn block_form_entry_offsets_are_block_offsets() {
+rust-fs-erofs/src/zmap.rs:900:    fn locate_compact_pack(&self, i: u64) -> Result<PackLocation> {
+rust-img-qcow2/src/reader.rs:1062:    fn lookup_cluster(&self, virt: u64) -> Result<ClusterMap> {
+
+=== 6. ALLOCATION BITMAPS ===
+rust-fs-ext4/src/inode.rs:15:/// Offset where the i_extra_isize field begins (start of extra section).
+rust-fs-ext4/src/inode.rs:18:// Raw inode field byte offsets (from the start of the on-disk inode, little-endian).
+rust-fs-ext4/src/inode.rs:41:/// Minimum inode buffer length for i_crtime (offset 0x90) to be present.
+rust-fs-ext4/src/inode.rs:58:    /// Spec: kernel.org/doc/html/latest/filesystems/ext4/inodes.html
+rust-fs-ext4/src/inode.rs:197:            // Layout (offset from inode start):
+rust-fs-ext4/src/inode.rs:270:    /// True when EXT4_EXTENTS_FL is set in i_flags — i_block holds an extent
+rust-fs-ext4/src/inode.rs:276:    /// True when INLINE_DATA flag is set — file contents live inside i_block.
+rust-fs-ext4/src/inode.rs:282:    pub fn flag_set(&self) -> InodeFlags {
+rust-fs-ext4/src/inode.rs:302:#[cfg(test)]
+rust-fs-ext4/src/inode.rs:303:mod tests {
+rust-fs-ext4/src/inode.rs:306:    #[test]
+rust-fs-ext4/src/inode.rs:314:    #[test]
+rust-fs-ext4/src/inode.rs:321:    #[test]
+rust-fs-ext4/src/inode.rs:327:    #[test]
+rust-fs-ext4/src/inode.rs:336:    #[test]
+rust-fs-ext4/src/inode.rs:348:    #[test]
+rust-fs-ext4/src/features.rs:3://! Spec source: kernel.org/doc/html/latest/filesystems/ext4/super.html
+rust-fs-ext4/src/features.rs:109:    /// No EXTENTS, HAS_JOURNAL set (jbd2-style log on a hidden journal inode).
+rust-fs-ext4/src/features.rs:111:    /// EXTENTS set (with or without a journal — modern ext4 typically has one).
+rust-fs-ext4/src/features.rs:127:    /// True when the driver should allocate new inodes with `EXT4_EXTENTS_FL`
+rust-fs-ext4/src/features.rs:128:    /// set (so file contents are tracked by an extent tree). False for ext2/3,
+rust-fs-ext4/src/file_mut.rs:3://! Composes bitmap allocation (E5/E6), extent-tree mutation (E7), and
+rust-fs-ext4/src/file_mut.rs:6://! - `split_into_block_writes` — turn a `(offset, data)` byte-range write into
+rust-fs-ext4/src/file_mut.rs:7://!   a list of `(logical_block, offset_in_block, payload_slice)` — the unit
+rust-fs-ext4/src/file_mut.rs:26:    /// Logical block number within the file (offset / block_size).
+rust-fs-ext4/src/file_mut.rs:28:    /// Byte offset within the block where the payload starts (0..block_size).
+rust-fs-ext4/src/file_mut.rs:29:    pub offset_in_block: u32,
+rust-fs-ext4/src/file_mut.rs:31:    /// and `offset_in_block == 0`.
+rust-fs-ext4/src/file_mut.rs:35:/// Split a byte-range write `(offset, data)` into per-block `BlockWrite` units.
+rust-fs-ext4/src/file_mut.rs:38:/// starts at `offset_in_block == 0` AND covers the full block, OR is the
+rust-fs-ext4/src/file_mut.rs:39:/// first write whose offset is not block-aligned. The last write may be
+rust-fs-ext4/src/file_mut.rs:41:pub fn split_into_block_writes(offset: u64, data: &[u8], block_size: u32) -> Vec<BlockWrite> {
+rust-fs-ext4/src/file_mut.rs:47:    let mut cur = offset;
+rust-fs-ext4/src/file_mut.rs:48:    let end = offset + data.len() as u64;
+rust-fs-ext4/src/file_mut.rs:58:            offset_in_block: off_in_block,
+rust-fs-ext4/src/file_mut.rs:80:pub fn compute_write_range(offset: u64, length: u64, block_size: u32) -> Option<WriteBlockRange> {
+rust-fs-ext4/src/file_mut.rs:85:    let first = offset / bs;
+rust-fs-ext4/src/file_mut.rs:86:    let last = (offset + length - 1) / bs;
+rust-fs-ext4/src/file_mut.rs:87:    let full_blocks = offset.is_multiple_of(bs) && (offset + length).is_multiple_of(bs);
+rust-fs-ext4/src/file_mut.rs:119:/// `FreePhysicalRun` entries against the bitmap allocator.
+rust-fs-ext4/src/file_mut.rs:122:/// return [`Error::CorruptExtentTree`] with a clear message — E9/E11 will
+rust-fs-ext4/src/file_mut.rs:220:#[cfg(test)]
+rust-fs-ext4/src/file_mut.rs:221:mod tests {
+rust-fs-ext4/src/file_mut.rs:228:    #[test]
+rust-fs-ext4/src/file_mut.rs:234:        assert_eq!(out[0].offset_in_block, 0);
+rust-fs-ext4/src/file_mut.rs:238:    #[test]
+rust-fs-ext4/src/file_mut.rs:243:        // block 0: offset 3000 to end, 1096 bytes
+rust-fs-ext4/src/file_mut.rs:245:        assert_eq!(out[0].offset_in_block, 3000);
+rust-fs-ext4/src/file_mut.rs:249:        assert_eq!(out[1].offset_in_block, 0);
+rust-fs-ext4/src/file_mut.rs:251:        // block 2: offset 0, 6000 - 1096 - 4096 = 808 bytes
+rust-fs-ext4/src/file_mut.rs:253:        assert_eq!(out[2].offset_in_block, 0);
+rust-fs-ext4/src/file_mut.rs:257:    #[test]
+rust-fs-ext4/src/file_mut.rs:262:    #[test]
+rust-fs-ext4/src/file_mut.rs:267:        assert_eq!(out[0].offset_in_block, 1000);
+rust-fs-ext4/src/file_mut.rs:275:    #[test]
+rust-fs-ext4/src/file_mut.rs:283:    #[test]
+rust-fs-ext4/src/file_mut.rs:291:    #[test]
+rust-fs-ext4/src/file_mut.rs:300:    #[test]
+rust-fs-ext4/src/file_mut.rs:307:    #[test]
+rust-fs-ext4/src/file_mut.rs:349:    #[test]
+
+=== 7. FFI PANIC GUARDS ===
+rust-fs-ext4/src/capi.rs:106:/// Wrap an FFI body in `catch_unwind`. If the body panics, record the panic
+rust-fs-ext4/src/capi.rs:109:fn ffi_guard<T>(fail: T, body: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
+rust-fs-ext4/src/capi.rs:110:    match std::panic::catch_unwind(body) {
+rust-fs-xfs/src/capi.rs:9://!    entry point runs inside [`catch_unwind`] and converts a panic into
+rust-fs-xfs/src/capi.rs:37:use std::panic::{catch_unwind, AssertUnwindSafe};
+rust-fs-xfs/src/capi.rs:121:    match catch_unwind(AssertUnwindSafe(f)) {
+rust-fs-btrfs/src/capi.rs:9://!    entry point runs inside [`catch_unwind`] and converts a panic into
+rust-fs-btrfs/src/capi.rs:36:use std::panic::{catch_unwind, AssertUnwindSafe};
+rust-fs-btrfs/src/capi.rs:108:    match catch_unwind(AssertUnwindSafe(f)) {
+rust-fs-erofs/src/capi.rs:90:fn ffi_guard<T>(fail: T, body: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
+rust-fs-erofs/src/capi.rs:91:    match std::panic::catch_unwind(body) {
+rust-fs-squashfs/src/capi.rs:73:/// Wrap an FFI body in `catch_unwind`, returning `fail` on panic. Crossing
+rust-fs-squashfs/src/capi.rs:75:fn ffi_guard<T>(fail: T, body: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
+rust-fs-squashfs/src/capi.rs:76:    match std::panic::catch_unwind(body) {
+rust-img-qcow2/src/capi.rs:72:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-qcow2/src/capi.rs:109:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vhd/src/capi.rs:49:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vhd/src/capi.rs:115:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vhd/src/capi.rs:154:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vhdx/src/capi.rs:53:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vhdx/src/capi.rs:89:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vmdk/src/capi.rs:65:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-img-vmdk/src/capi.rs:102:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-partitions/src/capi.rs:257:    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-partitions/src/capi.rs:285:    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-partitions/src/capi.rs:324:    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-partitions/src/capi.rs:363:    let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+rust-partitions/src/capi.rs:385:    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| unsafe {
+
+=== 8. ERROR ENUMS: variants per crate ===
+rust-fs-ext4: 20
+rust-fs-ntfs: no error.rs
+rust-fs-xfs: 13
+rust-fs-btrfs: 15
+rust-fs-erofs: 10
+rust-fs-squashfs: 10
+rust-img-qcow2: 11
+rust-img-vhd: 11
+rust-img-vhdx: 11
+rust-img-vmdk: 6
+rust-partitions: 10
+rust-lzo1x: no error.rs
+rust-blk-probe: no error.rs
+
+=== 9. SHARED ERROR VARIANT NAMES ACROSS CRATES ===
+   8 Io
+   7 ReadOnly
+   5 OutOfBounds
+   5 NotFound
+   5 NotADirectory
+   5 Corrupt
+   4 Unsupported
+   4 BadSuperblock
+   3 Block
+   3 BadChecksum
+   2 UnsupportedFeature
+   2 OutOfRange
+   2 NotAFile
+   2 DirtyLog
+   2 ChecksumMismatch
+   2 BlockIdentityMismatch
+   2 BadMetadata
+   2 BadInode
+   2 BadDirent
+   2 AlreadyExists
+   1 UnsupportedVersion
+   1 UnsupportedRoCompat
+   1 UnsupportedProfile
+   1 UnsupportedLayout
+   1 UnsupportedIncompat
+   1 UnsupportedDiskType
+   1 UnsupportedCompression
+   1 UnsupportedChecksum
+   1 UnmappedLogical
+   1 ParentTooDeep
+
+=== 10. OFFSET-TABLE CONVENTIONS ===
+rust-fs-ext4: offsets-modules=0 inline-hex-ranges=343
+rust-fs-ntfs: offsets-modules=0 inline-hex-ranges=61
+rust-fs-xfs: offsets-modules=13 inline-hex-ranges=0
+rust-fs-btrfs: offsets-modules=5 inline-hex-ranges=10
+rust-fs-erofs: offsets-modules=0 inline-hex-ranges=91
+rust-fs-squashfs: offsets-modules=0 inline-hex-ranges=9
+rust-img-qcow2: offsets-modules=0 inline-hex-ranges=0
+rust-img-vhd: offsets-modules=0 inline-hex-ranges=0
+rust-img-vhdx: offsets-modules=0 inline-hex-ranges=0
+rust-img-vmdk: offsets-modules=0 inline-hex-ranges=0
+rust-partitions: offsets-modules=0 inline-hex-ranges=3
+rust-lzo1x: offsets-modules=0 inline-hex-ranges=0
+rust-blk-probe: offsets-modules=0 inline-hex-ranges=0
+
+=== 11. TIMESTAMP CONVERSION ===
+rust-fs-ext4/src/mkfs.rs:740:        .duration_since(std::time::UNIX_EPOCH)
+rust-fs-ext4/src/fs.rs:144:    use std::time::{SystemTime, UNIX_EPOCH};
+rust-fs-ext4/src/fs.rs:146:        .duration_since(UNIX_EPOCH)
+rust-fs-ntfs/src/record_build.rs:21:/// "Now" as NT FILETIME (100 ns since 1601-01-01 UTC).
+rust-fs-ntfs/src/record_build.rs:22:pub fn nt_time_now() -> u64 {
+rust-fs-ntfs/src/record_build.rs:23:    const EPOCH_DIFF: u64 = 11_644_473_600;
+rust-fs-ntfs/src/record_build.rs:25:        .duration_since(std::time::UNIX_EPOCH)
+rust-fs-ntfs/src/record_build.rs:27:    let secs_since_1601 = dur.as_secs() + EPOCH_DIFF;
+rust-fs-ntfs/src/record_build.rs:28:    secs_since_1601 * 10_000_000 + (dur.subsec_nanos() as u64) / 100
+rust-fs-ntfs/src/record_build.rs:1081:    fn nt_time_now_is_above_year_2020_floor() {
+rust-fs-ntfs/src/record_build.rs:1082:        // Year 2020 in NT FILETIME (100ns since 1601-01-01).
+rust-fs-ntfs/src/mkfs.rs:2588:        .duration_since(std::time::UNIX_EPOCH)
+rust-fs-ntfs/src/lib.rs:433:/// Convert a raw NTFS FILETIME (100-ns intervals since 1601-01-01 UTC, as the
+rust-fs-ntfs/src/lib.rs:437:fn nt_parts(nt: u64) -> (i64, u32) {
+rust-fs-ntfs/src/lib.rs:1586:/// is NT FILETIME (100 ns since 1601-01-01 UTC). Pass `NULL` for any
+rust-fs-ntfs/src/lib.rs:2492:/// timestamps are NT 100-nanosecond intervals since 1601-01-01 UTC.
+rust-fs-ntfs/src/lib.rs:3598:    //! Inputs are raw NTFS FILETIMEs (100-ns intervals since 1601-01-01 UTC),
+rust-fs-ntfs/src/lib.rs:3604:        // 1970-01-01T00:00:00Z = 11644473600 seconds after 1601-01-01
+rust-fs-ntfs/src/write.rs:25:/// NTFS file times in 100 ns intervals since 1601-01-01 UTC.
+rust-fs-ntfs/src/facade.rs:422:/// Split an NTFS FILETIME (100-ns since 1601) into (Unix seconds, nanoseconds).
+rust-fs-ntfs/src/facade.rs:423:fn nt_parts(nt: u64) -> (i64, u32) {
+rust-fs-ntfs/src/read.rs:502:/// Seconds between the NTFS epoch (1601-01-01) and the Unix epoch (1970-01-01).
+rust-fs-ntfs/src/read.rs:503:const NT_UNIX_EPOCH_DIFF_SECS: i64 = 11_644_473_600;
+rust-fs-ntfs/src/read.rs:505:/// Convert an NTFS FILETIME (100-ns intervals since 1601-01-01 UTC) to whole
+rust-fs-ntfs/src/read.rs:508:    (nt / 10_000_000) as i64 - NT_UNIX_EPOCH_DIFF_SECS
+rust-fs-ntfs/src/read.rs:1194:        // NTFS epoch (1601-01-01) maps to -11_644_473_600 Unix seconds.
+rust-fs-xfs/src/inode.rs:176:const BIGTIME_EPOCH_OFFSET_SECS: i64 = -2_147_483_648;
+rust-fs-xfs/src/inode.rs:190:                sec: BIGTIME_EPOCH_OFFSET_SECS + (ns / NSEC_PER_SEC) as i64,
+rust-fs-xfs/src/inode.rs:211:            let from_epoch = self.sec.saturating_sub(BIGTIME_EPOCH_OFFSET_SECS);
+rust-fs-xfs/src/inode.rs:727:        assert_eq!(inode.atime.sec, BIGTIME_EPOCH_OFFSET_SECS + 1);
+
+=== 12. CACHES ===
+rust-fs-ext4/src/indirect.rs:53:pub struct IndirectCache {
+rust-fs-erofs/src/fs.rs:36:struct PclusterCache {
+rust-img-vmdk/src/reader.rs:82:struct GtCache {
+
+=== 13. DIRECTORY ITERATION ===
+rust-fs-ext4/src/dir.rs:60:pub struct DirBlockIter<'a> {
+rust-fs-ntfs/src/attr_io.rs:286:struct AttrIter<'a> {
+rust-fs-ntfs/src/lib.rs:413:pub struct FsNtfsDirIter {
+rust-fs-ntfs/src/facade.rs:266:    pub fn read_dir(&self, path: &str) -> Result<Vec<DirEntry>, Error> {
+rust-fs-ntfs/src/read.rs:818:pub fn read_dir_entries<T: BlockIo + ?Sized>(
+rust-fs-ntfs/src/read.rs:1347:    fn read_dir_on_a_file_errors() {
+rust-fs-xfs/src/fs.rs:596:    pub fn read_dir(&self, inode: &Inode, raw: &[u8]) -> Result<Vec<DirEntry>> {
+rust-fs-btrfs/src/fs.rs:694:    pub fn read_dir(&self, ino: u64) -> Result<Vec<DirEntry>> {
+rust-fs-erofs/src/fs.rs:305:    pub fn read_dir(&self, inode: &Inode) -> Result<Vec<DirEntry>> {
+rust-fs-squashfs/src/fs.rs:84:    pub fn read_dir(&self, inode: &Inode) -> Result<Vec<DirEntry>> {
+rust-img-qcow2/src/reader.rs:149:pub struct ExtentIter<'a> {
+
+=== 14. CARGO DEPENDENCIES (what each crate actually shares) ===
+--- rust-fs-ext4
+crc32c = "0.6"
+bitflags = "2"
+unicode-normalization = "0.1"
+caseless = "0.2"
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-fs-ntfs
+log = "0.4"
+am-fs-core = { path = "vendor/rust-fs-core", version = "0.2" }
+--- rust-fs-xfs
+crc32c = "0.6"
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-fs-btrfs
+crc32c = "0.6"
+twox-hash = { version = "2", default-features = false, features = ["xxhash64"] }
+sha2 = "0.10"
+blake2b_simd = "1.0"
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+miniz_oxide = "0.9.1"
+am-lzo1x = "0.1.0"
+ruzstd = "0.9.0"
+--- rust-fs-erofs
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+lz4_flex = { version = "0.11", default-features = false, features = ["safe-decode", "safe-encode"] }
+lzma-rs = "0.3"
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+crc32c = "0.6"
+lru = "0.12"
+--- rust-fs-squashfs
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+am-lzo1x = "0.1.0"
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+lzma-rs = "0.3"
+lz4_flex = { version = "0.11", default-features = false, features = ["safe-decode"] }
+ruzstd = "0.8"
+--- rust-img-qcow2
+flate2 = "1"
+ruzstd = "0.8"
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-img-vhd
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-img-vhdx
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+crc32c = "0.6"
+--- rust-img-vmdk
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-partitions
+crc32fast = "1"
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+--- rust-lzo1x
+--- rust-blk-probe
+am-fs-core = { path = "../rust-fs-core", version = "0.2" }
+am-img-qcow2 = { path = "../rust-img-qcow2", version = "0.4" }
+am-img-vhd = { path = "../rust-img-vhd", version = "0.3" }
+am-img-vhdx = { path = "../rust-img-vhdx", version = "0.3" }
+am-img-vmdk = { path = "../rust-img-vmdk", version = "0.3" }
+am-partitions = { path = "../rust-partitions", version = "0.3" }
+DONE
+```

--- a/docs/constellation/plan-2026-08-30.md
+++ b/docs/constellation/plan-2026-08-30.md
@@ -1,0 +1,390 @@
+# What to do about the duplication, and what to leave alone
+
+A plan against [`evidence-2026-08-30.md`](evidence-2026-08-30.md). Every
+claim here should be checkable against a section of that file or against
+a named file in the tree; where it rests on judgement instead, it says
+so.
+
+**The short answer to the premise.** Yes, there is real duplication, and
+no, `am-fs-core` is not the answer to most of it. fs-core genericises
+**I/O** — a block device, some adapters, an FFI handle — and does that
+well. Almost nothing else in the family is genuinely shared behaviour
+waiting to be pulled up. What the scan found is mostly *three different
+problems* wearing one costume:
+
+1. **helpers that are duplicated and identical** — cheap to fix, small
+   gain each, and the gain is not "less code" but "one place to be
+   wrong";
+2. **abstractions that exist and are too narrow to use** — the real
+   defect class, and the one that produced actual bugs;
+3. **conventions that differ between crates** — the largest readability
+   gap in the family, and not a code-sharing question at all.
+
+Sorting the work by which of those it is matters more than sorting it by
+line count.
+
+---
+
+## 0. The method, first, because it is what produced the results
+
+Everything below assumes this, and it is not optional:
+
+> Before changing a duplicated thing, **break each copy in turn and see
+> which ones anything notices.**
+
+Across the fixes made on 2026-08-30 this found, every time:
+
+| crate | what the probe found |
+|---|---|
+| ext4 | five of sixteen copies of the directory-tail checksum had **zero** tests — including `apply_mkdir`'s |
+| erofs | one of four copies of the pack geometry was a **discarded argument**; mutating it changed nothing because it could not |
+| vhd | two copies with opposite bounds discipline, so the asymmetry itself was the question |
+| btrfs, vhdx | every copy was genuinely covered — so consolidating was safe rather than merely tidy, and it was worth knowing that before starting |
+
+It also caught a bad *test*: the first ext4 growth test created two
+hundred files and then checked, and saw nothing, because every later
+write to a block fixed the checksum the path under test had got wrong.
+A test can be green for the reason the code is broken.
+
+**A consolidation without this probe is a refactor with an unknown
+blast radius.** With it, each one carries its own evidence: "these N
+copies were covered, this one was not, here is what fails now."
+
+One consequence worth stating: consolidating sometimes makes a value
+*harder* to catch, not easier. Three copies of `SECTOR_SIZE` could
+disagree with each other and a test would notice; one copy cannot
+disagree with anything, so the guard has to become a test of the value
+against the format. That trade is fine, but it has to be made
+deliberately and the replacement test written.
+
+---
+
+## 1. Do these — clear gain, bounded cost
+
+### 1.1 One in-memory test device per crate — **not one for the family**
+
+**Evidence:** §4, 31 declarations across 11 repos.
+
+The largest count in the scan, and the most tempting thing to put in
+fs-core. Do not put it in fs-core.
+
+- **ntfs cannot use it.** It has its own `BlockIo` trait —
+  `read_exact_at(&mut self) -> Result<(), String>` — which is a
+  different shape from `fs_core::BlockRead` in mutability, error type
+  and method names. Nine of the 31 copies are ntfs's, and a shared type
+  reaches none of them.
+- **Integration tests cannot see a `#[cfg(test)]` item.** Sharing with
+  `tests/` means exporting the device from the public API behind a
+  feature — changing what the crate offers the world for the
+  convenience of its own tests.
+
+So the shape that works is **one per crate, plus one per `tests/`
+directory** — which is what erofs now has (7 → 2, with the second
+justified by a compilation boundary rather than by laziness).
+
+| crate | copies | worth doing |
+|---|---|---|
+| ntfs | 9 | **yes** — the largest single win left |
+| ext4 | 7 | **yes** |
+| erofs | 7 → 2 | done |
+| xfs, squashfs, partitions, vhdx | 2–3 each | marginal; do it when touching the file anyway |
+
+**The gain is not fewer lines.** It is one definition of what happens on
+a read past the end. A device that quietly zero-fills makes a parser
+reading past its own structure look correct, which is the opposite of
+what a test device is for — and with nine copies, nine chances for one
+of them to do that.
+
+**Cost:** an afternoon per crate for ntfs and ext4. **Risk:** low; the
+copies are near-identical and every one is exercised by definition.
+**Verify:** mutate the shared device to stop refusing short reads and
+require tests to fail.
+
+### 1.2 Adopt one FFI panic guard — but **not by adopting fs-core's**
+
+**Evidence:** §7, `catch_unwind` hand-rolled in 11 crates in two shapes.
+
+This looked like the cleanest cross-crate win and it has a trap in it.
+
+`fs_core::ffi::ffi_guard_or` records the panic message into **fs-core's**
+thread-local, read by `fs_core_last_error_message()`. The private
+`ffi_guard` in ext4, erofs and squashfs records into **their own**, read
+by `fs_ext4_last_error()` and friends — which is what their C callers
+actually call. Swapping one for the other would move every panic message
+to a slot no consumer reads.
+
+So the shareable part is not the guard. It is:
+
+- **`panic_message()`** — the downcast ladder over `&'static str` /
+  `String` / neither, which is written four times and produces four
+  different strings for the same panic (`"panic: {s}"`,
+  `"panic (non-string payload)"`, …).
+- **the shape of the guard**, as a documented idiom rather than a shared
+  function.
+
+**Concretely:** export `fs_core::ffi::panic_message` (it is already
+written, currently private), and give the guard a sink so a crate can
+pass its own error setter:
+
+```rust
+pub fn ffi_guard_with<T, F>(fail: T, sink: impl FnOnce(String), body: F) -> T
+```
+
+Then each crate's `ffi_guard` becomes a two-line call that keeps its own
+thread-local. Eleven crates, one panic-message format, no consumer
+breakage.
+
+**Cost:** small in fs-core, one small PR per crate. **Risk:** low, but
+each crate needs a test that a panicking entry point leaves a message in
+*its own* error slot — which is exactly the test that was missing in
+fs-core and found three swallowed panics there.
+
+### 1.3 Dependency hygiene
+
+**Evidence:** §14.
+
+Three specific items, all cheap:
+
+- **`ruzstd` is 0.8 in squashfs and qcow2, 0.9.0 in btrfs.** Pick one.
+  Version skew inside one dependency tree means two copies of a
+  decompressor in any binary that links both, and a bug fixed in one is
+  not fixed in the other.
+- **ntfs depends on `am-fs-core` through `vendor/rust-fs-core`; the
+  other twelve use `../rust-fs-core`.** One crate resolves its sibling
+  differently from every other, which is a trap for the sibling-build
+  script and for anyone reading two `Cargo.toml`s side by side.
+- **`lru` in erofs only.** Fine, but see §2.3.
+
+**Do not unify the two CRC32 crates.** The evidence file flags
+`crc32c` (five crates) against `crc32fast` (partitions) as a possible
+problem. It is not: partitions computes GPT's CRC-32/ISO-HDLC, and the
+filesystems compute CRC-32C/Castagnoli. **Different polynomials, both
+correct.** Unifying them would be a bug. This row is corrected in the
+evidence document.
+
+**Cost:** an hour. **Risk:** the `ruzstd` bump needs each crate's
+decompression tests re-run against real images.
+
+---
+
+## 2. Do these, but they are bigger than they look
+
+### 2.1 Name the on-disk offsets in ext4 and erofs
+
+**Evidence:** §10 — ext4 has **343** inline hex slice ranges and zero
+named-offset modules; erofs has 91; ntfs has 61. xfs has **13 offset
+modules and zero inline ranges**.
+
+This is the largest readability gap in the family, and it is **not a
+code-sharing problem**. Two crates in one family have opposite
+conventions for the same job, and xfs's is demonstrably the better one —
+its own offset module says why:
+
+> a numeric literal in a parse expression carries no way to tell a
+> correct offset from a typo, and two of the three bugs this crate has
+> shipped were exactly that
+
+That is the argument, from the crate that learned it the hard way.
+
+**But it is a very large change.** 343 sites in ext4 is not an
+afternoon, and a mechanical rewrite of offset literals is exactly the
+kind of change that introduces the bug it was meant to prevent.
+
+**How to do it without that risk:**
+
+1. Add the offsets module **first**, with the constants and no callers.
+2. Add a test that each constant equals the literal currently at that
+   site — the offsets module checked against the code it is about to
+   replace, which is the only oracle available.
+3. Convert **one structure at a time**, running the full suite between
+   each. ext4's inode is one structure; the superblock is another.
+4. Never convert a site the suite does not cover. Probe it first (§0);
+   an uncovered offset is a finding in its own right, and ext4 already
+   produced five of those.
+
+**Cost:** weeks, spread. **Gain:** the largest single improvement to how
+the two biggest crates read. **Risk:** high if done mechanically, low if
+done structure-at-a-time with the tests as the gate.
+
+**Do erofs first.** 91 sites rather than 343, and its M22 finding
+already names it.
+
+### 2.2 The error-code mapping, not the error types
+
+**Evidence:** §8–9 — eleven error enums, ~130 variants, with `Io`,
+`ReadOnly`, `OutOfBounds`, `NotFound`, `NotADirectory` and `Corrupt`
+appearing in five to eight of them.
+
+**Do not unify the error types.** A driver's errors are its vocabulary,
+and they are more specific than the shared names suggest: xfs's
+`BlockIdentityMismatch` carries an expected and a found address; btrfs's
+`UnsupportedProfile` names a RAID profile. Folding those into a common
+`Corrupt` would make every one of them vaguer, and the value of the
+errors this family produces is precisely that they are specific — that
+is what made the human-code sweep able to say *which* refusal a caller
+would see.
+
+**Do share the mapping to errno.** Eight files implement some form of
+"turn this error into a C error code", and `ntfs` does it by matching on
+the error's *rendered message string* (`infer_errno_from_message`),
+which is what happens when a crate has no error enum to match on.
+
+The shareable piece is small and concrete: the errno constants and the
+`Error → code` convention, so `ENOTEMPTY` is not `66` in one crate with
+a comment saying "macOS; Linux is 39; both non-zero, good enough" on a
+public ABI.
+
+**Cost:** medium. **Risk:** it is the C ABI; every change is observable
+by a consumer. Needs a test per crate that each variant maps to the code
+the header documents.
+
+### 2.3 Look at the caches together — once
+
+**Evidence:** §12 — `IndirectCache` (ext4), `PclusterCache` (erofs),
+`GtCache` (vmdk), plus `fs_core::CachingDevice`, plus ext4's own
+`block_cache::CachedDevice`, plus a **second, unused** LRU in
+`ext4/src/block_io.rs` that the ext4 report already flags as ~200 dead
+lines with a name that collides with the live one.
+
+Four caches and two dead ones is not obviously wrong — a grain-table
+cache and a pcluster cache genuinely differ. But nobody has looked at
+them as a set, and the dead one in ext4 should go regardless.
+
+**Do:** delete ext4's dead `CachingDevice` (it is already a filed
+finding). **Then:** one investigation, not a refactor — write down what
+each cache keys on and what it evicts on, and only then decide whether
+any two are the same.
+
+---
+
+## 3. Do not do these
+
+### 3.1 Do not centralise the endian readers
+
+**Evidence:** §2 — 14 definitions across three crates.
+
+It looks like the obvious shared helper and it is the wrong call.
+
+XFS is **big-endian throughout**; btrfs, ext4, erofs, squashfs and every
+image format are **little-endian throughout**. Each crate's module now
+says so explicitly, and says there is deliberately no half for the other
+byte order — *a big-endian read in this crate would be a bug, and a
+helper for it would make the bug spellable.*
+
+A shared `fs_core::endian` with both halves would delete that guarantee
+from every crate at once, in exchange for saving three functions each.
+A byte-order slip is invisible to a round trip through a single crate —
+reader and writer agree with each other while disagreeing with the
+kernel — so the compile-time impossibility is worth more than the
+deduplication.
+
+**Within** a crate, consolidate freely. btrfs went 3 → 1 and vhdx 9 → 1
+on 2026-08-30. **Across** crates, do not.
+
+### 3.2 Do not build a generic "filesystem" trait yet
+
+The tempting shape is a `Filesystem` trait with `read_dir`, `stat`,
+`read_at` that all six drivers implement. §13 shows six crates with a
+`read_dir` and that is exactly the evidence that does *not* support it:
+a shared name is not a shared shape.
+
+Two concrete reasons to wait:
+
+- The consumers already have this abstraction, at the right level, in
+  Swift: `MountableFileSystem` and `FileSystemItem<Tag>` in
+  DiskJockeyLibrary. A second one in Rust would have to agree with it,
+  and the FSKit side is where the requirements actually live.
+- The drivers are not at the same maturity. ext4 and ntfs read and
+  write; xfs writes through a journal; erofs, squashfs and btrfs are
+  read-only. A trait wide enough for all six is either mostly
+  `unimplemented!` or so narrow it says nothing.
+
+Revisit when btrfs's write path lands, because that is when the shapes
+would actually have to agree.
+
+### 3.3 Do not unify the two CRC32 crates
+
+Covered in §1.3 — different polynomials, both correct.
+
+---
+
+## 4. Needs investigation before it can be planned
+
+### The logical-to-physical mapping
+
+The one genuinely interesting question, and the scan cannot answer it.
+
+Seven crates map a logical position to a physical one:
+
+| crate | mechanism |
+|---|---|
+| ext4 | extent tree, and indirect blocks for ext2/3 |
+| ntfs | data runs |
+| xfs | bmbt |
+| btrfs | file extent items |
+| qcow2 | two-level L1/L2 table |
+| vhd, vhdx | block allocation table |
+| vmdk | grain directory + grain tables |
+
+They rhyme: each takes a logical block, walks a structure, and returns
+either a physical block, a hole, or "defer to a parent image". Several
+have the same three-way outcome and the same sparse-file semantics.
+
+**Whether that is one algorithm or seven that merely rhyme is not
+knowable from a grep**, and the difference decides whether this is the
+biggest win in the family or a trap. The honest next step is one
+investigation with a written output: take the seven `map_logical` /
+`lookup_cluster` / `find_run_for_vcn` bodies, put their control flow
+side by side, and answer three questions —
+
+1. Do they return the same *kinds* of answer? (present / hole / parent /
+   compressed / unwritten)
+2. Do they share a caching or bounds-checking discipline, or does each
+   invent one?
+3. Would a shared type make each driver's mapping code shorter **and
+   clearer**, or only shorter?
+
+If the answer to (3) is "only shorter", stop. That is the test this
+whole plan should be held to.
+
+---
+
+## 5. Order
+
+Roughly by ratio of gain to risk:
+
+| # | work | size | why here |
+|---|---|---|---|
+| 1 | Dependency hygiene (§1.3) | hours | Cheapest real fix; unblocks nothing but costs nothing |
+| 2 | ntfs and ext4 test devices (§1.1) | days | Largest count, lowest risk, no public surface touched |
+| 3 | `panic_message` + guard sink (§1.2) | days | Fixes a live defect class — swallowed panics — in eleven crates |
+| 4 | Delete ext4's dead cache (§2.3) | hours | Already a filed finding; ~200 lines and a name collision |
+| 5 | erofs offsets (§2.1) | week+ | The convention fix, at the smaller of the two sites, as a rehearsal |
+| 6 | Mapping investigation (§4) | week | Answer before planning; may make 7 unnecessary |
+| 7 | ext4 offsets (§2.1) | weeks | Biggest readability gain, biggest care required |
+| 8 | errno mapping (§2.2) | weeks | C ABI; wants doing once, deliberately |
+
+Items 1–4 are safe to start now and could be done in a fortnight of
+part-time work. Item 6 gates whether anything larger is worth doing at
+all.
+
+---
+
+## 6. How to tell whether this worked
+
+Not by line count. Three checks, all of which the 2026-08-30 fixes can
+already be measured against:
+
+- **Coverage moved the right way.** After each consolidation, mutating
+  the single definition should fail *more* tests than mutating any one
+  copy did before. btrfs: 4 and 20 → 72. vhdx: 2/3/4/11 → 18. ext4:
+  five sites at zero → 12.
+- **The reasons are written down.** Every consolidation above should
+  leave behind a doc comment saying what is *not* there and why — no
+  big-endian half, no bounds check and the sizing argument that makes it
+  safe, the one copy that stays and the compilation boundary that
+  justifies it. A shared helper with no such note is a helper the next
+  person will duplicate again.
+- **Nothing got vaguer.** If an error message, a refusal, or a type got
+  less specific in order to be shared, that is a loss even if the diff
+  is negative.

--- a/docs/constellation/scan.sh
+++ b/docs/constellation/scan.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Evidence for: is there a layer of shared behaviour above am-fs-core
+# that the driver and image crates each re-implement?
+#
+# Writes $CLAUDE_JOB_DIR/tmp/constellation-evidence.txt. Set
+# CLAUDE_JOB_DIR to anywhere writable:
+#
+#     CLAUDE_JOB_DIR=/tmp docs/constellation/scan.sh
+#
+# Expects the sibling crates checked out beside this repository, which
+# is the same layout `scripts/sibling-build.sh` assumes.
+#
+# These are greps: they count text, not meaning. Sections 2, 6 and 13
+# are known to under- or over-count — see the "How to read it" section
+# of the evidence document for which and why.
+set -u
+# The siblings live beside this repository, not inside it.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.." || exit 1
+OUT="${CLAUDE_JOB_DIR:?set CLAUDE_JOB_DIR to a writable directory}/tmp/constellation-evidence.txt"
+mkdir -p "$(dirname "$OUT")"
+: > "$OUT"
+REPOS="rust-fs-ext4 rust-fs-ntfs rust-fs-xfs rust-fs-btrfs rust-fs-erofs rust-fs-squashfs rust-img-qcow2 rust-img-vhd rust-img-vhdx rust-img-vmdk rust-partitions rust-lzo1x rust-blk-probe"
+
+say() { echo "$@" >> "$OUT"; }
+
+say "=== 1. SIZE ==="
+printf '%-18s %8s %8s\n' repo src tests >> "$OUT"
+for r in $REPOS; do
+  s=$(find "$r/src" -name '*.rs' 2>/dev/null -exec cat {} + | wc -l | tr -d ' ')
+  t=$(find "$r/tests" -name '*.rs' 2>/dev/null -exec cat {} + | wc -l | tr -d ' ')
+  printf '%-18s %8s %8s\n' "$r" "$s" "$t" >> "$OUT"
+done
+
+say ""
+say "=== 2. ENDIAN HELPERS (per-crate fn definitions) ==="
+for r in $REPOS; do
+  n=$(grep -rhcE "^\s*(pub(\(crate\))? )?(const )?fn (read_)?(le|be)_?(u)?(8|16|32|64)" "$r/src" 2>/dev/null | paste -sd+ - | bc 2>/dev/null)
+  say "$r: ${n:-0}"
+  grep -rnE "^\s*(pub(\(crate\))? )?(const )?fn (read_)?(le|be)_?(u)?(8|16|32|64)" "$r/src" 2>/dev/null | sed "s|^|    |" >> "$OUT"
+done
+
+say ""
+say "=== 3. CHECKSUM IMPLEMENTATIONS ==="
+grep -rn "fn crc32\|fn linux_crc32c\|const CRC32\|CRC32C_TABLE\|fn compute_checksum\|fn checksum" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null >> "$OUT"
+
+say ""
+say "=== 4. IN-MEMORY TEST DEVICES ==="
+grep -rn "struct MemDev\|struct MemoryDevice\|struct MemBlockDevice\|struct InMemoryDevice\|struct TestDevice" $(for r in $REPOS; do echo "$r/src" "$r/tests"; done) 2>/dev/null >> "$OUT"
+
+say ""
+say "=== 5. LOGICAL->PHYSICAL MAPPING (the extent/run/BAT/grain family) ==="
+grep -rn "fn map_logical\|fn lookup_cluster\|fn find_run_for_vcn\|fn locate\|fn resolve_block\|fn block_for\|fn translate" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null >> "$OUT"
+
+say ""
+say "=== 6. ALLOCATION BITMAPS ==="
+grep -rn "fn.*bitmap.*(get\|set\|test\|clear\|alloc\|free)\|fn bitmap_\|fn set_bit\|fn clear_bit\|fn test_bit" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null | head -60 >> "$OUT"
+
+say ""
+say "=== 7. FFI PANIC GUARDS ==="
+grep -rn "fn ffi_guard\|catch_unwind" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null >> "$OUT"
+
+say ""
+say "=== 8. ERROR ENUMS: variants per crate ==="
+for r in $REPOS; do
+  n=$(grep -cE "^\s{4}[A-Z][A-Za-z0-9]*(\s*\{|\(|,)" "$r/src/error.rs" 2>/dev/null)
+  say "$r: ${n:-no error.rs}"
+done
+
+say ""
+say "=== 9. SHARED ERROR VARIANT NAMES ACROSS CRATES ==="
+for r in $REPOS; do
+  grep -hoE "^\s{4}[A-Z][A-Za-z0-9]*" "$r/src/error.rs" 2>/dev/null | tr -d ' '
+done | sort | uniq -c | sort -rn | head -30 >> "$OUT"
+
+say ""
+say "=== 10. OFFSET-TABLE CONVENTIONS ==="
+for r in $REPOS; do
+  n=$(grep -rc "mod offsets" "$r/src" 2>/dev/null | grep -v ':0' | wc -l | tr -d ' ')
+  h=$(grep -rhoE "\[0x[0-9a-fA-F]+\.\.0x[0-9a-fA-F]+\]" "$r/src" 2>/dev/null | wc -l | tr -d ' ')
+  say "$r: offsets-modules=$n inline-hex-ranges=$h"
+done
+
+say ""
+say "=== 11. TIMESTAMP CONVERSION ==="
+grep -rn "fn nt_time\|fn unix_to\|fn to_unix\|EPOCH\|fn nt_parts\|1601\|11644473600" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null | head -30 >> "$OUT"
+
+say ""
+say "=== 12. CACHES ==="
+grep -rn "struct .*Cache\b" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null >> "$OUT"
+
+say ""
+say "=== 13. DIRECTORY ITERATION ==="
+grep -rn "struct .*DirIter\|struct .*Iter<\|fn iter_dir\|fn read_dir\|fn list_dir" $(for r in $REPOS; do echo "$r/src"; done) 2>/dev/null | head -40 >> "$OUT"
+
+say ""
+say "=== 14. CARGO DEPENDENCIES (what each crate actually shares) ==="
+for r in $REPOS; do
+  say "--- $r"
+  sed -n '/^\[dependencies\]/,/^\[/p' "$r/Cargo.toml" 2>/dev/null | grep -E "^[a-z]" >> "$OUT"
+done
+echo "DONE" >> "$OUT"


### PR DESCRIPTION
`docs/constellation/` — the evidence behind the "does `am-fs-core` genericise enough?" question, the script that produced it, and a plan.

### The answer to the premise

**Half right.** The duplication is real. `am-fs-core` is not where most of it belongs — it genericises I/O and does that well, and almost nothing else in the family is shared behaviour waiting to be pulled up.

What the scan found is three different problems wearing one costume: helpers that are duplicated and identical, **abstractions that exist and are too narrow to use**, and conventions that differ between crates. Sorting by which of those a thing is matters more than sorting by line count.

### Two checks while writing the plan changed it

**Adopting fs-core's FFI guard downstream would be wrong.** The private `ffi_guard` in ext4, erofs and squashfs records the panic into *their own* thread-local — which is what `fs_ext4_last_error()` and friends read. fs-core's records into fs-core's. Swapping them moves every panic message to a slot no consumer reads. The shareable part is `panic_message` plus a guard that takes a sink, not the guard.

**The two CRC32 crates are not a problem.** partitions computes GPT's CRC-32/ISO-HDLC; the filesystems compute CRC-32C/Castagnoli. Different polynomials, both correct — unifying them would be a bug. The evidence row is corrected and kept as a worked example of a grep finding that does not survive being looked at.

### What the plan says not to do

- **Do not centralise the endian readers.** Each crate's module now states there is deliberately no half for the other byte order — *a big-endian read in this crate would be a bug, and a helper for it would make the bug spellable*. A shared module with both halves deletes that guarantee from every crate at once, to save three functions each. A byte-order slip is invisible to a round trip through one crate, so the compile-time impossibility is worth more than the deduplication.
- **Do not build a generic `Filesystem` trait yet.** Six crates having a `read_dir` is a shared *name*, not a shared shape. The abstraction already exists at the right level in Swift (`MountableFileSystem`), and three of the six drivers are read-only — a trait wide enough for all of them is either mostly `unimplemented!` or says nothing.
- **Do not unify the error types.** ~130 variants across eleven enums with six shared names, but xfs's `BlockIdentityMismatch` carries an expected and a found address. Folding that into a common `Corrupt` makes every message vaguer, and specificity is what these errors are for. Share the *errno mapping* instead.

### What it says to do, in order

| # | work | size |
|---|---|---|
| 1 | Dependency hygiene — `ruzstd` skew, ntfs's `vendor/` sibling path | hours |
| 2 | ntfs (9 copies) and ext4 (7) test devices — **one per crate, not one for the family** | days |
| 3 | `panic_message` + a guard sink — fixes swallowed panics in eleven crates | days |
| 4 | Delete ext4's dead second LRU (~200 lines, name collides with the live one) | hours |
| 5 | erofs offsets (91 sites) as a rehearsal for ext4 (343) | week+ |
| 6 | **Investigate** the logical→physical mapping across seven crates | week |
| 7 | ext4 offsets | weeks |
| 8 | errno mapping | weeks |

Item 6 gates whether anything larger is worth doing at all — whether the mapping in ext4 extents, NTFS data runs, XFS bmbt, btrfs, VHD BATs, qcow2 L1/L2 and VMDK grain tables is one algorithm or seven that rhyme is **not knowable from a grep**, and the answer decides whether it is the biggest win in the family or a trap.

### The method section is the part that matters

> Before changing a duplicated thing, break each copy in turn and see which ones anything notices.

Every fix made on 2026-08-30 that used this found something the report had not: five of ext4's sixteen checksum copies had **zero** tests; one of erofs's four geometry copies was a **discarded argument**; vhd's two copies had opposite bounds discipline. It also caught a bad *test* — a growth test that was green because every later write fixed the checksum the path under test had got wrong.

### Success is explicitly not line count

Coverage must move the right way (btrfs 4 and 20 → **72**; vhdx 2/3/4/11 → **18**; ext4 five sites at zero → **12**), the reasons must be written down, and nothing may get vaguer in order to be shared.

https://claude.ai/code/session_01KBZm6RgVBWbeeAS8FoAag3