### PR TITLE
docs: bind a destructive act to a token, not a re-derived identity

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -553,6 +553,22 @@ agent totals divided by issue counts.
 no `git checkout`, no `git pull` in a repository you do not own — one
 agent swept up another's untracked work.
 
+**Bind a destructive act to a token you recorded, never to an identity
+you re-derive.** Four rows this week converge on this one primitive:
+`ext4#104` (break_lock deletes whichever lock is present, not the one the
+waiter inspected), `xfs#158`, `diskjockey#123`/`#124` (the ledger lock
+and the slot reclaim, same shape), and `btrfs#141` — where the oracle
+slot's release compares the *invoked script's own path*, derived from
+`BASH_SOURCE`, against the path recorded at acquire time. Under
+one-worktree-per-issue a different checkout is the **normal** case, so
+the holder-only guard that `#100` added — the right instinct — silently
+declines to release and leaks the slot.
+
+The fix is not to drop the guard; it is to compare a recorded token
+rather than a re-derived identity, and to reach the release on every exit
+path. Watch for the trap that inherits the defect: an `EXIT` trap whose
+token is still the checkout path is the same leak with better manners.
+
 **Never `rm` with a glob or a bare variable.** Name the exact path.
 
 **Push over HTTPS** with the `gh` credential helper; SSH to GitHub fails


### PR DESCRIPTION
Four rows this week are the same primitive, and naming it is cheaper than meeting the fifth:

- `rust-fs-ext4#104` — `break_lock` deletes whichever lock is present, not the one the waiter inspected, so two waiters can both acquire.
- `rust-fs-xfs#158` — the same shape in `vm-slot.sh`'s pre-move token check.
- `diskjockey#123` / `#124` — the ledger lock's stale break and `am-slot`'s reclaim each remove whichever file is present, not the one whose pid they read.
- `rust-fs-btrfs#141` — the oracle slot's release compares the **invoked script's own path**, derived from `BASH_SOURCE`, against the path recorded at acquire time.

That last one is the clearest case, because the guard is deliberate: `7f71458` (#100) made release holder-only so one script could not release another's slot. Right instinct, implemented against a **re-derived** value — and under one-worktree-per-issue a different checkout is the *normal* case, so the guard silently declines to release and the slot leaks. Measured twice in one item, under holder names `btrfs75fix` and `bt75-main`, both of which are directory basenames.

**The fix is not to drop the guard.** Compare a recorded token, and reach the release on every exit path. The entry also records the trap that inherits the defect whole: an `EXIT` trap whose token is still the checkout path is the same leak with better manners.

Traced by the triage stage from the *caller* rather than from the script — `:56` derives `REPO` from `BASH_SOURCE`, `:141` writes it into the record, `:199` compares field 1 against the releasing process's own value and returns 0 silently on a mismatch — plus `grep -c '^\s*trap '` = 0 in both scripts against a control of 5 `release` mentions, and 11 `exit` statements reaching a release at 3. That turned "where is the release missed" from open into two candidates with a one-grep discriminator.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm