### PR TITLE
fix: a malformed GPT no longer crashes the disk probe

### DIFF
--- a/DiskJockeyApplication/Services/SwiftPartitionProbe.swift
+++ b/DiskJockeyApplication/Services/SwiftPartitionProbe.swift
@@ -193,9 +193,17 @@ enum SwiftPartitionProbe {
         let entrySize     = UInt64(le32(header, offset: 84))
         guard entrySize >= 128, entryCount > 0, entryCount <= 256 else { return [] }
 
+        // An entry-array LBA too large to express as a byte offset makes the
+        // whole table unreadable, not just one entry of it.
+        guard let entryTableStart = byteOffset(lba: entryStartLBA) else { return [] }
+
         var parts: [DiskProbeResult.Partition] = []
         for i in 0..<entryCount {
-            let entryOffset = (entryStartLBA * 512) + i * entrySize
+            let (indexOffset, indexOverflow) = i.multipliedReportingOverflow(by: entrySize)
+            guard !indexOverflow else { continue }
+            let (entryOffset, offsetOverflow) = entryTableStart.addingReportingOverflow(indexOffset)
+            guard !offsetOverflow else { continue }
+
             guard let entry = try? readBytes(handle: handle, at: entryOffset, count: Int(entrySize)),
                   entry.count >= 56 else { continue }
 
@@ -203,10 +211,15 @@ enum SwiftPartitionProbe {
             let typeBytes = Data(entry[0..<16])
             guard typeBytes.contains(where: { $0 != 0 }) else { continue }
 
-            let partStart  = le64(entry, offset: 32) * 512
-            let partEnd    = le64(entry, offset: 40) * 512
-            guard partEnd > partStart else { continue }
-            let partLength = partEnd - partStart + 512
+            // A single unrepresentable entry is skipped; the rest of an
+            // otherwise-parseable table still yields its partitions.
+            guard let partStart = byteOffset(lba: le64(entry, offset: 32)),
+                  let partEnd   = byteOffset(lba: le64(entry, offset: 40)),
+                  partEnd > partStart else { continue }
+            // GPT's last-LBA is inclusive, so the span is one sector more than
+            // the difference — and that last sector can be what tips it over.
+            let (partLength, lengthOverflow) = (partEnd - partStart).addingReportingOverflow(512)
+            guard !lengthOverflow else { continue }
 
             let typeGuid = formatGPTGUID(typeBytes)
 
@@ -354,6 +367,22 @@ enum SwiftPartitionProbe {
     }
 
     // MARK: - Low-level helpers
+
+    /// Convert an on-disk LBA to a byte offset, or nil when the sector count
+    /// is too large for the byte offset to be expressed in a `UInt64`.
+    ///
+    /// Every LBA reaching this comes off the disk with no upper bound, and
+    /// Swift's `*` and `+` on fixed-width integers trap on overflow in
+    /// **every** build configuration — there is no equivalent of the
+    /// `overflow-checks = false` release default this project's Rust crates
+    /// have to reason about separately. So an unchecked conversion here is not
+    /// a wrong number on a corrupt or crafted image, it is the shipped app
+    /// terminating the moment it probes one. Callers drop the entry, or the
+    /// whole table, instead.
+    private static func byteOffset(lba: UInt64) -> UInt64? {
+        let (bytes, overflow) = lba.multipliedReportingOverflow(by: 512)
+        return overflow ? nil : bytes
+    }
 
     private static func readBytes(handle: FileHandle, at offset: UInt64, count: Int) throws -> Data {
         try handle.seek(toOffset: offset)

--- a/DiskJockeyTests/SwiftPartitionProbeTests.swift
+++ b/DiskJockeyTests/SwiftPartitionProbeTests.swift
@@ -226,3 +226,162 @@ struct ClassifyExtTests {
         #expect(SwiftPartitionProbe.classifyExt(extBytes(incompat: allFlags)) == "ext4")
     }
 }
+
+// MARK: - parseGPT overflow tests
+
+/// A GPT header, and every partition entry inside it, carries LBA values with
+/// no upper bound. Turning one into a byte offset is a multiply, and Swift
+/// traps on integer overflow in **every** build configuration — Release
+/// included — so before these guards a corrupt or crafted image terminated the
+/// app the moment Disk Inspector probed it.
+///
+/// Each malformed image below is built so that the overflowing value *wraps
+/// onto a real partition entry*. That matters: the guards use
+/// `multipliedReportingOverflow`/`addingReportingOverflow`, which wrap
+/// silently rather than trapping, so an image whose wrapped offset pointed at
+/// nothing would read back as "no partitions" whether the guard was there or
+/// not. Landing the wrap on a valid entry makes the guard's presence
+/// observable — unguarded yields a partition, guarded yields none.
+struct GPTOverflowTests {
+
+    /// UInt64.max / 512 — the largest LBA whose byte offset is representable.
+    static let maxSafeLBA = UInt64.max / 512          // 0x1FF_FFFF_FFFF_FFFF
+    /// `lba * 512` overflows and wraps to exactly 1024: any lba ≡ 2 (mod 2^55).
+    static let wrapsTo1024: UInt64 = (1 << 55) + 2
+    /// Same shape, wrapping to 2048.
+    static let wrapsTo2048: UInt64 = (1 << 55) + 4
+
+    /// A well-formed entry at LBA 34-40 → start 17408, length 3584.
+    static let goodEntryStart: UInt64 = 34 * 512
+    static let goodEntryLength: UInt64 = (40 - 34) * 512 + 512
+
+    private struct Entry {
+        let at: Int             // byte offset of the entry within the image
+        let firstLBA: UInt64
+        let lastLBA: UInt64
+    }
+
+    /// Build a raw GPT image. Header fields are written verbatim so a hostile
+    /// value can be injected, and entries are placed at explicit byte offsets
+    /// so a wrap has something to land on.
+    private func gptImage(entryTableLBA: UInt64,
+                          entryCount: UInt32,
+                          entrySize: UInt32,
+                          entries: [Entry],
+                          sectors: Int = 64) -> Data {
+        var d = Data(count: sectors * 512)
+        func le(_ v: UInt64, _ n: Int, at off: Int) {
+            for k in 0..<n { d[off + k] = UInt8((v >> (8 * UInt64(k))) & 0xFF) }
+        }
+        let h = 512                                    // LBA 1 = GPT header
+        d.replaceSubrange(h..<(h + 8), with: Array("EFI PART".utf8))
+        le(entryTableLBA, 8, at: h + 72)
+        le(UInt64(entryCount), 4, at: h + 80)
+        le(UInt64(entrySize), 4, at: h + 84)
+        for e in entries {
+            d[e.at] = 0xAB                             // non-zero type GUID
+            le(e.firstLBA, 8, at: e.at + 32)
+            le(e.lastLBA, 8, at: e.at + 40)
+        }
+        return d
+    }
+
+    /// Per-pid-and-counter fixture name — never a fixed one, so tests running
+    /// in parallel and concurrent runs of the suite can't collide on a path.
+    private static let counterLock = NSLock()
+    private static var counter = 0
+    private func writeImage(_ d: Data) throws -> URL {
+        Self.counterLock.lock()
+        Self.counter += 1
+        let n = Self.counter
+        Self.counterLock.unlock()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dj-gpt-overflow-\(getpid())-\(n).img")
+        try d.write(to: url)
+        return url
+    }
+
+    /// Probe an image, then delete it.
+    private func probe(_ d: Data) throws -> DiskProbeResult? {
+        let url = try writeImage(d)
+        defer { try? FileManager.default.removeItem(at: url) }
+        return SwiftPartitionProbe.probe(at: url)
+    }
+
+    // MARK: The five overflow sites
+
+    @Test func entryTableLBATooLargeYieldsNoPartitions() throws {
+        // entryStartLBA * 512 overflows, wrapping onto the entry at byte 1024.
+        let r = try probe(gptImage(entryTableLBA: Self.wrapsTo1024,
+                                   entryCount: 1, entrySize: 128,
+                                   entries: [Entry(at: 1024, firstLBA: 34, lastLBA: 40)]))
+        #expect(r?.table == "gpt")
+        #expect(r?.partitions.isEmpty == true)
+    }
+
+    @Test func entryOffsetSumOverflowSkipsEntry() throws {
+        // tableStart is exactly representable; tableStart + 1*512 overflows
+        // and wraps to 0, where a real entry sits.
+        let r = try probe(gptImage(entryTableLBA: Self.maxSafeLBA,
+                                   entryCount: 2, entrySize: 512,
+                                   entries: [Entry(at: 0, firstLBA: 34, lastLBA: 40)]))
+        #expect(r?.table == "gpt")
+        #expect(r?.partitions.isEmpty == true)
+    }
+
+    @Test func partitionFirstLBATooLargeSkipsEntry() throws {
+        // firstLBA * 512 overflows, wrapping to 1024 — under the 2048 partEnd,
+        // so an unguarded wrap would satisfy `partEnd > partStart`.
+        let r = try probe(gptImage(entryTableLBA: 2, entryCount: 1, entrySize: 128,
+                                   entries: [Entry(at: 1024,
+                                                   firstLBA: Self.wrapsTo1024,
+                                                   lastLBA: 4)]))
+        #expect(r?.partitions.isEmpty == true)
+    }
+
+    @Test func partitionLastLBATooLargeSkipsEntry() throws {
+        // lastLBA * 512 overflows, wrapping to 2048 — over the 1024 partStart.
+        let r = try probe(gptImage(entryTableLBA: 2, entryCount: 1, entrySize: 128,
+                                   entries: [Entry(at: 1024,
+                                                   firstLBA: 2,
+                                                   lastLBA: Self.wrapsTo2048)]))
+        #expect(r?.partitions.isEmpty == true)
+    }
+
+    @Test func partitionLengthOverflowSkipsEntry() throws {
+        // Both multiplies fit. GPT's last-LBA is inclusive, so the span is the
+        // difference plus one sector, and that last sector is what overflows:
+        // an unguarded wrap reports a partition of length 0.
+        let r = try probe(gptImage(entryTableLBA: 2, entryCount: 1, entrySize: 128,
+                                   entries: [Entry(at: 1024,
+                                                   firstLBA: 0,
+                                                   lastLBA: Self.maxSafeLBA)]))
+        #expect(r?.partitions.isEmpty == true)
+    }
+
+    // MARK: Scope of the rejection
+
+    @Test func oneBadEntryDoesNotDiscardTheGoodOnes() throws {
+        // An unrepresentable entry is dropped on its own; the rest of an
+        // otherwise-parseable table still yields its partitions.
+        let r = try probe(gptImage(entryTableLBA: 2, entryCount: 2, entrySize: 128,
+                                   entries: [Entry(at: 1024,
+                                                   firstLBA: 2,
+                                                   lastLBA: Self.wrapsTo2048),
+                                             Entry(at: 1152, firstLBA: 34, lastLBA: 40)]))
+        #expect(r?.partitions.count == 1)
+        #expect(r?.partitions.first?.start == Self.goodEntryStart)
+        #expect(r?.partitions.first?.length == Self.goodEntryLength)
+    }
+
+    @Test func wellFormedGPTStillParses() throws {
+        // The control: without this, every assertion above could be satisfied
+        // by a probe that rejects all GPTs.
+        let r = try probe(gptImage(entryTableLBA: 2, entryCount: 1, entrySize: 128,
+                                   entries: [Entry(at: 1024, firstLBA: 34, lastLBA: 40)]))
+        #expect(r?.table == "gpt")
+        #expect(r?.partitions.count == 1)
+        #expect(r?.partitions.first?.start == Self.goodEntryStart)
+        #expect(r?.partitions.first?.length == Self.goodEntryLength)
+    }
+}


### PR DESCRIPTION
`SwiftPartitionProbe.parseGPT` turned on-disk LBA values into byte offsets with bare `*` and `+`. Swift traps on integer overflow in **every** build configuration — Release included, with no equivalent of the `overflow-checks = false` release default this project's Rust crates reason about separately — so a corrupt or crafted GPT did not yield a wrong number, it terminated the app the moment Disk Inspector probed the disk.

Five reachable trap sites, all fed by unbounded on-disk values: `198:46`, `198:53`, `206:54`, `207:54`, `209:50`.

## Two different blast radii, deliberately

An entry-array LBA too large to express as a byte offset makes the whole table unreadable, so the table is rejected. A single unrepresentable *entry* costs only that entry — the rest of an otherwise-parseable table still yields its partitions, which `oneBadEntryDoesNotDiscardTheGoodOnes` pins.

GPT's last-LBA is inclusive, so a partition's span is one sector more than the difference, and that last sector is what tips the length calculation over. It gets its own guard.

## The fixtures land the wrap on a real entry, and that is the point

`multipliedReportingOverflow` / `addingReportingOverflow` **wrap** rather than trapping, so with a guard deleted the code keeps running and produces a wrapped offset. An image whose wrapped offset pointed at nothing would read back as "no partitions" whether the guard was present or not — a test asserting only "no crash, no partitions" would pass with the guard gone.

Every fixture therefore parks a valid partition entry exactly where the overflow wraps to, which makes the guard's presence observable: unguarded yields a partition, guarded yields none.

## Witnessed

7 tests in `DiskJockeyTests/SwiftPartitionProbeTests.swift`. Control: 31 tests in 3 suites, EXIT=0, 0 compile errors. Each guard neutered separately, expression asserted unique first, file checksum confirmed changed before any exit code was read, restored between arms.

| arm | EXIT | compile errors | failed |
|---|---|---|---|
| **original unfixed source** | 1 | **0** | process killed by **signal 5 (SIGTRAP)** mid-suite |
| entry-array LBA unchecked | 1 | 0 | `entryTableLBATooLargeYieldsNoPartitions` |
| `i * entrySize` unchecked | **0** | 0 | none — see below |
| entry-offset sum unchecked | 1 | 0 | `entryOffsetSumOverflowSkipsEntry` |
| partition first-LBA unchecked | 1 | 0 | `partitionFirstLBATooLargeSkipsEntry` |
| partition last-LBA unchecked | 1 | 0 | `partitionLastLBATooLargeSkipsEntry`, `oneBadEntryDoesNotDiscardTheGoodOnes` |
| partition length unchecked | 1 | 0 | `partitionLengthOverflowSkipsEntry` |

The first row is the control that matters: the unfixed source **compiles cleanly** (`Build complete!`, zero swiftc diagnostics) and then dies on `signal code 5` while the GPT suite is running, with the unrelated `ClassifyTests` and `ClassifyExtTests` suites passing. The crash this issue reports is reproduced, not inferred.

The last-LBA arm fails two tests rather than one: `oneBadEntryDoesNotDiscardTheGoodOnes` sees 2 partitions instead of 1, the first starting at 1024 with length 1536 instead of the good entry's 17408 / 3584. That is the wrap landing on a valid entry and displacing the real one — extra coverage rather than imprecision.

## One arm is unwitnessed, by construction

`i * entrySize` cannot be made to overflow: `entryCount <= 256` and `entrySize` comes from a `u32`, bounding the product at 1095216660225, far below the `UInt64` ceiling. Its guard survives mutation with the whole suite green. It is checked so that relaxing either bound later cannot silently reintroduce a trap, and it is recorded here as argued rather than measured.

## Gate coverage

`.github/workflows/ci.yml` triggers on `pull_request`, its `Test` step carries no `if:` and no `continue-on-error:`, uses `set -o pipefail` so the `xcbeautify` pipe cannot swallow a failure, and skips only `DiskJockeyUITests`. `DiskJockeyTests` is a `PBXFileSystemSynchronizedRootGroup`, so this file is a target member by directory membership — it appears zero times in `project.pbxproj` because synchronized groups enumerate nothing, not because it is unwired.

Closes #95

https://claude.ai/code/session_01HTGSqRj8p3JjekeP9pP6iz
