### PR TITLE
docs: two readings that stop early and look like measurements

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -256,6 +256,16 @@ exists for.
 one tree. When two PRs touch the same file, merging one invalidates the
 other's *evidence* as well as its mergeability.
 
+**A fail-fast run reports a truncated world, and the number it gives
+looks like a measurement.** The benign-failure set of one repository was
+recorded as **four** tests from a fail-fast run, which stops at the first
+failing target; measured with `--no-fail-fast` on the same commit it is
+**347 names across 63 of 111 targets**, which agrees with this document's
+own 63-of-108 figure for that crate. Every comparison against a
+fail-fast baseline is therefore a comparison against an arbitrary prefix
+of the failures. Use `--no-fail-fast` for any figure you intend to
+subtract, and say which you used.
+
 **Run the targeted test, not the suite.** A mutation only has to prove
 that assertion can fail. Full suite once at the end.
 
@@ -596,6 +606,16 @@ What matters is what the change adds to the supply chain: a dependency,
 a third-party action, a trigger change, a network call, a secret
 reference. Read the shell too — `read -r -a args <<< "$VAR"` splits
 without evaluating, which is not `eval`.
+
+**A run id resolves to the latest attempt, not to the run you looked
+at.** `actions/runs/<id>` returns whichever attempt ran last, so a
+failure cited by run id reads **green** to the next person the moment
+anybody re-runs it. Measured 2026-09-10: an issue filed against a flaky
+check cited `runs/34446493979`, which by the time triage read it returned
+`attempt 2, success` — the failure lives only at
+`…/runs/<id>/attempts/1`. Cite the attempt, and treat a re-run as
+destroying the evidence unless the attempt number is in the citation.
+Same family as the rule below, one level further down.
 
 **2. A green tick belongs to a commit, not to a pull request.**
 


### PR DESCRIPTION
**1. A run id resolves to the latest attempt.** `actions/runs/<id>` returns whichever attempt ran last, so a failure cited by run id reads **green** the moment anybody re-runs it.

Measured 2026-09-10: `diskjockey#139` cited `runs/34446493979` as its evidence of a failure. By the time triage read the issue, that id returned `attempt 2, success`; the failure exists only at `…/runs/34446493979/attempts/1`. Anyone checking the citation would have concluded the issue was wrong.

Filed beside "a green tick belongs to a commit, not to a pull request" because it is the same rule one level further down — and it means a re-run destroys the cited evidence unless the attempt number is part of the citation.

**2. A fail-fast run reports a truncated world, and the number looks like a measurement.** One repository's benign-failure set was on record as **four** tests. That came from a fail-fast run, which stops at the first failing target. On the same commit with `--no-fail-fast` it is **347 names across 63 of 111 targets** — which agrees with this document's own 63-of-108 figure for that crate, so the doc was right and the circulating number was the truncated one.

Every comparison against a fail-fast baseline is therefore a comparison against an arbitrary prefix of the failures. Use `--no-fail-fast` for any figure you intend to subtract, and say which you used.

Both found by stages reading numbers the pipeline itself had produced, which is where most of today's corrections have come from.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm