### PR TITLE
feat: one table of every open issue across the constellation

### DIFF
--- a/chores.yml
+++ b/chores.yml
@@ -1,0 +1,56 @@
+version: "3"
+chore_min_version: 0.6.0
+
+# WHAT THIS FILE IS FOR, AND WHAT IT IS NOT.
+#
+# diskjockey is the controller: it orchestrates the twelve library
+# repositories rather than being one of them, so it has no `staticlib` and no
+# `artifact` — the two tasks every sibling exposes. What it does have is
+# oversight, and that is what lives here.
+#
+# The tasks are thin on purpose. Each one names a script in scripts/ and
+# nothing else: the knowledge of HOW to answer a question belongs in the
+# script, which is testable, reviewable and runnable without chore at all.
+# A task that grows a pipeline of its own is a task nobody can test.
+
+tasks:
+  overview:
+    desc: Every open issue across the constellation, as a table
+    # NO `sources`, DELIBERATELY. Freshness here is not a property of any
+    # file in this repository — the answer lives on GitHub and changes when
+    # somebody files an issue. A `sources` list would let chore report this
+    # task as up to date while the backlog moved underneath it, which is the
+    # exact shape of defect the pipeline spends its time filing: a check
+    # whose output does not depend on what it is meant to detect.
+    cmds:
+      - scripts/am-overview
+
+  overview:summary:
+    desc: Counts only — one row per project, no issue detail
+    cmds:
+      - scripts/am-overview --summary
+
+  overview:tsv:
+    desc: The detail rows as TSV, for piping somewhere else
+    cmds:
+      - scripts/am-overview --tsv
+
+  check:scripts:
+    desc: Run every scripts/tests/*.sh guard
+    # The same loop the `Shell scripts` CI job runs, so a guard that passes
+    # here passes there. It refuses an empty glob rather than reporting
+    # success for a set whose size nothing asserted.
+    cmds:
+      - |
+        set -euo pipefail
+        shopt -s nullglob
+        tests=(scripts/tests/*.sh)
+        if [ ${#tests[@]} -eq 0 ]; then
+            echo "check:scripts: no tests found under scripts/tests/" >&2
+            exit 1
+        fi
+        for t in "${tests[@]}"; do
+            echo "== $t"
+            bash "$t"
+        done
+        echo "check:scripts: ${#tests[@]} test file(s) passed"

--- a/scripts/am-overview
+++ b/scripts/am-overview
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# am-overview — one table of every open issue across the constellation.
+#
+# The projects are the array at the top of this file. Each entry is
+# `<name>:<owner>/<repo>`; the name is what the tables print and the slug
+# is what `gh` is asked about.
+#
+#   scripts/am-overview                 summary table, then one row per issue
+#   scripts/am-overview --summary       counts only
+#   scripts/am-overview --project NAME  one project (repeatable)
+#   scripts/am-overview --tsv           detail rows as TSV, no padding
+#   scripts/am-overview --print-jq      the issue filter, for its own test
+#
+# EXIT STATUS IS PART OF THE OUTPUT. A project whose fetch fails still
+# gets a row, marked `FETCH FAILED`, and the command exits 4 — because a
+# missing row reads as "no open issues", which is the failure this
+# constellation keeps paying for. A row you cannot miss beats a silent
+# omission; see docs/issue-pipeline.md on a check that cannot answer
+# returning the permissive one.
+#
+# THE ARRAY IS CHECKED AGAINST THE LEDGER'S. scripts/am-ledger already
+# carries the same list, and a second copy that drifts is diskjockey#128
+# exactly — the reaper's list omits agent-skills while the ledger has it,
+# so a whole repository is invisible to one tool and not the other. This
+# script parses am-ledger's DEFAULT_REPOS and refuses to print anything
+# if the two disagree, naming the difference in both directions.
+#
+# Environment, for tests and for pointing at a different constellation:
+#   AM_OVERVIEW_LEDGER_BIN   the am-ledger to compare against
+#   AM_OVERVIEW_FETCH        command called with a slug instead of gh
+#   AM_OVERVIEW_STALE_DAYS   what counts as stale in the summary (30)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------- projects
+# Same shape as am-ledger's DEFAULT_REPOS, deliberately: one list to read,
+# one list to diff. Add a project here AND there, or this refuses to run.
+PROJECTS=(
+    "rust-fs-core:antimatter-studios/rust-fs-core"
+    "rust-fs-xfs:antimatter-studios/rust-fs-xfs"
+    "rust-fs-ext4:christhomas/rust-fs-ext4"
+    "rust-fs-btrfs:antimatter-studios/rust-fs-btrfs"
+    "rust-fs-erofs:antimatter-studios/rust-fs-erofs"
+    "rust-fs-squashfs:antimatter-studios/rust-fs-squashfs"
+    "rust-fs-ntfs:christhomas/rust-fs-ntfs"
+    "rust-img-qcow2:antimatter-studios/rust-img-qcow2"
+    "rust-img-vhd:antimatter-studios/rust-img-vhd"
+    "rust-img-vhdx:antimatter-studios/rust-img-vhdx"
+    "rust-img-vmdk:antimatter-studios/rust-img-vmdk"
+    "rust-partitions:antimatter-studios/rust-partitions"
+    "agent-skills:antimatter-studios/agent-skills"
+    "diskjockey:antimatter-studios/diskjockey"
+)
+
+# The one jq program this tool depends on, hoisted so a test can run it
+# against a fixture rather than asserting it exists in the source. `--print-jq`
+# prints it for exactly that reason.
+ISSUE_JQ='.[] | select(.pull_request == null)
+    | [(.number|tostring), .created_at,
+       (([.labels[].name] | join(",")) | if . == "" then "-" else . end),
+       (.title | if . == "" then "(no title)" else . end)]
+    | join("\u001f")'
+
+LEDGER_BIN="${AM_OVERVIEW_LEDGER_BIN:-$HERE/am-ledger}"
+STALE_DAYS="${AM_OVERVIEW_STALE_DAYS:-30}"
+MODE=full
+WANT=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --summary) MODE=summary ;;
+        --tsv)     MODE=tsv ;;
+        --project) shift; [ $# -gt 0 ] || { echo "am-overview: --project needs a name" >&2; exit 2; }; WANT+=("$1") ;;
+        --print-jq) printf '%s\n' "$ISSUE_JQ"; exit 0 ;;
+        -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)         echo "am-overview: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --------------------------------------------------------------- drift check
+# Parse the ledger's list rather than sourcing it: am-ledger runs work at
+# load time, and sourcing it would import its `set -euo pipefail` into this
+# shell — the trap that silently truncated a test file after check 7 on
+# 2026-09-10.
+ledger_names() {
+    [ -r "$LEDGER_BIN" ] || return 1
+    sed -n '/^DEFAULT_REPOS=(/,/^)/p' "$LEDGER_BIN" \
+        | sed -n 's/^[[:space:]]*"\([^:"]*\):\([^"]*\)".*/\1:\2/p'
+}
+
+check_drift() {
+    local theirs mine
+    theirs="$(ledger_names || true)"
+    # An unparseable ledger must not read as agreement. Twelve is the
+    # count below which this cannot be the real list.
+    if [ "$(printf '%s\n' "$theirs" | grep -c ':' || true)" -lt 12 ]; then
+        echo "am-overview: could not read DEFAULT_REPOS from $LEDGER_BIN" >&2
+        echo "am-overview: refusing to run rather than assume the lists agree" >&2
+        return 1
+    fi
+    mine="$(printf '%s\n' "${PROJECTS[@]}")"
+    local only_here only_there
+    only_here="$(comm -23 <(printf '%s\n' "$mine" | sort) <(printf '%s\n' "$theirs" | sort))"
+    only_there="$(comm -13 <(printf '%s\n' "$mine" | sort) <(printf '%s\n' "$theirs" | sort))"
+    if [ -n "$only_here$only_there" ]; then
+        echo "am-overview: this file and $LEDGER_BIN disagree about the projects." >&2
+        [ -n "$only_here" ]  && { echo "  only in am-overview:" >&2; printf '    %s\n' $only_here >&2; }
+        [ -n "$only_there" ] && { echo "  only in am-ledger:"   >&2; printf '    %s\n' $only_there >&2; }
+        echo "am-overview: fix one of them; a drifted second copy is diskjockey#128." >&2
+        return 1
+    fi
+    return 0
+}
+
+check_drift || exit 3
+
+# -------------------------------------------------------------------- fetch
+# `repos/<slug>/issues` RETURNS PULL REQUESTS TOO. Every PR is an issue in
+# that endpoint, so the `.pull_request == null` filter is what makes this a
+# list of issues; without it the counts are wrong in the direction that
+# looks busy.
+fetch_repo() {
+    local slug="$1"
+    if [ -n "${AM_OVERVIEW_FETCH:-}" ]; then
+        "$AM_OVERVIEW_FETCH" "$slug"
+        return $?
+    fi
+    # An EMPTY FIELD IS NOT SAFE to hand to `read`, whatever the delimiter:
+    # TAB is IFS whitespace, so bash collapses a run of them and every later
+    # field shifts left. Measured while writing this: an unlabelled issue put
+    # its title in the labels column and left the title empty — a plausible
+    # table, not an error. So jq emits `-` for no labels, and the reader below
+    # uses a non-whitespace separator as well. Belt and braces, because the
+    # failure is silent and looks like data.
+    gh api "repos/$slug/issues" -X GET -f state=open -f per_page=100 --paginate --jq "$ISSUE_JQ"
+}
+
+# Epoch of an ISO-8601 Z timestamp. `date -j -f` parses in LOCAL time and
+# ignores the trailing Z, which inflated every age in am-ledger by the
+# operator's UTC offset (diskjockey#132) — hence -u here, and the GNU
+# fallback for a Linux runner.
+to_epoch() {
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null \
+        || date -u -d "$1" +%s 2>/dev/null \
+        || echo 0
+}
+
+wanted() {
+    [ ${#WANT[@]} -eq 0 ] && return 0
+    local w
+    for w in "${WANT[@]}"; do [ "$w" = "$1" ] && return 0; done
+    return 1
+}
+
+NOW="$(date -u +%s)"
+rows="$(mktemp)"; summary="$(mktemp)"; failed="$(mktemp)"
+trap 'rm -f "$rows" "$summary" "$failed"' EXIT
+
+for entry in "${PROJECTS[@]}"; do
+    name="${entry%%:*}"; slug="${entry#*:}"
+    wanted "$name" || continue
+    out="$(fetch_repo "$slug")"; rc=$?
+    if [ "$rc" -ne 0 ]; then
+        printf '%s\n' "$name" >> "$failed"
+        printf '%s\x1f%s\x1f%s\x1f%s\x1f%s\n' "$name" "FETCH FAILED" "-" "-" "-" >> "$summary"
+        continue
+    fi
+    count=0; oldest=0; stale=0
+    while IFS=$'\x1f' read -r num created labels title; do
+        [ -n "${num:-}" ] || continue
+        count=$((count + 1))
+        ts="$(to_epoch "$created")"
+        days=0
+        [ "$ts" -gt 0 ] && days=$(( (NOW - ts) / 86400 ))
+        [ "$days" -gt "$oldest" ] && oldest=$days
+        [ "$days" -ge "$STALE_DAYS" ] && stale=$((stale + 1))
+        printf '%s\x1f%s\x1f%s\x1f%s\x1f%s\n' "$name" "$num" "${days}d" "${labels:--}" "$title" >> "$rows"
+    done <<< "$out"
+    printf '%s\x1f%s\x1f%s\x1f%s\x1f%s\n' "$name" "$count" "${oldest}d" "$stale" "-" >> "$summary"
+done
+
+total="$(wc -l < "$rows" | tr -d ' ')"
+nfailed="$(wc -l < "$failed" | tr -d ' ')"
+
+# An empty table and a broken query look identical, so say which this is.
+if [ "$total" -eq 0 ] && [ "$nfailed" -eq 0 ]; then
+    if [ ${#WANT[@]} -gt 0 ]; then
+        echo "am-overview: no open issues in the named project(s)"
+    else
+        echo "am-overview: no open issues in any of the ${#PROJECTS[@]} projects"
+    fi
+    exit 0
+fi
+
+if [ "$MODE" = tsv ]; then
+    # The internal separator is US; TSV is what a caller asked for.
+    tr '\037' '\t' < "$rows"
+else
+    printf '%-18s %6s %7s %6s\n' PROJECT OPEN OLDEST "≥${STALE_DAYS}d"
+    while IFS=$'\x1f' read -r name count oldest stale _; do
+        if [ "$count" = "FETCH FAILED" ]; then
+            printf '%-18s %6s\n' "$name" "FETCH FAILED"
+        else
+            printf '%-18s %6s %7s %6s\n' "$name" "$count" "$oldest" "$stale"
+        fi
+    done < "$summary"
+    printf '%-18s %6s\n' TOTAL "$total"
+
+    if [ "$MODE" = full ] && [ "$total" -gt 0 ]; then
+        echo
+        printf '%-18s %6s %6s  %s\n' PROJECT ISSUE AGE TITLE
+        sort -t$'\x1f' -k1,1 -k2,2n "$rows" | while IFS=$'\x1f' read -r name num age labels title; do
+            printf '%-18s %6s %6s  %s\n' "$name" "#$num" "$age" "${title:0:88}"
+        done
+    fi
+fi
+
+if [ "$nfailed" -gt 0 ]; then
+    echo >&2
+    echo "am-overview: $nfailed project(s) could not be read:" >&2
+    sed 's/^/    /' "$failed" >&2
+    echo "am-overview: the counts above are incomplete BY THAT MUCH." >&2
+    exit 4
+fi
+exit 0

--- a/scripts/tests/am-overview.sh
+++ b/scripts/tests/am-overview.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# am-overview.sh — the overview table refuses rather than under-reports.
+#
+# Three of these checks pin defects that were live while the tool was
+# being written, and each of them produced a PLAUSIBLE TABLE rather than
+# an error:
+#
+#   - an unlabelled issue shifted every later field left, because TAB is
+#     IFS whitespace and `read` collapses a run of them, so titles
+#     appeared in the labels column and the title column was empty;
+#   - a second copy of the project list can drift from am-ledger's, which
+#     is diskjockey#128 in another file;
+#   - a timestamp parsed with `date -j -f` and no -u is read as local
+#     time, which is diskjockey#132.
+#
+# Nothing here touches the network: AM_OVERVIEW_FETCH replaces the gh
+# call and AM_OVERVIEW_LEDGER_BIN points at a fixture list.
+#
+#   bash scripts/tests/am-overview.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="$REPO/scripts/am-overview"
+fails=0
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+
+check() { # check <what> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "ok — $1"
+    else
+        echo "FAIL — $1: expected [$2] got [$3]" >&2
+        fails=$((fails + 1))
+    fi
+}
+contains() { # contains <what> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "ok — $1" ;;
+        *) echo "FAIL — $1: [$2] not in output" >&2; fails=$((fails + 1)) ;;
+    esac
+}
+
+# A ledger fixture whose list is, by construction, the one the tool carries:
+# generated from the tool itself, so "they agree" is not asserted by hand.
+mk_ledger() { # mk_ledger <path> [omit-name] [extra-entry]
+    local out="$1" omit="${2:-}" extra="${3:-}"
+    { echo 'DEFAULT_REPOS=('
+      sed -n '/^PROJECTS=(/,/^)/p' "$BIN" | sed -n 's/^[[:space:]]*"\(.*\)".*/    "\1"/p' \
+        | { [ -n "$omit" ] && grep -v "\"$omit:" || cat; }
+      [ -n "$extra" ] && echo "    \"$extra\""
+      echo ')'
+    } > "$out"
+}
+
+# A fetch stub. Each line of $sandbox/<slug-with-slashes-as-dashes>.rows is
+# emitted verbatim; a file named .fail makes the fetch exit non-zero.
+cat > "$sandbox/fetch" <<'STUB'
+#!/usr/bin/env bash
+slug="$1"
+key="$(printf '%s' "$slug" | tr '/' '-')"
+[ -f "$AM_OVERVIEW_FIXTURES/$key.fail" ] && exit 1
+[ -f "$AM_OVERVIEW_FIXTURES/$key.rows" ] && cat "$AM_OVERVIEW_FIXTURES/$key.rows"
+exit 0
+STUB
+chmod +x "$sandbox/fetch"
+export AM_OVERVIEW_FETCH="$sandbox/fetch"
+export AM_OVERVIEW_FIXTURES="$sandbox"
+
+row() { printf '%s\x1f%s\x1f%s\x1f%s\n' "$1" "$2" "$3" "$4"; }
+now_minus() { # seconds -> ISO-8601 Z
+    if date -u -r 0 +%s >/dev/null 2>&1; then
+        date -u -r "$(( $(date -u +%s) - $1 ))" +%Y-%m-%dT%H:%M:%SZ
+    else
+        date -u -d "@$(( $(date -u +%s) - $1 ))" +%Y-%m-%dT%H:%M:%SZ
+    fi
+}
+
+# ---------------------------------------------------------------- 1. agrees
+mk_ledger "$sandbox/ledger-ok"
+export AM_OVERVIEW_LEDGER_BIN="$sandbox/ledger-ok"
+row 12 "$(now_minus 3600)" - "one hour old"       > "$sandbox/antimatter-studios-agent-skills.rows"
+row 13 "$(now_minus 432000)" bug "five days old" >> "$sandbox/antimatter-studios-agent-skills.rows"
+out="$("$BIN" --project agent-skills 2>&1)"; rc=$?
+check "a matching list runs" 0 "$rc"
+contains "the count is the row count" "agent-skills            2" "$out"
+
+# ------------------------------------------------- 2. an hour is not a day
+# The whole point of parsing the timestamp as UTC: with `date -j -f` and no
+# -u this reads as local time, and an hour-old issue in CEST comes out at
+# -1 or 0 depending on sign. diskjockey#132 is the same defect in am-ledger.
+contains "an hour old is 0d" "   0d" "$out"
+contains "five days old is 5d" "   5d" "$out"
+
+# --------------------------------- 2b. and the offset is what makes it visible
+# THE INTEGER DAY IS WHY THE CHECK ABOVE CANNOT SEE THE DEFECT. Dropping -u
+# shifts every age by the operator's UTC offset, and a two-hour shift does not
+# move a 1-hour-old or a 5-day-old issue across a day boundary — measured: the
+# no-utc arm passed all of the checks above. So this one sits 1 hour BELOW a
+# boundary, with TZ pinned to a positive-offset zone: correct is 4d, and a
+# local-time parse reports 5d. Under TZ=UTC there is no difference at all,
+# which is exactly why diskjockey#132 was invisible in CI.
+row 14 "$(now_minus $(( 5 * 86400 - 3600 )))" - "just under five days" > "$sandbox/antimatter-studios-agent-skills.rows"
+out2="$(TZ=Europe/Berlin "$BIN" --project agent-skills --tsv)"
+check "an age just under a boundary stays below it" "4d" "$(printf '%s\n' "$out2" | awk -F'\t' '$2==14 {print $3}')"
+row 12 "$(now_minus 3600)" - "one hour old"       > "$sandbox/antimatter-studios-agent-skills.rows"
+row 13 "$(now_minus 432000)" bug "five days old" >> "$sandbox/antimatter-studios-agent-skills.rows"
+
+# ------------------------------------------ 3. an empty field shifts nothing
+contains "the title is in the title column" "one hour old" "$out"
+tsv="$("$BIN" --project agent-skills --tsv)"
+check "the labels column holds the label" "bug" "$(printf '%s\n' "$tsv" | awk -F'\t' '$2==13 {print $4}')"
+check "the title column holds the title" "five days old" "$(printf '%s\n' "$tsv" | awk -F'\t' '$2==13 {print $5}')"
+
+# ------------------------------------------------------------ 4. drift, ours
+mk_ledger "$sandbox/ledger-missing" agent-skills
+AM_OVERVIEW_LEDGER_BIN="$sandbox/ledger-missing" out="$("$BIN" --summary 2>&1)"; rc=$?
+check "a list the ledger lacks refuses" 3 "$rc"
+contains "and names the direction" "only in am-overview" "$out"
+contains "and names the project" "agent-skills" "$out"
+
+# ---------------------------------------------------------- 5. drift, theirs
+mk_ledger "$sandbox/ledger-extra" "" "rust-fs-zfs:antimatter-studios/rust-fs-zfs"
+AM_OVERVIEW_LEDGER_BIN="$sandbox/ledger-extra" out="$("$BIN" --summary 2>&1)"; rc=$?
+check "a project only the ledger has refuses" 3 "$rc"
+contains "and names that direction too" "only in am-ledger" "$out"
+
+# -------------------------------------------------- 6. unreadable is not ok
+: > "$sandbox/ledger-empty"
+AM_OVERVIEW_LEDGER_BIN="$sandbox/ledger-empty" out="$("$BIN" --summary 2>&1)"; rc=$?
+check "an unparseable ledger refuses" 3 "$rc"
+contains "rather than assuming agreement" "refusing to run" "$out"
+
+# ------------------------------------------------------- 7. a failed fetch
+export AM_OVERVIEW_LEDGER_BIN="$sandbox/ledger-ok"
+: > "$sandbox/antimatter-studios-rust-partitions.fail"
+out="$("$BIN" --project agent-skills --project rust-partitions 2>&1)"; rc=$?
+check "a failed fetch exits 4" 4 "$rc"
+contains "the row says so" "FETCH FAILED" "$out"
+contains "and the shortfall is stated" "incomplete BY THAT MUCH" "$out"
+contains "while the readable project still counts" "agent-skills            2" "$out"
+rm -f "$sandbox/antimatter-studios-rust-partitions.fail"
+
+# --------------------------------------------------------- 8. nothing found
+rm -f "$sandbox/antimatter-studios-agent-skills.rows"
+out="$("$BIN" --project agent-skills 2>&1)"; rc=$?
+check "no issues exits 0" 0 "$rc"
+contains "and says so in words" "no open issues" "$out"
+case "$out" in
+    *PROJECT*) echo "FAIL — an empty result printed a table header" >&2; fails=$((fails + 1)) ;;
+    *) echo "ok — an empty result is not an empty table" ;;
+esac
+
+# ------------------------------------------------- 9. the filter drops PRs
+# The endpoint returns pull requests as issues; without the filter every
+# count is wrong in the direction that looks busy.
+if command -v jq >/dev/null 2>&1; then
+    cat > "$sandbox/two.json" <<'JSON'
+[{"number":1,"created_at":"2026-09-01T00:00:00Z","labels":[],"title":"an issue"},
+ {"number":2,"created_at":"2026-09-01T00:00:00Z","labels":[],"title":"a pull request",
+  "pull_request":{"url":"https://example.invalid/pr/2"}}]
+JSON
+    got="$(jq -r "$("$BIN" --print-jq)" < "$sandbox/two.json" | wc -l | tr -d ' ')"
+    check "a pull request is not an issue" 1 "$got"
+    got="$(jq -r "$("$BIN" --print-jq)" < "$sandbox/two.json" | cut -d$'\x1f' -f4)"
+    check "and the issue is the one kept" "an issue" "$got"
+else
+    echo "ok — jq absent, filter check skipped (stated, not silent)"
+fi
+
+if [ "$fails" -eq 0 ]; then
+    echo "am-overview: all checks passed"
+else
+    echo "am-overview: $fails check(s) failed" >&2
+fi
+exit $(( fails > 0 ))


### PR DESCRIPTION
`chore overview` — the whole backlog, from your own machine.

```
PROJECT              OPEN  OLDEST ≥30d
rust-fs-core           18      3d      0
rust-fs-xfs            31      3d      0
rust-fs-ext4           62      3d      0
rust-fs-btrfs          42      3d      0
rust-fs-erofs          29      3d      0
rust-fs-squashfs       22      3d      0
rust-fs-ntfs           83      3d      0
rust-img-qcow2         20      3d      0
rust-img-vhd           15      3d      0
rust-img-vhdx          18      3d      0
rust-img-vmdk          24      3d      0
rust-partitions        32      3d      0
agent-skills            9      1d      0
diskjockey             37      3d      0
TOTAL                 442
```

Then one row per issue: project, number, age, title. `--tsv` for piping, `--project NAME` to narrow, `--summary` for counts alone. About twelve seconds for all fourteen.

**Tasks**: `chore overview`, `chore overview:summary`, `chore overview:tsv`, `chore check:scripts`. This is diskjockey's **first** `chores.yml` — it has neither `staticlib` nor `artifact`, because it orchestrates the twelve libraries rather than being one of them, and oversight is what it has instead.

**What it refuses to do**, each because the alternative is a plausible table rather than an error:

- **A failed fetch still gets a row**, marked `FETCH FAILED`, and the command exits **4** with the shortfall stated. A missing row reads as "no open issues" — the permissive-when-unanswerable family this repo has four filed members of.
- **The array is diffed against `am-ledger`'s `DEFAULT_REPOS`** and any disagreement refuses, naming both directions. A second copy of the project list that drifts is `#128` in another file — the reaper's list omits `agent-skills` while the ledger has it. An unparseable ledger refuses too, rather than reading as agreement.
- **"No open issues" is said in words**, because an empty table and a broken query look identical.

**Two defects found while writing it, both worth reading:**

1. **An unlabelled issue shifted every later field left.** TAB is IFS whitespace, so `read` collapses a run of them: titles appeared in the labels column and the title column was empty. A plausible table, not an error. Fixed with a non-whitespace separator *and* a jq that emits no empty field.
2. **The first version of the UTC check was unwitnessed.** The `no-utc` mutation arm passed **all 23 checks**, because dropping `-u` shifts ages by the operator's offset and two hours does not move a 1-hour-old or a 5-day-old issue across a day boundary. The check now sits one hour *below* a boundary with `TZ` pinned to a positive-offset zone — which is also precisely why `#132` is invisible in CI.

**Tests**: 24 checks in `scripts/tests/am-overview.sh`, no network (the gh call and the ledger are both injectable). Six mutation arms, each failing a named check: no `-u` (1), TAB delimiter (2), no drift check (6), silently skipping a failed fetch (2), a table on zero issues (1), no pull-request filter (2). The endpoint returns PRs as issues, so `--print-jq` exists to let the test drive that filter against a fixture rather than assert it appears in the source.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm