### PR TITLE
docs: the failure-counting grep counts one failure twice

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -246,7 +246,15 @@ yields named failures and leaves the sibling assertions green, so a fix
 that over-corrected would fail too.
 
     compile-errors=$(grep -acE '^error\[E[0-9]+\]' log)
-    test-failures=$(grep -acE '^test .* FAILED' log)
+    test-failures=$(grep -acE '^test [a-z].*\.\.\. FAILED' log)
+
+**The obvious pattern for the second one is off by exactly one.** `^test
+.* FAILED` also matches the summary line `test result: FAILED. 52
+passed; 1 failed`, so a single failure counts as two and every arm's
+figure is inflated by one. Measured 2026-09-10 on a two-line fixture: the
+loose pattern returns 2, the anchored one returns 1. A fixer caught it
+only because the number looked odd, which is the least reliable way to
+catch anything — anchor on the `... FAILED` that follows a test name.
 
 **A surviving mutation may mean the test is missing, not the code.** Ask
 whether the check is unwitnessed rather than inert, and build the case it


### PR DESCRIPTION
The document's own recipe for separating a compile error from a test failure counts one failing test as two.

`^test .* FAILED` matches the real line **and** cargo's summary line:

```
test index_io::tests::a_thing ... FAILED
test result: FAILED. 52 passed; 1 failed; 0 ignored
```

Measured 2026-09-10 on exactly that two-line fixture: the loose pattern returns **2**, the anchored `^test [a-z].*\.\.\. FAILED` returns **1**.

Every mutation arm's failure figure taken with the loose pattern is inflated by exactly one, and this recipe is quoted into stage briefs and from there into issue bodies, where nothing can correct it. A fixer caught it only because the number looked odd — the least reliable way to catch anything, which is why the correction says what to anchor on rather than only what was wrong.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm