### PR TITLE
fix: the reaper says what it measured, not more

### DIFF
--- a/scripts/am-worktree-reap
+++ b/scripts/am-worktree-reap
@@ -164,7 +164,23 @@ consider() {
             return
         fi
         if [ "$unpushed" -gt 0 ]; then
-            keep "$path" "$unpushed unpushed commit(s) on '$branch'"
+            # AHEAD OF THE TRACKING REF, WHICH IS NOT THE SAME AS
+            # UNPUSHED. `@{upstream}` is a local remote-tracking branch
+            # and it is only as current as the last fetch, so a commit
+            # pushed from elsewhere -- or pushed from here by explicit
+            # refspec, which does not move it -- reads as ahead forever.
+            #
+            # One worktree here reported "1 unpushed commit" for a commit
+            # that was already on the remote at the same sha. Keeping it
+            # was still right; claiming it was unpushed was not, and a
+            # message that overstates its evidence is how a correct
+            # refusal gets argued with.
+            #
+            # Asking the remote per worktree would be a network call
+            # apiece, which is too slow for the several dozen this scans.
+            # So the wording states what was actually measured and the
+            # decision stays conservative.
+            keep "$path" "$unpushed commit(s) ahead of a tracking ref that may be stale — not proven pushed"
             return
         fi
     fi


### PR DESCRIPTION
`am-worktree-reap` reported **"1 unpushed commit(s)"** for a commit that was already on the remote at the same sha.

`@{upstream}` is a local remote-tracking branch and is only as current as the last fetch. A commit pushed from elsewhere — or pushed from here by explicit refspec, which does not move the tracking ref — reads as ahead indefinitely.

**Keeping the worktree was still correct.** Claiming the commit was unpushed was not, and that distinction matters more than it looks: a message overstating its evidence is how a correct refusal gets argued with. The next reader checks, finds the commit on the remote, and concludes the tool is wrong about the thing it was right about.

Asking the remote per worktree would be a network call apiece, too slow for the several dozen this scans. So the decision stays conservative and only the wording changes to match what was measured:

```
before:  1 unpushed commit(s) on 'cth/an-entrys-tail-belongs-to-the-partition'
after:   1 commit(s) ahead of a tracking ref that may be stale — not proven pushed
```

Found while reaping worktrees after a batch of merges: the reaper flagged a branch as holding unpushed work, and `ls-remote` showed it at the identical sha.

https://claude.ai/code/session_01HTGSqRj8p3JjekeP9pP6iz