### PR TITLE
docs: a pattern can also match something else entirely

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -273,6 +273,15 @@ reviewing, repeatedly:
 - a scan whose pattern cannot match — `\s` is not honoured by every
   `grep`, so it matched nothing everywhere and read as twelve clean
   repositories;
+- a scan whose pattern matches something else entirely, which is the
+  same defect with the sign flipped: an unanchored `grep -q 'up to
+  date'` for a task-skip check matched `rustup`'s own `info: component
+  rust-std is up to date`, so every run recorded as skipped and
+  "the `sources:` list has no effect" was briefly a finding. Measured
+  2026-09-10 by the verifier that wrote it, caught because a run it had
+  called skipped had regenerated a file it had just deleted. Anchor the
+  pattern, and keep a control that shows the check discriminates — here,
+  a `README.md` edit that genuinely does skip;
 - an empty search result whose coverage was never established —
   `gh issue list --search` does not index comment bodies; use
   `gh issue view --json comments`;


### PR DESCRIPTION
The recurring-defect list carries **"a scan whose pattern cannot match"** — the `\s` case that matched nothing everywhere and read as twelve clean repositories. Its mirror image was missing, and it cost a measurement today.

A verifier checking whether a build task had skipped used an unanchored `grep -q 'up to date'`. It matched **rustup's own** `info: component rust-std is up to date`, so every run recorded as a skip, and *"the `sources:` list has no effect"* was briefly a finding.

It was caught not by the check — which agreed with itself every time — but because a run that had been called skipped had regenerated a file that had just been deleted.

The entry records the control that settles it: a `README.md` edit that genuinely does skip, proving the check discriminates rather than always answering the same way. Same discipline as the `\s` case, opposite failure: there the pattern could never fire, here it always did.

Measured 2026-09-10 by the verifier that wrote it, and reported as a self-correction rather than left in the log.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm