### PR TITLE
chore: the ledger tracks the controller and the skills repository

### DIFF
--- a/scripts/am-ledger
+++ b/scripts/am-ledger
@@ -106,6 +106,23 @@ DEFAULT_REPOS=(
     "rust-img-vhdx:antimatter-studios/rust-img-vhdx"
     "rust-img-vmdk:antimatter-studios/rust-img-vmdk"
     "rust-partitions:antimatter-studios/rust-partitions"
+    # Not a driver, and tracked anyway. The dependency-pin guard that every
+    # repo above carries a copy of has its fix location HERE, not in the
+    # constellation: the upstream copy never had the sibling-version check
+    # at all, so syncing the copies onto it would delete the capability
+    # from eleven repositories. Until a corrected version is ported up,
+    # agent-skills#34 is the parent of five defects in three generations
+    # of that script — and an untracked repository is one no stage ever
+    # dispatches, which is how it sat unowned.
+    "agent-skills:antimatter-studios/agent-skills"
+    # And the controller project itself. It was left out because it
+    # orchestrates the twelve rather than being one of them — but issues
+    # get filed against it like anywhere else (the reaper, the ledger,
+    # the merge gate, the bundle lockfiles), and an untracked repository
+    # is one no stage dispatches. diskjockey#90 sat selected-for-
+    # development with a marker on GitHub and no way for a fixer to find
+    # it, which is the same hole agent-skills was in one line above.
+    "diskjockey:antimatter-studios/diskjockey"
 )
 
 REPOS=()


### PR DESCRIPTION
An issue in a repository absent from `am-ledger`'s `DEFAULT_REPOS` is one
no pipeline stage ever discovers. Every stage finds work through
`am-ledger next <stage>`, not through GitHub — so such an issue can be
filed, triaged, and carry a `This issue is selected for development`
marker, and still never reach a fixer.

Two repositories were in that state today, and both were found by an
agent asking rather than by anything failing.

**`antimatter-studios/agent-skills`** is not a driver, but it holds the
upstream copy of `.githooks/pre-commit.d/rust-deps-pinned.sh`, which
eleven repositories each carry a variant of. Five distinct defects across
three generations of that script are parented on `agent-skills#34`, so
the whole family was blocked on a repository nothing would dispatch.

Worth reading before anyone "fixes" that by syncing the copies: the
upstream file **has never had the sibling-version-pin section at all**.
`git log --all -S` across agent-skills' entire history returns nothing
for it. Running the skill's own "upgrade all deployments" today would
delete the capability from all eleven repos that have it — a regression
below even the oldest generation. The copies are divergent because the
shared source lacks parity, not out of inertia.

**`antimatter-studios/diskjockey`** was left out because it orchestrates
the twelve rather than being one of them. But issues get filed against it
like anywhere else — the worktree reaper, this script, the merge gate,
the bundle lockfiles — and being the tool rather than the product does
not exempt it from having defects. `#79` had been sitting outside the
pipeline since before today. `#90` sat selected-for-development with a
marker on GitHub and no way for a fixer to find it, and it was the only
defect found today in code that users actually run.

Both entries carry a comment explaining why a non-driver is tracked, so
neither gets removed later as out of scope.

**Cost:** `am-ledger refresh` makes one GitHub call per tracked
repository, so this makes a refresh slightly more expensive. That is the
whole downside.

Verified: `sh -n` clean, `am-ledger stats` and `refresh` both run, and a
refresh moved the ledger 381 -> 416 with eleven previously-invisible
diskjockey issues appearing at `pending`.

https://claude.ai/code/session_01HTGSqRj8p3JjekeP9pP6iz
