### PR TITLE
docs: path= is not a variable name in zsh, it is PATH

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -575,6 +575,24 @@ back empty. Each looked like a finding.
 exits on first match, the producer gets SIGPIPE, and the pipeline exits
 141 *because* the match succeeded.
 
+**`path=` is not a variable name in zsh — it is `PATH`.** zsh ties the
+`path` array to `PATH`, so `path="$repo/include"` inside a loop replaces
+the search path and every external command afterwards is gone. Measured
+2026-09-10: a header survey assigned `path=` per file, `wc`, `tr` and
+then `gh` itself vanished, and every `grep -c` returned **0** — which
+read exactly as "these headers never mention the symbol". It was caught
+only because the survey carried a known-positive control that went to
+zero at the same time. `cdpath`, `fpath`, `manpath` and `mailpath` are
+tied the same way.
+
+That is the third of these in one session, and they are one family:
+`$REF:path` taking `:t` as a history modifier, an unquoted expansion not
+word-splitting, and `path=` clobbering `PATH`. **zsh's departures from
+bash turn a failed query into a plausible negative**, which is why every
+survey needs a control that must be non-zero — the control is not
+diligence, it is the only thing that separates "no hits" from "no
+command".
+
 **Process substitution is a bashism.** `done < <(...)` is rejected at
 parse time, so running the script with `sh` kills every subcommand with
 a syntax error pointing at a line the caller never asked for.


### PR DESCRIPTION
zsh ties the `path` array to `PATH`. So `path="$repo/include"` inside a loop replaces the search path, and every external command after it is gone.

Measured 2026-09-10 by a triage agent surveying C headers for a symbol: it assigned `path=` per file, then `wc`, `tr` and eventually `gh` itself vanished, and every `grep -c` returned **0** — which read exactly as *"these headers never mention the symbol"*. It was caught only because the survey carried a known-positive control (`FsCoreDevice`, six occurrences in a header it had already read) that went to zero at the same moment. `cdpath`, `fpath`, `manpath` and `mailpath` are tied the same way.

Re-measured with the assignment renamed, the survey held exactly: two members, with `partitions` at 0 *and* its control at 6.

This is the third such trap in one session and they are one family — `$REF:path` taking `:t` as a history modifier, an unquoted expansion not word-splitting, and now `path=` clobbering `PATH`. **zsh's departures from bash turn a failed query into a plausible negative**, which is the real argument for a must-be-non-zero control in every survey: the control is not diligence, it is the only thing that separates "no hits" from "no command".

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm