### PR TITLE
feat: a tag runs the tests and produces nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,21 @@ name: CI
 # `push` run and a `pull_request` run fired for the same commit and raced for
 # the limited macos-26 runner pool, leaving one of them cancelled.
 # No code signing — unit + library tests only.
+#
+# A `v*` TAG RUNS THE TESTS AND NOTHING ELSE. This repository ships a paid app
+# through the App Store, so it publishes no release artefacts: a tag is
+# metadata that records which commit a version was built from, and the only
+# thing it should produce is public evidence that the tree at that commit
+# passes. `release.yml` deliberately does NOT trigger on tags for the same
+# reason — see the note at its own `on:` block.
+#
+# The concurrency group below keys on `ref_name`, which for a tag is the tag
+# itself, so a tag run and a `main` run never cancel each other.
 
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,20 @@ name: Release
 #   The CI keychain password is generated in-pipeline (no secret). Uploads are
 #   gated by the repo variable MAS_SUBMIT (set =true to actually submit).
 
+# MANUAL ONLY, DELIBERATELY. This used to trigger on `push: tags: ['v*']`, and
+# that coupling is why the repository had no tags at all: marking which commit
+# a version shipped from and producing a signed, downloadable build were the
+# same action, so the only way to avoid the second was to never do the first.
+#
+# Two reasons it stays manual. The app is sold through the App Store, so a
+# release asset in a public repository is a free copy of a paid product. And a
+# tag push must not sign anything with the owner's Developer ID as a side
+# effect of recording provenance.
+#
+# So: tags are metadata, `ci.yml` runs the tests on them, and a release is an
+# explicit `workflow_dispatch` by someone who means it.
+
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
 
 concurrency:

--- a/scripts/tests/tags-are-tested-not-built.sh
+++ b/scripts/tests/tags-are-tested-not-built.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# tags-are-tested-not-built.sh — a tag runs the tests and produces nothing.
+#
+# This repository ships a paid app through the App Store, so it publishes no
+# release artefacts. That makes a tag pure metadata: it records which commit a
+# version was built from, and the evidence it should produce is a public test
+# run, not a signed download.
+#
+# The two halves are one decision and they are in different files, which is
+# exactly how a decision comes apart. Before this guard existed the coupling
+# ran the other way — `release.yml` triggered on `push: tags`, so marking a
+# version and signing a build with the owner's Developer ID were the same
+# action, and the repository consequently had NO TAGS AT ALL for three
+# releases. Nothing recorded which commit shipped as 1.0.1, 1.1.0 or 1.2.0
+# except two local, unpushed refs, one of which pointed at a commit whose own
+# project file declared a different version.
+#
+# So this asserts both halves, and it asserts them against the parsed YAML
+# rather than a grep: `on:` is the one key in a workflow that YAML reads as the
+# boolean `true`, so a text search for "tags" finds the comments as readily as
+# the trigger.
+#
+#   bash scripts/tests/tags-are-tested-not-built.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CI="$REPO/.github/workflows/ci.yml"
+RELEASE="$REPO/.github/workflows/release.yml"
+fails=0
+
+check() { # check <what> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "ok — $1"
+    else
+        echo "FAIL — $1: expected [$2] got [$3]" >&2
+        fails=$((fails + 1))
+    fi
+}
+
+# `on:` parses as the boolean true; ask for both spellings so this does not
+# depend on which YAML library reads it.
+trigger() { # trigger <file> <ruby expression over the `on` mapping>
+    ruby -ryaml -e '
+        d = YAML.load_file(ARGV[0])
+        on = d.key?(true) ? d[true] : d["on"]
+        abort "no on: block" if on.nil?
+        print(eval(ARGV[1]))
+    ' "$1" "$2" 2>/dev/null
+}
+
+command -v ruby >/dev/null 2>&1 || { echo "tags-are-tested-not-built: ruby absent, cannot parse the workflows" >&2; exit 1; }
+
+# ------------------------------------------------------------------ ci.yml
+check "ci.yml runs on a v* tag" \
+      "true" "$(trigger "$CI" '(on["push"]["tags"] || []).include?("v*")')"
+check "ci.yml still runs on main" \
+      "true" "$(trigger "$CI" '(on["push"]["branches"] || []).include?("main")')"
+check "ci.yml still runs on pull requests" \
+      "true" "$(trigger "$CI" 'on.key?("pull_request")')"
+
+# A tag run must not cancel a main run. The group keys on ref_name, which for a
+# tag is the tag itself; if someone keys it on `github.workflow` alone, pushing
+# a tag cancels whatever main is doing.
+check "the concurrency group separates a tag from a branch" \
+      "true" "$(ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); print d["concurrency"]["group"].include?("ref_name")' "$CI" 2>/dev/null)"
+
+# ------------------------------------------------------------- release.yml
+# The load-bearing assertion: no push trigger of any kind. Not "no tags" —
+# a branch push would sign a build just as readily.
+check "release.yml has no push trigger at all" \
+      "false" "$(trigger "$RELEASE" 'on.key?("push")')"
+check "release.yml is still manually dispatchable" \
+      "true" "$(trigger "$RELEASE" 'on.key?("workflow_dispatch")')"
+
+# And the reason, kept next to the assertion so a reader who disagrees knows
+# what they are overruling rather than assuming an oversight.
+check "release.yml says why it is manual only" \
+      "true" "$(grep -qc 'MANUAL ONLY, DELIBERATELY' "$RELEASE" >/dev/null && echo true || echo false)"
+
+if [ "$fails" -eq 0 ]; then
+    echo "tags-are-tested-not-built: all checks passed"
+else
+    echo "tags-are-tested-not-built: $fails check(s) failed" >&2
+fi
+exit $(( fails > 0 ))


### PR DESCRIPTION
**Merge this first.** Everything else rebases on top of it, so every other branch gets tested by the pipeline this establishes before it can merge.

Marking which commit a version shipped from and building a signed artefact were **the same action** — `release.yml` triggered on `push: tags: ['v*']` — so the only way to avoid the second was never to do the first. The repository therefore has **no tags at all** for three shipped releases:

| version | set by | tag |
|---|---|---|
| 1.0.1 | `cab66a8` `release: 1.0.1 — vendor refresh…` | local only |
| 1.1.0 | `e18511a` `feat: integrate EROFS + SQUASHFS…` | **none** |
| 1.2.0 | `e9fb77d` `feat: add Home landing page…; release 1.2.0 (build 4)` | local only, and pointing at `f51df8ea`, a `fix(ci)` commit that declares `MARKETING_VERSION = 1.0.1` |
| 1.3.0 | `7ad164e`, on the unmerged `chore/release-1.3.0` | **none** |

**Two edits, one decision:**

- **`ci.yml`** — `push` now includes `tags: ['v*']`, so a tag runs `Build & Test` and `Shell scripts`. The repository is public, so that run is citable evidence for the tree at that commit.
- **`release.yml`** — the `push` trigger is **gone entirely**; `workflow_dispatch` remains, so a release is an explicit act by someone who means it.

The app is sold through the App Store, so a release asset in a public repository would be a free copy of a paid product, and a tag must not sign anything with the owner's Developer ID as a side effect of recording provenance. Both reasons are written at `release.yml`'s own `on:` block, where the next person to wonder will be standing.

**The guard**: `scripts/tests/tags-are-tested-not-built.sh`, seven checks. It parses the YAML rather than grepping — `on:` is the one key a YAML reader returns as the boolean `true`, and a text search for "tags" finds the new comments as readily as the trigger. The load-bearing assertion is that `release.yml` has **no push trigger of any kind**, not merely no tag trigger: a branch push would sign a build just as readily. It also pins the concurrency group, which keys on `ref_name` so a tag run and a `main` run never cancel each other — checked rather than assumed.

**Five mutation arms, each failing exactly one named check**: removing the tag trigger; putting a tag trigger back on `release.yml`; giving `release.yml` a branch push instead; collapsing the concurrency group; and deleting the sentence that records the choice as deliberate.

One caveat that matters before the first tag is cited publicly: `Build & Test` on this repository is intermittently truncating — `#139` — and it hit four PRs today. Tag runs become public evidence, so that defect stops being an annoyance at that point.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm