### PR TITLE
feat: next prefers a repository nobody else is in

### DIFF
--- a/scripts/am-ledger
+++ b/scripts/am-ledger
@@ -501,8 +501,55 @@ do_next() {
     local want="$1" only="${2:-}" owner="${AM_LEDGER_OWNER:-$$}"
     [ -f "$LEDGER" ] || return 0
     local row
-    row=$(awk -F'\t' -v s="$want" -v r="$only" \
-          '$3==s && $4=="-" && (r=="" || $1==r) {print; exit}' "$LEDGER")
+    # PREFER A REPOSITORY NOBODY ELSE IS IN. Two agents in one repository
+    # is how a file that was byte-identical across five repos acquires two
+    # divergent answers, and how a rebase under someone's feet voids
+    # evidence they have already paid for. Both happened on 2026-09-09.
+    #
+    # A repository is busy if any row in it is claimed by somebody who is
+    # not the caller, at any stage where work is actually in flight. Rows
+    # the caller holds do not make it busy: continuing in a repository you
+    # are already in is the good case, not the collision.
+    #
+    # Naming a repository explicitly still overrides all of this, because
+    # a defect that spans repositories wants the opposite arrangement —
+    # one owner crossing several repos, everyone else off that file.
+    #
+    # The scan runs to END before choosing, so a claim recorded LOWER in
+    # the file still excludes its repository; a streaming version handed
+    # out a repository whose only claim happened to sort after the
+    # candidate. And it runs under the same lock as the write below, so
+    # the answer cannot go stale between deciding and recording it.
+    # STAGES THAT TOUCH A CHECKOUT ARE THE ONLY ONES THAT CAN COLLIDE.
+    # Triage reads an issue and writes a marker; it edits no file, holds no
+    # worktree, and pushes no branch, so excluding a repository from it buys
+    # nothing and costs everything: with the exclusion on, a `next pending`
+    # whose only rows sit in repositories a fixer happens to hold returns
+    # empty, which is indistinguishable from "the queue is drained". That
+    # read triage as idle while work waited, on the night this was written.
+    case "$want" in
+        fixing|testing|pr) ;;
+        *) only="${only:-}"
+           row=$(awk -F'\t' -v s="$want" -v r="$only" \
+                 '$3==s && $4=="-" && (r=="" || $1==r) {print; exit}' "$LEDGER")
+           if [ -n "$row" ]; then
+               do_set "$(printf '%s' "$row" | cut -f1)" \
+                      "$(printf '%s' "$row" | cut -f2)" "owner=$owner" >/dev/null
+               printf '%s\n' "$row"
+           fi
+           return 0 ;;
+    esac
+    if [ -n "$only" ]; then
+        row=$(awk -F'\t' -v s="$want" -v r="$only" \
+              '$3==s && $4=="-" && $1==r {print; exit}' "$LEDGER")
+    else
+        row=$(awk -F'\t' -v s="$want" -v me="$owner" '
+            $4 != "-" && $4 != me &&
+            ($3=="fixing" || $3=="testing" || $3=="pr" || $3=="pending") { busy[$1] = 1 }
+            $3 == s && $4 == "-" { cand[++n] = $0; crepo[n] = $1 }
+            END { for (i = 1; i <= n; i++) if (!(crepo[i] in busy)) { print cand[i]; exit } }
+        ' "$LEDGER")
+    fi
     [ -n "$row" ] || return 0
     local short num
     short=$(printf '%s' "$row" | cut -f1)


### PR DESCRIPTION
`am-ledger next` now skips repositories claimed by anybody who is not the caller, at the stages where work is actually in flight (`fixing`, `testing`, `pr`).

Two agents in one repository is how a file that was byte-identical across five repos acquires two divergent answers, and how a rebase under someone's feet voids evidence already paid for. Both happened on 2026-09-09.

- Rows the caller already holds do not make a repository busy: continuing where you already are is the good case, not the collision.
- Naming a repository explicitly (`next <stage> <repo>`) still overrides the exclusion, which is what a cross-repo family needs: one owner crossing several repos, everyone else off that file.
- The exclusion is deliberately **not** applied to `pending`/triage. Triage reads an issue and writes a marker — it edits no file, holds no worktree, pushes no branch — so excluding a repository there buys nothing and costs everything: a `next pending` whose only rows sit in repositories a fixer holds returns empty, which is indistinguishable from a drained queue. That read triage as idle while work waited.
- The scan runs to END before choosing, so a claim recorded lower in the file still excludes its repository (a streaming version handed out a repository whose only claim sorted after the candidate), and it runs under the same lock as the write, so the answer cannot go stale between deciding and recording it.

Recovered from an interrupted session: the change was uncommitted in the working tree and existed nowhere else. Rebased onto current `main` — the branch it was sitting on had already been merged as #93.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm