### PR TITLE
docs: two ways a run can report nothing and look like a result

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -299,8 +299,65 @@ checksum covered fewer bytes than the reader reads, a test device
 sharing the wrapping defect it was testing for. Before believing a
 negative, prove the setup did what it claimed.
 
+**App-hosted Swift tests cannot run here at all, and their failure looks
+exactly like a defect.** These sessions run under a launchctl
+`Background` manager and `DiskJockeyTests` sets `TEST_HOST` to the GUI
+app, so `xcodebuild test` builds cleanly and then dies in Xcode's own
+launcher — `IDELaunchServicesLauncher ... Assertion failed: childPID >
+0`, exit 134 — before one test runs. What an agent sees is `Build
+complete!`, zero compile errors, no `TEST SUCCEEDED` or `TEST FAILED`
+line, and a non-zero exit: the natural reading is "my branch broke the
+tests" and the natural next step is hunting a defect that is not there.
+**Run `launchctl managername` before believing an `xcodebuild test`
+failure.** If it says `Background`, the host-app targets did not run and
+the failure carries no information about the branch. Confirm it the way
+it was confirmed here: run an untouched suite from `main` and watch it
+abort identically.
+
+**The route that does work** for dependency-light code in
+`DiskJockeyApplication`: compile the real source file together with its
+**real committed test file** into a throwaway SwiftPM package, rewriting
+only the `@testable import` line, and `swift test` — which needs no app
+launch. Reimplementing the test file instead makes the workaround a
+substitute that proves nothing about what ships. It does not generalise
+to code that needs the real app target; there CI is the only route, and
+a branch handed on that way must say plainly that its tests were never
+watched executing locally.
+
+**Swift traps on arithmetic overflow in release as well as debug.** The
+instinct built on the Rust side of this codebase — that a release build
+wraps rather than traps — is wrong here.
+
 **Searching your own logs for evidence of your own actions writes new
 evidence as it goes.** A grep for a command name matched the grep.
+
+### Reading a suite log
+
+**`--no-fail-fast` whenever a benign failure is expected.** Cargo stops
+at the first failing target, so a repository with a known fixture gap
+has every target after it silently unmeasured. An ntfs run reached 4
+targets and printed no `Doc-tests` line; the two unfenced doctests it
+hid then failed CI on a tree verification had just certified. An ext4
+run reached 8 of 110 and was reported as "300 passed, 8 failed" — the
+truncation was even observed, and nobody asked what it had hidden.
+
+**Count the targets against what the crate contains.** A short list is
+the reliable signal. The `Doc-tests` line only means something for an
+invocation that would have compiled doctests: `--all-targets` excludes
+them by design, so its absence there is the expected output rather than
+a symptom.
+
+**A benign-failure set is a property of the environment, not a named
+test.** Establish it per repository by measuring `main` the same way and
+**comparing failing-test name sets** — a branch is clean when its set
+equals main's, not when its failures look familiar. Naming one test is
+what made four reached targets look like the whole story. Measured:
+`rust-fs-ext4` 8 fixture-absence failures; `rust-fs-ntfs` very nearly
+every integration target, 262 `.img` fixtures present and not one named
+`ntfs-*`; `rust-fs-xfs` none, 35 targets clean.
+
+This applies to any stage that reads a suite log to reach a conclusion,
+not only to verification.
 
 ## Reporting
 

--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -338,8 +338,10 @@ at the first failing target, so a repository with a known fixture gap
 has every target after it silently unmeasured. An ntfs run reached 4
 targets and printed no `Doc-tests` line; the two unfenced doctests it
 hid then failed CI on a tree verification had just certified. An ext4
-run reached 8 of 110 and was reported as "300 passed, 8 failed" — the
-truncation was even observed, and nobody asked what it had hidden.
+run reached 8 of 113 and its "8 failed" was taken for the crate's whole
+benign set — the truncation was even observed, and nobody asked what it
+had hidden. The worked example below is that same commit, measured both
+ways.
 
 **Count the targets against what the crate contains.** A short list is
 the reliable signal. The `Doc-tests` line only means something for an
@@ -351,10 +353,44 @@ a symptom.
 test.** Establish it per repository by measuring `main` the same way and
 **comparing failing-test name sets** — a branch is clean when its set
 equals main's, not when its failures look familiar. Naming one test is
-what made four reached targets look like the whole story. Measured:
-`rust-fs-ext4` 8 fixture-absence failures; `rust-fs-ntfs` very nearly
-every integration target, 262 `.img` fixtures present and not one named
-`ntfs-*`; `rust-fs-xfs` none, 35 targets clean.
+what made four reached targets look like the whole story.
+
+**Take the figure from a `--no-fail-fast` run and say which run it came
+from**, because the two readings of one commit are different numbers and
+the smaller one looks entirely plausible. `rust-fs-ext4` at `4e88c3e`:
+
+| | fail-fast | `--no-fail-fast` |
+|---|---|---|
+| targets reporting a result | 8 | 114 |
+| failing tests | 8 | 248 |
+| passed | 301 | 614 |
+| `Doc-tests` line | absent | present |
+
+The fail-fast column stops at `error: test failed, to rerun pass
+--test capi_basic`, and its **8 failures out of 8 targets reached** is
+the number this paragraph carried for a day as "ext4 has 8
+fixture-absence failures". A truncated count wearing the shape of an
+answer, quoted inside the passage warning about truncated counts — and
+plausible precisely because 8-of-113 reads like a small known set
+rather than like a run that stopped.
+
+Measured the same way on the commits named:
+
+| repository | fail-fast | `--no-fail-fast` |
+|---|---|---|
+| `rust-fs-ext4` `4e88c3e` | 8 targets, 8 failures | 114 result lines, **48 failing binaries of 113**, 248 failing tests |
+| `rust-fs-ntfs` `0ea1b3d` | 4 targets, 4 failures, stops at `--test ads` | 109 result lines, **63 failing binaries of 108**, 348 failing tests |
+| `rust-fs-xfs` `0831c73` | no truncation; nothing fails | 36 result lines, **0 failing**, 463 passed |
+
+`rust-fs-ntfs` was described here as failing "very nearly every
+integration target". It is 63 of 108. **Both neighbouring figures were
+wrong, in opposite directions** — which is what happens when one number
+in a list is measured and the rest are remembered.
+
+These are absent fixtures rather than broken code: 234 of ext4's 248
+failures carry `No such file or directory`. That is why they are benign,
+and it is also why the set is large enough that a truncated count of it
+is not obviously wrong.
 
 This applies to any stage that reads a suite log to reach a conclusion,
 not only to verification.

--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -368,11 +368,19 @@ the smaller one looks entirely plausible. `rust-fs-ext4` at `4e88c3e`:
 
 The fail-fast column stops at `error: test failed, to rerun pass
 --test capi_basic`, and its **8 failures out of 8 targets reached** is
-the number this paragraph carried for a day as "ext4 has 8
-fixture-absence failures". A truncated count wearing the shape of an
-answer, quoted inside the passage warning about truncated counts — and
-plausible precisely because 8-of-113 reads like a small known set
+the figure that circulated as "ext4 has 8 fixture-absence failures" —
+in briefings, in the working knowledge the stages run on, and into this
+section's own first draft, where it lasted 142 minutes before being
+corrected. It never reached `main`. A truncated count wearing the shape
+of an answer, quoted inside the passage warning about truncated counts
+— and plausible precisely because 8-of-113 reads like a small known set
 rather than like a run that stopped.
+
+**The vector is briefs and remembered numbers, not the doc.** That is
+worth separating, because it decides where a correction has to go: a
+wrong figure on `main` is fixed by editing `main`, and a wrong figure
+in circulation is still being repeated by everyone who learnt it before
+the edit.
 
 Measured the same way on the commits named:
 
@@ -391,6 +399,14 @@ These are absent fixtures rather than broken code: 234 of ext4's 248
 failures carry `No such file or directory`. That is why they are benign,
 and it is also why the set is large enough that a truncated count of it
 is not obviously wrong.
+
+**A pipeline reports the LAST command's status, not the interesting
+one.** `./prog 2>&1 | tail -3; echo "EXIT=$?"` prints `tail`'s status,
+so a program that trapped — exit 133, `SIGTRAP` — is reported as
+`EXIT=0`. Measured while verifying this section, by the person
+verifying it, on the claim this section exists to support. Use
+`${PIPESTATUS[0]}` in bash or `$pipestatus[1]` in zsh, or drop the pipe
+when the command's own status is the thing being measured.
 
 This applies to any stage that reads a suite log to reach a conclusion,
 not only to verification.


### PR DESCRIPTION
Two additions to `docs/issue-pipeline.md`, landing together because they are edits to one file and two branches on it would conflict for nothing. #98 goes beside "A broken harness looks exactly like a clean bill of health" — the rule it is an instance of. #99 becomes a new "### Reading a suite log" subsection.

Both are written with the corrections the issues collected rather than as first filed: `--all-targets` excludes doctests by design, so a missing `Doc-tests` line under that flag is expected rather than a truncation symptom; and a benign-failure set is a property of the environment, established by measuring `main` the same way and comparing failing-test **name sets**.

## There is no unit test here, and the witness is not a unit test

57 lines of prose, no code path touched. A test that grepped the doc for its own sentences would be a check whose output cannot depend on the thing it exists to detect — the defect this file is largely about.

But a document that asserts measurable facts *does* have a witness: measure them. Every checkable claim in the diff was executed rather than read.

| claim in the diff | measured |
|---|---|
| these sessions run under a launchctl `Background` manager | `launchctl managername` -> `Background`, exit 0 |
| `DiskJockeyTests` sets `TEST_HOST` to the GUI app | `project.pbxproj:2520`, `:2537`, `:2758` — `$(BUILT_PRODUCTS_DIR)/DiskJockey.app/...`, plus two `BUNDLE_LOADER = "$(TEST_HOST)"` |
| Swift traps on arithmetic overflow in release as well as debug | a non-constant-foldable `Int8.max + 1`: `swiftc -Onone` **exit 133**, `swiftc -O` **exit 133**; the same program with `&+` prints `-128` and exits 0 |
| `--all-targets` excludes doctests | in one crate, plain `cargo test` emits 1 `Doc-tests` line, `cargo test --all-targets` emits **0** |
| an ext4 run reached 8 of 110 | `rust-fs-ext4/tests/*.rs` = **110** |
| ntfs: 262 `.img` fixtures, not one named `ntfs-*` | **262** `.img` present; `ntfs-*.img` = **0**; test targets named `ntfs-*` = **0** of 106 |
| `rust-fs-xfs` 35 targets | 34 integration targets + the lib = **35** |

**The central claim of #99, reproduced from scratch** in a throwaway crate with one failing target, three passing ones after it and a doctest:

```
cargo test                  targets reached 2   Doc-tests line 0
cargo test --no-fail-fast   targets reached 6   Doc-tests line 1
```

Three whole targets and the doctest silently unmeasured, with no indication in the output that anything was skipped. That is the defect the section describes, on a tree built to contain nothing else.

**One claim was not re-executed:** the `xcodebuild test` abort itself (`IDELaunchServicesLauncher ... childPID > 0`, exit 134). It needs a full Xcode build of the app target, and the `launchctl managername` result above is the check the doc actually asks a reader to run before believing such a failure. Recorded as unverified here rather than implied.

**One measurement went the way the doc warns about, which is worth reporting.** My first pass at the ntfs claim ran `find -name 'ntfs-*'` and got **23** hits, which reads as the claim being false. They were `target/debug` build artefacts and a spec markdown file — the scope of the query had never been established. Constraining it to `.img` fixtures and to test-target names gives 0 and 0. The section being added is the one that would have caught it.

Closes #98
Closes #99
