### PR TITLE
docs: two claims in circulation, both measured false

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -575,6 +575,18 @@ back empty. Each looked like a finding.
 exits on first match, the producer gets SIGPIPE, and the pipeline exits
 141 *because* the match succeeded.
 
+**zsh does not word-split an unquoted parameter expansion.** `for r in
+$refs` iterates **once**, over the whole string, and `set -- $pair`
+assigns the entire string to `$1` — so a loop over a variable holding a
+list runs one iteration with a nonsense value, every command inside it
+fails, and the result is an empty table. Measured twice on 2026-09-10:
+an audit's first cross-repo drift table came back `0/12` on all fifteen
+rows, and a coordinator's release loop reported `'rust-fs-xfs 158' is
+not a repository`. Both read exactly like findings. Use an array, or
+`${=var}` where a split is what you actually want. This is the same
+shape as the `${REF}:path` rule above: zsh's departures from bash are
+silent and produce empty results, and an empty result is not an answer.
+
 **Process substitution is a bashism.** `done < <(...)` is rejected at
 parse time, so running the script with `sh` kills every subcommand with
 a syntax error pointing at a line the caller never asked for.

--- a/scripts/am-ledger
+++ b/scripts/am-ledger
@@ -109,11 +109,25 @@ DEFAULT_REPOS=(
     # Not a driver, and tracked anyway. The dependency-pin guard that every
     # repo above carries a copy of has its fix location HERE, not in the
     # constellation: the upstream copy never had the sibling-version check
-    # at all, so syncing the copies onto it would delete the capability
-    # from eleven repositories. Until a corrected version is ported up,
-    # agent-skills#34 is the parent of five defects in three generations
-    # of that script — and an untracked repository is one no stage ever
-    # dispatches, which is how it sat unowned.
+    # at all, while ALL TWELVE consumers have it — measured 2026-09-10,
+    # `grep -c 'the lock must record the sibling version'` is 12/12 in
+    # the consumers and 0 upstream, across three generations of the file.
+    #
+    # THE MECHANISM IS NOT DELETION, and this comment said it was for a
+    # week. `install.sh` writes <repo>/.git/hooks and never
+    # <repo>/.githooks/ — it only reads the latter. So a sync leaves the
+    # tracked file, its section 5 and a clean `git status` exactly as
+    # they were, and changes only which copy `git commit` executes. A
+    # fixer confirming the risk by looking at the tree gets a false
+    # all-clear either way, which is agent-skills#44.
+    #
+    # The asymmetry is also one file wide, not the hook set: 14 of 15
+    # files sync upstream->consumer safely today and 8 need no sync at
+    # all. Read as a general caution it inflates the diff-them-all job
+    # that agent-skills#34 and #35 both gate on. #34 is the parent of
+    # eight defects, not five — five in its body plus the addendum's
+    # ext4#111/#115/#116 — and an untracked repository is one no stage
+    # ever dispatches, which is how it sat unowned.
     "agent-skills:antimatter-studios/agent-skills"
     # And the controller project itself. It was left out because it
     # orchestrates the twelve rather than being one of them — but issues


### PR DESCRIPTION
Two corrections to claims this repository puts into circulation, both found by agents acting on them.

**1. `scripts/am-ledger`'s comment on why `agent-skills` is tracked said syncing the hook copies onto upstream would *delete* the sibling-version check from eleven repositories.** Both halves are wrong.

- **The mechanism is not deletion.** `install.sh` writes `<repo>/.git/hooks` and never `<repo>/.githooks/`, which it only reads. A sync leaves the tracked file, its section 5 and a clean `git status` exactly as they were; what changes is which copy `git commit` executes. That matters precisely because a fixer confirming the risk by reading the tree gets a false all-clear whichever way it went — now filed as `agent-skills#44`.
- **It is twelve, not eleven.** `grep -c 'the lock must record the sibling version'` is 12/12 in the consumers and 0 upstream, across three generations of the file (`ca802001` 24465 B ×6, `30feddfe` 22575 B ×1, `ac1a254d` 13421 B ×5). "Eleven" invites a hunt for a twelfth that has none.
- The asymmetry is **one file wide, not the hook set**: 14 of 15 files sync upstream→consumer safely today and 8 need no sync at all. Read as a general caution it inflates the diff-them-all job that `#34` and `#35` both gate on. And `#34` carries eight defects, not five.

**2. `docs/issue-pipeline.md` had no rule about zsh word-splitting, and it has now cost two measurements.** `for r in $refs` iterates **once**, over the whole string; `set -- $pair` assigns the whole string to `$1`. So a loop over a variable holding a list runs one iteration with a nonsense value, every command inside fails, and the output is an empty table that reads exactly like a finding.

Measured twice on 2026-09-10: an audit's first cross-repo drift table came back `0/12` on all fifteen rows, and the coordinator's own ledger-release loop reported `'rust-fs-xfs 158' is not a repository in this project`. The rule now sits next to the `${REF}:path` one, because it is the same shape — zsh's departures from bash are silent and produce empty results.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm