### PR TITLE
docs: a resolution needs three checks, and mind zsh's :t modifier

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -376,6 +376,13 @@ in this environment.
 ref, and fails open with "stale info" without one. Name the sha you
 fetched and refuse if the remote has moved.
 
+**Brace a ref before a colon in zsh: `${REF}:path`, never `$REF:path`.**
+`:t` is a zsh history modifier meaning "tail", so `$M:tests/x` expands to
+`basename($M)` followed by `ests/x` — `mainests/x`. Five separate silent
+failures in one session traced to this: branches that appeared to touch
+no files, a CI job that appeared to run no tests, a test set that came
+back empty. Each looked like a finding.
+
 **No `grep -q` at the end of a pipeline under `set -o pipefail`.** It
 exits on first match, the producer gets SIGPIPE, and the pipeline exits
 141 *because* the match succeeded.
@@ -421,8 +428,29 @@ what is missing is a test.
     diff <(git show $THEIRS:$FILE | grep -o 'fn [a-z_0-9]*' | sort -u) \
          <(grep -o 'fn [a-z_0-9]*' $FILE | sort -u)
 
-**4a. A function-set comparison answers "was anything dropped" and
-nothing else.** A conflict boundary can bisect a function, leaving one
+**4a. A resolution needs three checks, and each catches what the others
+cannot.**
+
+| check | catches | misses |
+|---|---|---|
+| function-set comparison | a side silently dropped | anything structural |
+| `cargo test --no-run` | a bisected function, unclosed delimiter | a valid but wrong splice |
+| the full suite | a splice that compiles and means something else | — |
+
+The third is not redundant. One resolution here had whole-file brace
+balance `+0`, dropped nothing from either side, and **compiled** — and
+had spliced the tail of one test into the body of another. `124 passed,
+1 failed`, `assertion left == right, left: 2, right: 1`. Two of the
+three checks passed.
+
+**Brace-counting says how many braces are missing, not where they go**,
+and a plausible placement compiles. So when a conflict bisects a
+function, resolve it structurally rather than textually: take one side's
+file whole, append the other's additions as complete units, and verify
+each affected function name appears exactly once.
+
+**A function-set comparison answers "was anything dropped" and nothing
+else.** A conflict boundary can bisect a function, leaving one
 trailing brace two tests want: the set comparison passes and the file
 does not compile — and the near-miss version *does* compile, with one
 test's body inside another. Pair it with `cargo test --no-run`.

--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -210,6 +210,29 @@ first** — a guard's comparison is often written twice, once in the guard
 and once in a test's assertion about it, so a blind substitution edits
 the test, goes green, and reports a guard nothing touched.
 
+**Separate a compile error from a test failure.** Both give `EXIT=101`,
+and they are not the same evidence. Three controls in one session came
+back as compile errors:
+
+- **vmdk** — the fix widened `Arc<dyn BlockDevice>` to `Arc<dyn BlockRead>`.
+  Reverting it means the new tests cannot express what they test, because
+  a read-only device has no `BlockDevice` impl to pass. The type *is* the
+  guard, and the compile error is the complete control.
+- **ext4** — the test sources the script, and the previous version runs
+  its `case` at load and exits 2. The failure is "command not found",
+  not "defect detected". Worthless as a control.
+- **partitions** — the tests reference a new API, so reverting any of
+  three source files gives compile errors. Proves coupling, not
+  behaviour.
+
+Two of the three needed a **neutered guard** instead — the specific
+comparison replaced with `if false`, uniqueness asserted first — which
+yields named failures and leaves the sibling assertions green, so a fix
+that over-corrected would fail too.
+
+    compile-errors=$(grep -acE '^error\[E[0-9]+\]' log)
+    test-failures=$(grep -acE '^test .* FAILED' log)
+
 **A surviving mutation may mean the test is missing, not the code.** Ask
 whether the check is unwitnessed rather than inert, and build the case it
 exists for.


### PR DESCRIPTION
Two lessons from one conflict resolution.

**A resolution needs three checks, not two.** One resolution here had whole-file brace balance `+0`, dropped nothing from either side, and **compiled** — and had spliced the tail of one test into the body of another.

```
brace balance            +0                 pass
function-set comparison  nothing dropped    pass
cargo test --no-run      compiled           pass
cargo test               124 passed, 1 FAILED
                         assertion left == right, left: 2, right: 1
```

| check | catches | misses |
|---|---|---|
| function-set comparison | a side silently dropped | anything structural |
| `--no-run` | bisected function, unclosed delimiter | a valid but wrong splice |
| the full suite | a splice that compiles and means something else | — |

**Brace-counting says how many braces are missing, not where they go**, and a plausible placement compiles. So a conflict that bisects a function wants a structural resolution rather than a textual one: take one side's file whole, append the other's additions as complete units, verify each affected function name appears exactly once.

**And zsh's `:t` modifier**, which caused five silent failures in one session before I found it:

```
$M:tests/x     ->  mainests/x        # :t means "tail" — basename($M) + "ests/x"
${M}:tests/x   ->  refs/.../main:tests/x
```

Branches appeared to touch no files. A CI job appeared to run no tests. A test set came back empty. Each looked like a finding rather than a quoting bug, and each would have been reported as one.

https://claude.ai/code/session_01HTGSqRj8p3JjekeP9pP6iz