### PR TITLE
fix: the six bundle lockfiles now pin the am-fs-core release that fixes silent-wrong-bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # First, and needs nothing but the checkout -- no network, no
+      # toolchain. A stale transitive pin can sit for a long time
+      # otherwise: am-fs-core sat six releases behind for eight
+      # releases, missing a silent-wrong-bytes fix, because a lockfile
+      # can be internally self-consistent and still not use a version
+      # anyone has actually verified. See diskjockey#90 and the
+      # script's own header for why this is not the same check as the
+      # pre-commit hook's `cargo metadata --locked`.
+      - name: Check bundle dependency floor
+        run: scripts/check-bundle-core-pin.sh
+
       # The siblings are checkouts beside this repository now, not
       # submodules. Cloned at the ref SIBLING_PINS.txt names, so CI builds
       # what the pin says rather than whatever a developer has locally.
@@ -71,6 +82,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+
 
       # lib/ output is keyed on what now determines it: the bundle
       # manifests, which name the published crate versions, and the

--- a/rust-bundles/dj-btrfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-btrfs-bundle/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-img-qcow2"

--- a/rust-bundles/dj-erofs-bundle/Cargo.lock
+++ b/rust-bundles/dj-erofs-bundle/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-fs-erofs"

--- a/rust-bundles/dj-ext4-bundle/Cargo.lock
+++ b/rust-bundles/dj-ext4-bundle/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-fs-ext4"

--- a/rust-bundles/dj-ntfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-ntfs-bundle/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-fs-ntfs"

--- a/rust-bundles/dj-squashfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-squashfs-bundle/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-fs-squashfs"

--- a/rust-bundles/dj-xfs-bundle/Cargo.lock
+++ b/rust-bundles/dj-xfs-bundle/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "am-fs-core"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c00781b62009bed91093230d1cd103d6155b264a574c661876b33154a4fad58"
+checksum = "df95dc5d599cb2980663dd567b8b7abf68f6866676763b7989880b08d1e8f0a4"
 
 [[package]]
 name = "am-fs-xfs"

--- a/scripts/check-bundle-core-pin.sh
+++ b/scripts/check-bundle-core-pin.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# check-bundle-core-pin.sh — refuse a committed bundle lockfile that resolves
+# am-fs-core below the minimum this project has actually verified.
+#
+# WHY THIS EXISTS RATHER THAN RELYING ON .githooks/pre-commit.d/rust-deps-pinned.sh.
+# That hook's `cargo metadata --locked` check (part 4) asks "is this lockfile
+# still valid against these manifests" -- it passes as long as the LOCKED
+# am-fs-core version still satisfies whatever the LOCKED am-fs-btrfs (etc.)
+# happened to require when IT was published. A bundle can sit on am-fs-core
+# 0.2.2 indefinitely and that check stays green, because 0.2.2 was a valid
+# resolution the day the lock was written and nothing forces it to move
+# forward. Six bundles did exactly that for eight releases, missing a
+# silent-wrong-bytes fix in 0.2.5, until Greptile caught it on #77 and it
+# still wasn't fixed at review time. See diskjockey#90.
+#
+# So this asks a different, narrower question: not "is the lock internally
+# consistent" but "does it name a version we have actually decided is the
+# floor." MINIMUM_AM_FS_CORE below is that floor, bumped by hand when a fix
+# in am-fs-core is judged to matter to this project -- the same way
+# SIBLING_PINS.txt is bumped by hand for go-networkfs. It is not a general
+# "warn about anything behind latest" check; that is a different, harder
+# problem (a floor that always trails whatever crates.io just published is
+# not a policy anyone would follow), and it is not this script's job to
+# invent one -- see the note on agent-skills#34 in the issue this closes.
+#
+# Usage:  scripts/check-bundle-core-pin.sh
+#         scripts/check-bundle-core-pin.sh --self-test
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Bumped by hand. 0.2.10 is the release fixing the silent-wrong-bytes GPT
+# slice defect from diskjockey#90 (am-fs-core CHANGELOG 0.2.5) plus three
+# further correctness fixes (0.2.8, 0.2.9, and the pre-0.2.10 Unreleased
+# oversize-slice fix) that shipped between the version these bundles had
+# been stuck on and this one.
+MINIMUM_AM_FS_CORE="0.2.10"
+
+# Compare two dotted-numeric versions field by field. Returns 0 (true) if
+# $1 >= $2.
+#
+# NOT A STRING COMPARISON. "0.2.9" > "0.2.10" as strings -- the '9' sorts
+# after the '1' -- which is exactly backwards, and a version-floor check
+# built on `[[ "$v" > "$min" ]]` would pass a genuinely stale 0.2.9 against
+# a 0.2.10 floor while looking correct on every version pair someone
+# actually tries by hand (single-digit patch numbers). See --self-test.
+version_ge() {
+    local a="$1" b="$2"
+    local -a af bf
+    IFS='.' read -r -a af <<<"$a"
+    IFS='.' read -r -a bf <<<"$b"
+    local i n
+    n=${#af[@]}
+    [ "${#bf[@]}" -gt "$n" ] && n=${#bf[@]}
+    for ((i = 0; i < n; i++)); do
+        local av=${af[i]:-0} bv=${bf[i]:-0}
+        if ((10#$av > 10#$bv)); then
+            return 0
+        elif ((10#$av < 10#$bv)); then
+            return 1
+        fi
+    done
+    return 0 # equal
+}
+
+# Read the version pinned for `am-fs-core` in one Cargo.lock. Empty if the
+# package is not present at all -- a bundle that stopped depending on it
+# entirely is not this script's problem to diagnose further, and a
+# non-empty-required check downstream will refuse to treat that as a pass.
+locked_version() {
+    local lockfile="$1"
+    awk '
+        $0 == "name = \"am-fs-core\"" { hit = 1; next }
+        hit && /^version = / { gsub(/^version = "|"$/, "", $0); print; exit }
+    ' "$lockfile"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    fail=0
+    check() {
+        local a="$1" b="$2" want="$3" got
+        if version_ge "$a" "$b"; then got=true; else got=false; fi
+        if [ "$got" != "$want" ]; then
+            echo "SELF-TEST FAILED: version_ge($a, $b) = $got, want $want" >&2
+            fail=1
+        fi
+    }
+    # THE TRAP ITSELF: single-digit patch below a double-digit one. A
+    # string comparison gets every one of these backwards.
+    check "0.2.9" "0.2.10" false
+    check "0.2.10" "0.2.9" true
+    check "0.9.9" "0.10.0" false
+    check "1.2.3" "1.2.3" true
+    check "1.2.3" "1.2.4" false
+    check "1.2.4" "1.2.3" true
+    check "2.0.0" "1.99.99" true
+    check "0.2.2" "0.2.10" false
+    check "0.2.10" "0.2.2" true
+    # A missing field defaults to 0, so a bare "1.2" compares as "1.2.0".
+    check "1.2" "1.2.0" true
+    check "1.2" "1.2.1" false
+    if [ "$fail" -eq 0 ]; then
+        echo "version_ge behaves correctly on every case, including the string-compare trap"
+    fi
+    exit "$fail"
+fi
+
+fail=0
+found_any=0
+for bundle in "$root"/rust-bundles/dj-*-bundle; do
+    lockfile="$bundle/Cargo.lock"
+    [ -f "$lockfile" ] || continue
+    found_any=1
+    name=$(basename "$bundle")
+    v=$(locked_version "$lockfile")
+    if [ -z "$v" ]; then
+        echo "[deps] $name: am-fs-core not found in Cargo.lock -- cannot verify the pin" >&2
+        fail=1
+        continue
+    fi
+    if ! version_ge "$v" "$MINIMUM_AM_FS_CORE"; then
+        echo "[deps] $name: am-fs-core $v is below the required floor $MINIMUM_AM_FS_CORE" >&2
+        echo "       Fix: (cd $bundle && cargo update -p am-fs-core) && git add $lockfile" >&2
+        fail=1
+    fi
+done
+
+# Non-emptiness first. A glob that matched nothing would report success
+# having checked zero bundles -- an empty result read as a clean bill of
+# health is the same shape of mistake this issue itself is about.
+if [ "$found_any" -eq 0 ]; then
+    echo "[deps] no rust-bundles/dj-*-bundle directories found -- nothing was checked" >&2
+    exit 1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "all bundle lockfiles pin am-fs-core >= $MINIMUM_AM_FS_CORE"
+fi
+exit "$fail"


### PR DESCRIPTION
All six bundle lockfiles resolved `am-fs-core 0.2.2` while core was at `0.2.10` — eight releases behind. A lockfile can be internally self-consistent and still sit on an old-but-still-valid transitive version indefinitely, which is why `cargo metadata --locked` in the existing pre-commit hook stays green on exactly this shape of bug.

`cargo update -p am-fs-core` in each of the six `rust-bundles/dj-*-bundle` directories, plus `scripts/check-bundle-core-pin.sh` wired as the first ci.yml step, so it cannot drift back. The guard asks a deliberately narrow question — does every bundle resolve `am-fs-core` at or above a hand-maintained floor — rather than a general "warn if behind latest" policy.

The intervening releases are why the floor is `0.2.10` and not merely "newer": `0.2.5` fixed a slice rebasing a read off the end of its parent (silent wrong bytes, and its own changelog entry notes the addition wrapped because `overflow-checks` is off in the release profile these crates ship), and `0.2.8`/`0.2.9` fixed `CachingDevice` bypassing the cache for most real traffic and running off the last block of a device.

## Verification

Measured on a824a29, base main 70f4561, no rebase, in a worktree.

A dependency bump has no fix to revert, so the mutation work went at the new guard, which is the part with logic in it.

- **The bump itself.** Every one of the six lockfile diffs is exactly +2/−2 lines (version, checksum); nothing else moved. All six now resolve `am-fs-core 0.2.10`, and each lockfile contains exactly **one** `am-fs-core` version — the condition the bundles exist to maintain, since two copies of core in one staticlib means two copies of std and a duplicate `_rust_eh_personality` at link time.
- **All six build** `cargo build --locked --release`: EXIT=0, 0 errors, 0 warnings, no duplicate-symbol diagnostics, each resolving `am-fs-core v0.2.10` from crates.io — which also confirms 0.2.10 is actually published, not merely tagged.
- **The guard's negative control.** Reverting *only* the six lockfiles and keeping the script and ci.yml: EXIT=1, with all six bundles named on their own lines and an actionable fix command each. Restoring: EXIT=0. (Undone with `git reset --hard`, not `git checkout --`, since `git checkout <ref> -- <path>` stages the file and the obvious undo would restore the reverted content from the index.)
- **The guard cannot pass vacuously.** Run against a tree containing no `rust-bundles/dj-*-bundle` directories it exits 1 with "nothing was checked" — verified by actually running it there, not by reading the comment that claims it.
- **`version_ge` re-derived independently** rather than taken from its self-test. It splits on `.`, compares field-by-field under `10#` (so leading zeros are base-10, not invalid octal), and zero-fills missing fields — genuine dotted-numeric ordering. Confirmed on the named trap (`0.2.9` < `0.2.10`, which a string comparison gets backwards), on `0.9.9` < `0.10.0`, on `0.02.10` = `0.2.10`, and on `1.2` = `1.2.0`. Its own `--self-test` passes 11 cases.
- **Coverage limitation, stated rather than papered over.** The bundles contain no tests at all — each is a single `src/lib.rs` staticlib aggregator — so "the suites still pass against the newer core" is not available in this repository. The build is the only in-repo signal, and it proves linkage rather than behaviour. The behavioural coverage for the 0.2.2→0.2.10 range lives in `am-fs-core`'s own suite upstream.

### One non-blocking observation

`version_ge` fails **open** on a non-numeric version field, but only in a narrow shape: the malformed field must be in the final compared position with every prior field equal. `version_ge "0.2.x" "0.2.10"` returns true, because `10#x` is an arithmetic error, both comparisons evaluate false, and the loop falls through to the equal case. The realistic malformed inputs all fail closed instead — an empty version takes the separate "am-fs-core not found … cannot verify the pin" branch which sets `fail=1`, and `"garbage"` compares false on a later zero-filled field. Cargo writes semver into lockfiles, so the triggering input is not one this guard can actually receive; recorded because a fail-open direction is worth knowing about deliberately rather than discovering later.

Closes #90

https://claude.ai/code/session_01HTGSqRj8p3JjekeP9pP6iz
