### PR TITLE
fix: list filters a column through a flag, or says it did not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # THE SCRIPTS IN scripts/ HAD NO GATE AT ALL, and the pipeline is
+  # steered by them. `am-ledger list pr` returned 90 rows, 2 of them at
+  # stage `pr`, and a decision was taken on that listing and later
+  # retracted -- a filter that read the wrong thing and returned a
+  # screenful of plausible rows rather than an error.
+  #
+  # ubuntu-latest and no toolchain: this must be cheap enough that
+  # nobody is tempted to make it conditional. It does not touch the real
+  # ledger -- each test points AM_LEDGER_DIR at a temporary directory.
+  #
+  # `set -euo pipefail` around a bare `bash "$t"` so a non-zero exit
+  # fails the step, and the loop names the file it is running: a
+  # step whose result nothing reads is the defect this job exists for.
+  scripts:
+    name: Shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semantics the Xcode job cannot reach
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          found=0
+          for t in scripts/tests/*.sh; do
+            echo "::group::$t"
+            bash "$t"
+            echo "::endgroup::"
+            found=$((found + 1))
+          done
+          # A glob that matches nothing makes this step pass having run
+          # nothing, which reads exactly like a clean bill of health.
+          [ "$found" -gt 0 ] || { echo "scripts/tests/ matched no test files" >&2; exit 1; }
+          echo "ran $found script test(s)"
+
   test:
     name: Build & Test
     # macos-26 is the Apple Silicon runner for macOS 26.

--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -51,7 +51,7 @@ not have it produces exit 127 rather than an error anyone reads.
     am-ledger refresh                    rebuild from GitHub, keeping stages
     am-ledger next <stage> [repo]        claim one row atomically
     am-ledger set <repo> <n> stage=...   record progress
-    am-ledger list [filter]              rows
+    am-ledger list [--stage s] [--repo r] [--owner o] [text...]
     am-ledger stats                      counts by stage
     am-ledger stale [--all] [hours]      claimed rows that stopped moving
     am-ledger start <project> <owner/name>... | --org <org>
@@ -66,6 +66,21 @@ about where it is.** Release rows with `owner=-` when handing on.
 
 Stages: `pending accepted rejected fixing testing pr merged failed
 blocked`.
+
+**`list` filters a COLUMN only through a flag.** `--stage`, `--repo` and
+`--owner` compare that column literally and AND together; bare words are
+still an unanchored `grep -E` over the whole row, several of them ORed.
+`am-ledger list pr` used to return 90 rows, 2 of them at stage `pr` —
+`ci_profile`, `fingerprint`, `prefix`, `github-protect-main` — and a
+report was made on that listing and retracted. It is now refused with a
+suggestion; `-- pr` greps for the text.
+
+**This is the empty-result rule inverted, which is why it slipped past
+it.** An empty result invites suspicion; a screenful of plausible rows
+reads as a successful query. So `list` prints `matched N of M rows` on
+stderr on **every** call — the zero case was never the one that misled —
+and exits non-zero when N is 0. The line carries no tab, so a caller
+piping into `awk -F'\t'` is unaffected even if it merged stderr.
 
 **`failed` and `blocked` are different work.** `failed` — a build ran
 and said no; diagnose it. `blocked` — nothing ran (conflicting PR,

--- a/scripts/am-ledger
+++ b/scripts/am-ledger
@@ -3,7 +3,7 @@
 # am-ledger — one local list of every issue a pipeline is working on.
 #
 #   am-ledger refresh              rebuild the issue list from GitHub
-#   am-ledger list [filter...]     print rows, optionally filtered
+#   am-ledger list [--stage s] [--repo r] [--owner o] [text...]
 #   am-ledger next <stage> [repo]  print one row waiting at <stage>
 #   am-ledger set <repo> <num> <field>=<value> [field=value...]
 #   am-ledger stats                counts by stage
@@ -293,12 +293,138 @@ do_next() {
     printf '%s\n' "$row"
 }
 
+# Every stage a row can be at. Here rather than only in the header
+# comment because `list` needs to recognise one when it is handed one.
+STAGES="pending accepted rejected fixing testing pr merged failed blocked"
+
+# A `case` rather than a loop: `[ "$s" = "$want" ] && return 0` inside a
+# `for` is the classic `set -e` footgun, and this file runs under
+# `set -euo pipefail`.
+is_stage() {
+    [ -n "${1-}" ] || return 1
+    case " $STAGES " in *" $1 "*) return 0 ;; esac
+    return 1
+}
+
+# Print rows.
+#
+#   am-ledger list                       every row
+#   am-ledger list --stage pr            rows AT stage pr
+#   am-ledger list --repo rust-fs-xfs --owner fix
+#   am-ledger list refcount              free text, over the whole row
+#
+# THIS USED TO BE AN UNANCHORED `grep -E` OVER THE WHOLE ROW, with
+# `tr ' ' '|'` turning every extra word into an ALTERNATION. So a filter
+# that looked like it named a column named nothing of the kind, and a
+# two-term filter that looked like it narrowed actually broadened.
+#
+# `am-ledger list pr` returned 90 rows, 2 of which were at stage `pr`.
+# The other 88 matched the substring somewhere: `ci_profile`,
+# `fingerprint`, `prefix`, `github-protect-main`. A pipeline decision
+# was taken on that listing and later retracted.
+#
+# WHAT MAKES IT WORSE THAN RETURNING NOTHING: an empty result invites
+# suspicion, and a screenful of plausible rows reads as a successful
+# query. The standing rule -- assert non-emptiness before believing a
+# zero -- does not fire here, because the result is not empty. This is
+# the inverse case and it slips past the rule written for it.
+#
+# So:
+#
+#   * `--stage`, `--repo` and `--owner` compare a COLUMN, LITERALLY, and
+#     several of them are ANDed. No regex, no substring: `--repo
+#     rust-fs-core` does not match `rust-fs-core-x`, and a repository
+#     name containing `.` matches only itself.
+#   * FREE TEXT IS STILL A REGEX and still ORs its words, unchanged,
+#     because that is what several callers use and `list <repo> <num>`
+#     works today only by accident of the OR. Documented rather than
+#     changed.
+#   * THE MATCH COUNT GOES TO STDERR ON EVERY CALL, not only on zero.
+#     The zero case was never the one that misled; the 90-row case was,
+#     and it was silent. The line carries no tab, so a caller piping
+#     stdout into `awk -F'\t'` is unaffected even if it merged stderr.
+#   * A filter that is EXACTLY A STAGE NAME is refused rather than run.
+#     `stats` and `next` both take a stage as a real argument, so `list
+#     pr` reads as the same vocabulary and is not -- and the collision
+#     is knowable from in here, because the stage list is right above.
 do_list() {
     [ -f "$LEDGER" ] || { echo "am-ledger: no ledger; run refresh" >&2; return 1; }
-    if [ $# -eq 0 ]; then cat "$LEDGER"; return 0; fi
-    local pat
-    pat=$(printf '%s' "$*" | tr ' ' '|')
-    grep -E "$pat" "$LEDGER" || true
+
+    local stage="" repo="" owner="" free="" literal=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --stage|--repo|--owner)
+                [ $# -ge 2 ] && [ -n "$2" ] || { echo "am-ledger list: $1 needs a value" >&2; return 2; }
+                case "$1" in
+                    --stage) stage="$2" ;;
+                    --repo)  repo="$2" ;;
+                    --owner) owner="$2" ;;
+                esac
+                shift 2
+                continue
+                ;;
+            # An EMPTY value is an error rather than "no filter". A
+            # flag that silently stops filtering is the same defect
+            # this command is being repaired for, in a new spelling.
+            --stage=*) stage="${1#--stage=}"
+                       [ -n "$stage" ] || { echo "am-ledger list: --stage needs a value" >&2; return 2; } ;;
+            --repo=*)  repo="${1#--repo=}"
+                       [ -n "$repo" ] || { echo "am-ledger list: --repo needs a value" >&2; return 2; } ;;
+            --owner=*) owner="${1#--owner=}"
+                       [ -n "$owner" ] || { echo "am-ledger list: --owner needs a value" >&2; return 2; } ;;
+            # `--` IS THE ESCAPE HATCH the stage-name refusal below points
+            # at, so everything after it is text and the refusal does not
+            # apply. Without this the message names a way out that does
+            # not work, which is worse than no message.
+            --) literal=1; shift
+                while [ $# -gt 0 ]; do free="${free:+$free|}$1"; shift; done
+                continue ;;
+            -*) echo "am-ledger list: unknown option $1" >&2; return 2 ;;
+            *) free="${free:+$free|}$1" ;;
+        esac
+        shift
+    done
+
+    # A stage that is not a stage matches nothing, and matching nothing
+    # is exactly the failure this command is being repaired for. Say it.
+    if [ -n "$stage" ] && ! is_stage "$stage"; then
+        echo "am-ledger list: --stage $stage is not a stage; one of: $STAGES" >&2
+        return 2
+    fi
+
+    # The collision that produced the retracted report.
+    if [ "$literal" = 0 ] && [ -z "$stage$repo$owner" ] && is_stage "$free"; then
+        echo "am-ledger list: '$free' is a stage name, and free text does not read the" >&2
+        echo "am-ledger list: stage column -- it greps the whole row. Did you mean" >&2
+        echo "am-ledger list: --stage $free ?  Use -- $free to grep for it anyway." >&2
+        return 2
+    fi
+
+    # ENVIRON rather than -v: awk processes escape sequences in a -v
+    # value, so a filter containing a backslash would not be the filter
+    # the caller typed.
+    local out total matched
+    total=$(wc -l < "$LEDGER" | tr -d ' ')
+    out=$(AMLL_STAGE="$stage" AMLL_REPO="$repo" AMLL_OWNER="$owner" AMLL_PAT="$free" \
+        awk -F'\t' '
+        BEGIN {
+            stage = ENVIRON["AMLL_STAGE"]; repo  = ENVIRON["AMLL_REPO"]
+            owner = ENVIRON["AMLL_OWNER"]; pat   = ENVIRON["AMLL_PAT"]
+        }
+        stage != "" && $3 != stage { next }
+        repo  != "" && $1 != repo  { next }
+        owner != "" && $4 != owner { next }
+        pat   != "" && $0 !~ pat   { next }
+        { print }
+    ' "$LEDGER")
+
+    matched=0
+    if [ -n "$out" ]; then
+        printf '%s\n' "$out"
+        matched=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
+    fi
+    printf 'am-ledger list: matched %s of %s rows\n' "$matched" "$total" >&2
+    [ "$matched" != 0 ] || return 1
 }
 
 # Create a project: its directory, and the repositories it spans.

--- a/scripts/tests/am-ledger-list.sh
+++ b/scripts/tests/am-ledger-list.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# am-ledger-list.sh — `list` filters a COLUMN, or says it is not.
+#
+# `am-ledger list <filter>` was an unanchored `grep -E` over the whole
+# row with `tr ' ' '|'` turning every extra word into an alternation, so
+# a filter that looked like it named a column named nothing of the kind.
+# `am-ledger list pr` returned 90 rows, 2 of them at stage `pr`; the
+# other 88 matched `ci_profile`, `fingerprint`, `prefix`,
+# `github-protect-main`. A pipeline decision was taken on that listing
+# and later retracted.
+#
+# WHAT MAKES IT DIFFERENT FROM THE USUAL EMPTY-RESULT DEFECT: the result
+# was not empty. An empty result invites suspicion; a screenful of
+# plausible rows reads as a successful query, and the standing rule
+# about asserting non-emptiness cannot fire on it.
+#
+# The ledger here is a fixture under AM_LEDGER_DIR, so nothing touches
+# the live one.
+#
+#   bash scripts/tests/am-ledger-list.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LEDGER_BIN="$REPO/scripts/am-ledger"
+fails=0
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+export AM_LEDGER_DIR="$sandbox"
+
+# Six rows chosen so every historical false match is present:
+#   - a title containing "pr" while the row is NOT at stage pr
+#   - a repo name that is a prefix of another repo name
+#   - a repo name containing a regex metacharacter
+#   - one row genuinely at stage pr
+row() { printf '%s\t%s\t%s\t%s\t-\t-\t2026-09-09T00:00:00Z\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+{
+    row rust-fs-core   115 accepted fix   "the staticlib task does not fingerprint tests/"
+    row rust-fs-core-x 200 fixing   fix-2 "a prefix collision, deliberately"
+    row rust-img-qcow2  68 fixing   fix-2 "tests/ci_profile.rs leaves the guard green"
+    row rust-fs-xfs    138 pr       fix   "vm-slot.sh carries the generation race"
+    row rust-fs-ntfs   254 testing  '-'   "a fingerprint that cannot fail"
+    row 'rust.fs.dots'  1  accepted '-'   "a name whose dots are regex metacharacters"
+    # THE PAIR IS THE POINT. `rust.fs.dots` matches itself as a regex
+    # too, so a row that only a regex would confuse it with is what
+    # makes "compares literally" an assertion rather than a wish.
+    row 'rustXfsYdots'  2  accepted '-'   "the row a regex would confuse with the dotted one"
+} > "$sandbox/issues.tsv"
+TOTAL=7
+
+# `list` prints its count on stderr, so stdout is the rows and stderr is
+# the commentary. They are captured separately on purpose: a test that
+# merged them would be asserting against its own diagnostics.
+run() {
+    OUT="$("$LEDGER_BIN" list "$@" 2>"$sandbox/err")"
+    RC=$?
+    ERR="$(cat "$sandbox/err")"
+    if [ -z "$OUT" ]; then ROWS=0; else ROWS=$(printf '%s\n' "$OUT" | wc -l | tr -d ' '); fi
+}
+
+check_eq() {
+    local got="$1" want="$2" what="$3"
+    if [ "$got" = "$want" ]; then
+        printf 'ok    %s\n' "$what"
+    else
+        printf 'FAIL  %s: got %s, expected %s\n' "$what" "$got" "$want"
+        fails=$((fails + 1))
+    fi
+}
+
+check_contains() {
+    local hay="$1" needle="$2" what="$3"
+    case "$hay" in
+        *"$needle"*) printf 'ok    %s\n' "$what" ;;
+        *) printf 'FAIL  %s: %q does not contain %q\n' "$what" "$hay" "$needle"
+           fails=$((fails + 1)) ;;
+    esac
+}
+
+# --- the defect ------------------------------------------------------
+
+# THE FILED CASE. Under the old reader this returned every row whose
+# text contained "pr" ANYWHERE. In this fixture that is five of six:
+# `fingerprint` twice, `prefix`, `ci_profile`, and the one row actually
+# at stage `pr`. Four of the five have nothing to do with the stage.
+run --stage pr
+check_eq "$RC" 0 "--stage pr succeeds"
+check_eq "$ROWS" 1 "--stage pr returns the one row at stage pr"
+check_eq "$(printf '%s' "$OUT" | cut -f1)" rust-fs-xfs "and it is the right one"
+
+# The control on that control: the substrings really are there, so the
+# 1 above is a filter working rather than a fixture with nothing in it.
+run -- pr
+check_eq "$RC" 0 "free text still greps the whole row"
+check_eq "$ROWS" 5 "and 'pr' as free text matches five rows, one of them at stage pr"
+
+# --- the column filters are literal and ANDed ------------------------
+
+run --repo rust-fs-core
+check_eq "$ROWS" 1 "--repo matches the whole column, not a prefix of another repo"
+check_eq "$(printf '%s' "$OUT" | cut -f2)" 115 "and it is rust-fs-core's row, not rust-fs-core-x's"
+
+run --repo rust.fs.dots
+check_eq "$ROWS" 1 "--repo compares literally, so dots are dots"
+check_eq "$(printf '%s' "$OUT" | cut -f1)" 'rust.fs.dots' \
+    "and it is the dotted row, not the one a regex would also have matched"
+
+run --owner fix
+check_eq "$ROWS" 2 "--owner matches the owner column"
+
+run --owner fix --stage accepted
+check_eq "$ROWS" 1 "two column filters are ANDed, not ORed"
+check_eq "$(printf '%s' "$OUT" | cut -f1)" rust-fs-core "and the AND selects the right row"
+
+run --repo rust-fs-xfs --stage accepted
+check_eq "$RC" 1 "an AND that selects nothing fails rather than exiting 0"
+check_eq "$ROWS" 0 "and prints no rows"
+check_contains "$ERR" "matched 0 of $TOTAL rows" "and says how many it matched"
+
+# --- the count is on stderr, on every call ---------------------------
+
+run
+check_eq "$ROWS" "$TOTAL" "no filter prints every row"
+check_contains "$ERR" "matched $TOTAL of $TOTAL rows" \
+    "the count is printed even when nothing was filtered"
+
+run --stage pr
+check_contains "$ERR" "matched 1 of $TOTAL rows" "and on a successful filter too"
+
+# THE COUNT LINE MUST NOT LOOK LIKE A ROW. Callers pipe this into
+# `awk -F'\t'`, and some of them merge stderr into stdout. A line with
+# no tab is invisible to a column filter; a line with tabs would be a
+# seventh row.
+case "$ERR" in
+    *"$(printf '\t')"*) printf 'FAIL  the count line carries a tab and would read as a row\n'
+                        fails=$((fails + 1)) ;;
+    *) printf 'ok    the count line carries no tab, so it cannot be read as a row\n' ;;
+esac
+
+# --- the collision that produced the retracted report ----------------
+
+run pr
+check_eq "$RC" 2 "a bare filter that is exactly a stage name is refused"
+check_eq "$ROWS" 0 "and prints no rows at all"
+check_contains "$ERR" "Did you mean" "and suggests the flag"
+check_contains "$ERR" "--stage pr" "naming the stage the caller typed"
+
+# Every stage name, not just the one that bit. `fixing`, `testing` and
+# `merged` all appear inside ordinary titles too.
+for s in pending accepted rejected fixing testing pr merged failed blocked; do
+    run "$s"
+    if [ "$RC" != 2 ]; then
+        printf 'FAIL  the bare stage name %s is refused: rc=%s\n' "$s" "$RC"
+        fails=$((fails + 1))
+    fi
+done
+printf 'ok    every one of the nine stage names is refused as a bare filter\n'
+
+# THE ESCAPE HATCH WORKS, or the refusal is a wall rather than a
+# signpost. `-- pr` is how a caller greps for the text.
+run -- pr
+check_eq "$RC" 0 "-- pr greps for the text instead of refusing"
+check_eq "$ROWS" 5 "and finds every row containing it"
+
+# A word that merely CONTAINS a stage name is not a stage name.
+run vm-slot
+check_eq "$RC" 0 "free text that is not a stage name is not refused"
+check_eq "$ROWS" 1 "and still greps"
+
+# --- a stage that is not a stage -------------------------------------
+
+run --stage p
+check_eq "$RC" 2 "--stage p is refused rather than matching nothing"
+check_contains "$ERR" "is not a stage" "and says why"
+
+run --stage=
+check_eq "$RC" 2 "--stage= with no value is refused rather than read as no filter"
+
+run --stage
+check_eq "$RC" 2 "--stage with nothing after it is refused"
+
+run --nonsense
+check_eq "$RC" 2 "an unknown option is refused rather than grepped for"
+
+# --- free text is unchanged ------------------------------------------
+
+# SEVERAL WORDS ARE STILL AN OR. This is the historical behaviour and
+# `list <repo> <num>` depends on it; it is documented rather than
+# changed, and pinning it here is what stops a later reader "tidying"
+# it into an AND and breaking those callers silently.
+run -- rust-fs-core 138
+check_eq "$ROWS" 3 "free text ORs its words, as it always has"
+
+if [ "$fails" -eq 0 ]; then
+    echo "am-ledger-list: all checks passed"
+else
+    echo "am-ledger-list: $fails check(s) failed" >&2
+fi
+exit $(( fails > 0 ))


### PR DESCRIPTION
Closes #114.

`am-ledger list <filter>` was an unanchored `grep -E` over the whole row, with `tr ' ' '|'` turning every extra word into an alternation. So a filter that looked like it named a column named nothing of the kind, and a two-term filter that looked like it narrowed actually broadened.

`--stage`, `--repo` and `--owner` now compare a column, literally, ANDed. Free text is unchanged — still a regex, still ORs its words — because `list <repo> <num>` works today only by accident of that OR. `matched N of M rows` goes to stderr on every call (tab-free, so a caller piping stdout into `awk -F'\t'` is unaffected even if it merged stderr), zero matches exits non-zero, and a bare filter that is exactly a stage name is refused with `Did you mean --stage pr ?` — `-- pr` greps for it anyway.

### Verified

`bash scripts/tests/am-ledger-list.sh` at d412deb: **EXIT=0, 34 checks, 0 failed**. The live ledger was 578 rows before the run and 578 after — the tests point `AM_LEDGER_DIR` at a `mktemp -d` sandbox, and `scripts/am-ledger:79` honours it, so nothing touches the real one.

**Negative controls**, each a one-line mutation with `count == 1` asserted before mutating, `scripts/am-ledger` restored and re-hashed to `68a249f4…` after every arm:

| arm | result |
|---|---|
| `--repo` compared with `!~` instead of `!=` | EXIT=1, 30 ok, **4 failed** — "matches the whole column, not a prefix of another repo: got 2, expected 1"; "dots are dots: got 2, expected 1" |
| `--stage` compared against `$0` instead of `$3` | EXIT=1, 31 ok, **3 failed** — "--stage pr returns the one row at stage pr: got 5, expected 1" |
| column filters ORed instead of ANDed | EXIT=1, 29 ok, **5 failed** — "two column filters are ANDed, not ORed: got 7, expected 1" |
| the `matched N of M` line removed | EXIT=1, 31 ok, **3 failed** |
| the stage-name refusal → `if false &&` | EXIT=1, 30 ok, **13 failed** |
| zero matches `return 0` instead of `return 1` | EXIT=1, 33 ok, **1 failed** |
| `--` sets `literal=0` instead of `1` | EXIT=1, 30 ok, **4 failed** — "`-- pr` greps for the text instead of refusing" |

Every mechanism is pinned by a named check; nothing survives.

**The new CI job.** Parsed the workflow with a YAML parser rather than reading it: job `scripts` has keys `["name", "runs-on", "steps"]` only — no `if:`, no `continue-on-error:` — and `on:` is `["push", "pull_request"]`, so it gates a PR. The step's `run:` was extracted from the parsed YAML (397 bytes, not retyped) and executed as `bash -e`: **EXIT=0, "ran 1 script test(s)"**, 34 `ok` lines inside it. Re-run from a directory with an empty `scripts/tests/`: **EXIT=1, "scripts/tests/ matched no test files"** — so the `nullglob` arm is real and a glob matching nothing cannot pass as a clean bill of health.

`shellcheck -S warning` exits 0 with no output on both `scripts/am-ledger` and `scripts/tests/am-ledger-list.sh`.

No caller breaks: the only references to `am-ledger list` in the repository are the docs, this script's own comments and its test — nothing programmatic depends on the old exit-0-on-zero-matches.

Rebased onto `main` (5c255f9) before opening; the branch was one commit behind.
