### PR TITLE
docs: name the three families in the pipeline's own tooling

### DIFF
--- a/docs/issue-pipeline.md
+++ b/docs/issue-pipeline.md
@@ -263,6 +263,55 @@ that assertion can fail. Full suite once at the end.
 debug and release; a carry *within* a `u64` into flag bits does not,
 because `overflow-checks` never sees it.
 
+### Three families in the pipeline's own tooling
+
+Named on 2026-09-10 after four members of the second one turned up in
+four different files in a single day. A family is worth naming when it
+makes the next member findable — the third one below was found by asking
+what the first two did **not** cover.
+
+**1. Destructive re-resolution.** A command whose target is re-resolved
+between reading the state and acting on it: `ext4#104` (`break_lock`
+deletes whichever lock is present, not the one the waiter inspected),
+`diskjockey#123`/`#124` (the ledger lock's stale break and the slot
+reclaim), `btrfs#141` (the oracle slot's release compares the *invoked
+script's own path*). General form: **bind a destructive act to a token
+you recorded, never to an identity you re-derive.**
+
+**2. A check that cannot answer returning the permissive one.**
+`diskjockey#131`'s `in_use` probe answering the same when `lsof` is
+absent; `#127`'s `${when:-0}` epoch default; `#132`'s unparseable
+timestamp silently skipping the row; `#145`'s `sibling-build.sh:73`,
+where a failed `git status` leaves `DIRTY` empty and one unread status
+**disarms the guard and asserts the property the guard exists to
+establish** in a single step.
+
+**The blanket remedy for this family is wrong, measured.** Adding
+`set -o pipefail` everywhere fixes only the members that lose a status —
+and it breaks `#145` specifically, because `git status … | head -20`
+exits **141** whenever the producer has more than twenty lines to write
+(`set -o pipefail; yes | head -3` → 141, three of three), so under
+`set -e` it aborts in exactly the very-dirty case while still reading no
+status. Two of that row's three sites are **missing assertions rather
+than lost statuses**. Read each member before patching the family.
+
+**3. An unvalidated write that makes a later measurement quietly wrong,
+always in the reassuring direction.** `diskjockey#142`: `am-cost add`
+has an arity check and nothing else, so a non-numeric token count
+aggregates as 0 while still counting the run (141027 → 70513 per run), a
+swapped `<stage> <tokens>` pair invents a stage named `99999`, and a
+newline in the free-text note **forges a whole row** — all exiting 0,
+every error biasing the number **downward**. No reading of the file
+recovers the truth: `raw` shows the bad token, `report` shows a halved
+average, nothing connects them. This family is *annoy the human, do not
+corrupt the output* inverted, and it was found only because an agent
+finally **ran** the tool that every stage had declined to write to.
+
+**Two of those rows also carry a confident number from a path that did
+not act** — `#142`'s halved average and `#144`'s `removed/pruned: 1` for
+a worktree that still exists. Where a count and an action can disagree,
+assert the action.
+
 ### The recurring defect
 
 **A check whose output does not depend on the failure it exists to


### PR DESCRIPTION
Four members of one family turned up in four different files today, which is what a missing rule looks like. The triage stage asked twice for this section; here it is.

**1. Destructive re-resolution** — `ext4#104`, `diskjockey#123`/`#124`, `btrfs#141`. General form: bind a destructive act to a token you recorded, never to an identity you re-derive.

**2. A check that cannot answer returning the permissive one** — `#131`'s missing `lsof`, `#127`'s epoch-0 default, `#132`'s silently skipped unparseable timestamp, `#145`'s `sibling-build.sh:73`, where one unread `git status` **disarms the guard and asserts the property the guard exists to establish** in a single step.

The section records why the blanket remedy for this family is wrong, with numbers: adding `set -o pipefail` everywhere fixes only the members that lose a status, and it **breaks `#145` specifically** — `git status … | head -20` exits **141** whenever the producer has more than twenty lines (`set -o pipefail; yes | head -3` → 141, three of three), so under `set -e` it aborts in exactly the very-dirty case while still reading no status. Two of that row's three sites are missing assertions, not lost statuses.

**3. An unvalidated write that makes a later measurement quietly wrong, always in the reassuring direction** — `#142`. `am-cost add` has an arity check and nothing else: a non-numeric count aggregates as 0 while still counting the run (141027 → 70513), a swapped pair invents a stage named `99999`, a newline in the note forges a whole row. All exit 0; every error biases downward; no reading of the file recovers the truth.

That third one is the argument for naming families at all: it does not fit either of the first two — nothing is re-resolved, and there is no check to answer permissively — and it was found by asking what they did **not** cover, by an agent that finally *ran* the tool every stage had declined to write to.

Closing note in the section: two of those rows carry a confident number from a path that did not act (`#142`'s halved average, `#144`'s `removed/pruned: 1` for a worktree that still exists). Where a count and an action can disagree, assert the action.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm