### PR TITLE
docs: a syntax error has no E-code, so neither count sees it

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -245,6 +245,19 @@ comparison replaced with `if false`, uniqueness asserted first — which
 yields named failures and leaves the sibling assertions green, so a fix
 that over-corrected would fail too.
 
+**Neither count sees a syntax error, and the discriminator is the
+`test result:` line.** A mis-spliced brace gives `error: unexpected
+closing delimiter`, which carries **no `E`-code**, so the compile-error
+pattern below cannot match it; widening to a bare `error:` then matches
+cargo's own `error: test failed, to rerun pass …` on every real failure,
+so neither form is a reliable count. Measured 2026-09-10: an arm
+reported `EXIT=101` with **0 compile errors and 0 named failures**,
+which reads exactly like a surviving mutation. **A run that produced no
+`test result:` line at all did not run tests** — assert its presence
+before calling an arm behavioural, and refuse to report rather than
+record a survival. Caught only because `EXIT=101` with zero of both is
+internally inconsistent.
+
     compile-errors=$(grep -acE '^error\[E[0-9]+\]' log)
     test-failures=$(grep -acE '^test .* FAILED' log)
 


### PR DESCRIPTION
Companion to #133, on the same recipe.

A mutation arm reported **`EXIT=101`, 0 compile errors, 0 named failures** — which reads exactly like a surviving mutation, and would have been recorded as one. It was a mis-spliced brace:

```
error: unexpected closing delimiter
```

A syntax error carries **no `E`-code**, so `grep -acE '^error\[E[0-9]+\]'` cannot match it. And widening the pattern to a bare `error:` is not the fix: that matches cargo's own `error: test failed, to rerun pass …`, which appears on every genuine test failure. Neither form is a reliable count.

**The discriminator that works is whether a `test result:` line exists at all.** A run that produced none did not run tests, whatever its exit code says. Assert its presence before calling an arm behavioural, and refuse to report rather than record a survival.

Measured 2026-09-10 by the fix stage, which caught it only because `EXIT=101` with zero of both counts is internally inconsistent — the same way the fabricated `219` and the doubled failure count were caught. Three corrections to this one recipe today, none of them found by re-reading the pattern.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm