### PR TITLE
fix: the job has a ceiling, and a truncated run stops passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,30 +244,28 @@ jobs:
         timeout-minutes: 25
         run: |
           set -o pipefail
-          # DiskJockeyTests IS SKIPPED BECAUSE IT CANNOT RUN HERE, AND
-          # SAYING SO IS THE POINT. It is app-hosted — TEST_HOST is
-          # DiskJockey.app — and this step builds with
-          # CODE_SIGNING_ALLOWED=NO, so the host has no entitlements and no
-          # app group. `xcodebuild` then hangs in "preparing to run tests"
-          # until it gives up: measured repeatedly on 2026-09-10 as
+          # THE APP-HOSTED SUITE STAYS IN, AND THE COUNT IS THE GUARD.
+          #
+          # An earlier version of this step skipped DiskJockeyTests, on the
+          # evidence that every FAILED run today reported only the seven
+          # library suites — 90 cases of 250 — with
           # `DiskJockey (NNNN) encountered an error (The test runner timed
-          # out while preparing to run tests.)` after 7-8 minutes, and on a
-          # bad day as a 61-minute run or a two-hour wedge.
+          # out while preparing to run tests.)`. That inference was wrong,
+          # and measuring the SUCCESSFUL runs is what showed it: nine of
+          # them executed 244-250 cases across 24 suites. The app-hosted
+          # target runs here routinely and passes; it intermittently fails
+          # to PREPARE, and when it does the run dies early having reported
+          # no failures at all.
           #
-          # Those runs were ALREADY library-only — 90 executed cases of the
-          # 250 a full local run reports — they simply took minutes to fail
-          # at it and then reported a truncated pass or an unexplained
-          # timeout. Skipping the target explicitly loses no coverage; it
-          # converts a coin flip into a green that means what it says, and
-          # leaves the gap on the record instead of in the logs.
-          #
-          # To put those 15 suites back, CI has to sign the host app.
+          # So skipping it would have discarded ~160 passing cases to avoid
+          # an intermittent stall. What catches the stall without losing the
+          # coverage is the floor below: a truncated run reports zero
+          # failures, so only a count can see it.
           xcodebuild test \
             -project DiskJockey.xcodeproj \
             -scheme DiskJockey \
             -destination 'platform=macOS,arch=arm64' \
             -skip-testing DiskJockeyUITests \
-            -skip-testing DiskJockeyTests \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             CODE_SIGNING_REQUIRED=NO \
@@ -281,12 +279,14 @@ jobs:
           # A truncated run reports no failures at all — it simply stops
           # early — so nothing that greps for a failure can see it. Count
           # what executed and refuse a run that quietly did less.
-          # 85 against 90 observed: a floor, not a target. Raise it when the
-          # library suite grows; a run below it is the defect, not a pass.
+          # 240 against 244-250 observed across nine successful runs today:
+          # a floor, not a target. A library-only truncation reports ~90 and
+          # fails here, which is the whole point — that shape used to pass.
+          # Raise it as the suite grows; a run below it is the defect.
           executed=$(grep -c 'Test Case .* passed\|✔' "$RUNNER_TEMP/test-output.log" 2>/dev/null || true)
-          echo "executed cases: ${executed:-0} (floor 85)"
-          if [ "${executed:-0}" -lt 85 ]; then
-              echo "::error::only ${executed:-0} test cases executed, floor is 85 — a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
+          echo "executed cases: ${executed:-0} (floor 240)"
+          if [ "${executed:-0}" -lt 240 ]; then
+              echo "::error::only ${executed:-0} test cases executed, floor is 240 — a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,14 +244,49 @@ jobs:
         timeout-minutes: 25
         run: |
           set -o pipefail
+          # DiskJockeyTests IS SKIPPED BECAUSE IT CANNOT RUN HERE, AND
+          # SAYING SO IS THE POINT. It is app-hosted — TEST_HOST is
+          # DiskJockey.app — and this step builds with
+          # CODE_SIGNING_ALLOWED=NO, so the host has no entitlements and no
+          # app group. `xcodebuild` then hangs in "preparing to run tests"
+          # until it gives up: measured repeatedly on 2026-09-10 as
+          # `DiskJockey (NNNN) encountered an error (The test runner timed
+          # out while preparing to run tests.)` after 7-8 minutes, and on a
+          # bad day as a 61-minute run or a two-hour wedge.
+          #
+          # Those runs were ALREADY library-only — 90 executed cases of the
+          # 250 a full local run reports — they simply took minutes to fail
+          # at it and then reported a truncated pass or an unexplained
+          # timeout. Skipping the target explicitly loses no coverage; it
+          # converts a coin flip into a green that means what it says, and
+          # leaves the gap on the record instead of in the logs.
+          #
+          # To put those 15 suites back, CI has to sign the host app.
           xcodebuild test \
             -project DiskJockey.xcodeproj \
             -scheme DiskJockey \
             -destination 'platform=macOS,arch=arm64' \
             -skip-testing DiskJockeyUITests \
+            -skip-testing DiskJockeyTests \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
+          | tee "$RUNNER_TEMP/test-output.log" \
           | xcbeautify --renderer github-actions
+          rc=${PIPESTATUS[0]}
+
+          # AND A FLOOR, because the failure this replaces was an ABSENCE.
+          # A truncated run reports no failures at all — it simply stops
+          # early — so nothing that greps for a failure can see it. Count
+          # what executed and refuse a run that quietly did less.
+          # 85 against 90 observed: a floor, not a target. Raise it when the
+          # library suite grows; a run below it is the defect, not a pass.
+          executed=$(grep -c 'Test Case .* passed\|✔' "$RUNNER_TEMP/test-output.log" 2>/dev/null || true)
+          echo "executed cases: ${executed:-0} (floor 85)"
+          if [ "${executed:-0}" -lt 85 ]; then
+              echo "::error::only ${executed:-0} test cases executed, floor is 85 — a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
+              exit 1
+          fi
+          exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
   scripts:
     name: Shell scripts
     runs-on: ubuntu-latest
+    # Seven seconds in practice. Five minutes is a hang, not a slow runner —
+    # and an unbounded ubuntu job is cheap enough to be forgotten for hours.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Semantics the Xcode job cannot reach
@@ -113,6 +116,20 @@ jobs:
     # macos-26 is the Apple Silicon runner for macOS 26.
     # Fall back to macos-15 if the runner isn't available in your plan yet.
     runs-on: macos-26
+    # THE STEP BOUND IS NOT A JOB BOUND, and this is what that costs.
+    # `Test` has carried timeout-minutes: 25 since #117, chosen because that
+    # step was the one observed hanging. On 2026-09-10 a post-merge run on
+    # main hung in **Set up Go** — step 8 of 25, long before Test — and ran
+    # for TWO HOURS before a person noticed and cancelled it, holding the
+    # only macos-26 runner in the pool while the pull requests waiting to
+    # merge got no runner at all.
+    #
+    # 40 rather than 25: the job is the sum of its steps, and the slowest
+    # good run measured so far is 16.8 minutes of Test plus the setup and
+    # cache steps around it. This is the ceiling that stops a hang billing
+    # macOS minutes for six hours; the per-step bound stays where it is,
+    # because a bound that fires tells you which step it was.
+    timeout-minutes: 40
 
     steps:
       - name: Checkout

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -144,24 +144,32 @@ for job in scripts; do
     fi
 done
 
-# ------------------------------------------- the suite that cannot run here
-# The app-hosted target is skipped because CODE_SIGNING_ALLOWED=NO leaves its
-# host app without entitlements, so `xcodebuild` hangs in "preparing to run
-# tests". Both halves are asserted: the skip, and the floor that stops the
-# remaining suites truncating silently — the failure being replaced reported
-# NO failures at all, so only a count can see it.
+# ------------------------------------------------- the count is the guard
+# The app-hosted target stays in the run: nine successful runs on 2026-09-10
+# executed 244-250 cases across 24 suites, so it works here and only
+# intermittently fails to prepare. What must not come back is the truncated
+# pass — a run that dies early reports ZERO failures, so only a count sees it.
 test_run="$(ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); s=d["jobs"]["test"]["steps"].find{|x| x["name"]=="Test"}; print s["run"]' "$WORKFLOW" 2>/dev/null)"
 case "$test_run" in
     *"-skip-testing DiskJockeyTests"*)
-        echo "ok    the app-hosted target is skipped, and the workflow says why" ;;
-    *)  echo "FAIL  DiskJockeyTests is not skipped: it is app-hosted, the host is built unsigned, and xcodebuild hangs in 'preparing to run tests'" >&2
+        echo "FAIL  DiskJockeyTests is skipped: it executes 244-250 cases here when the host prepares, so skipping it discards ~160 passing cases to dodge an intermittent stall" >&2
+        fails=$((fails + 1)) ;;
+    *)  echo "ok    the app-hosted target is still in the run" ;;
+esac
+# ASSERT THE COMPARISON, NOT THE COMMENT. The first version of this check
+# matched the string "floor is 240" — which survives replacing the whole
+# `if` with `if false`, so an arm that disarmed the floor passed it. The
+# comparison is the behaviour; the message is decoration.
+case "$test_run" in
+    *'"${executed:-0}" -lt 240'*)
+        echo "ok    the executed-case floor compares against 240" ;;
+    *)  echo "FAIL  no live comparison against a 240 floor: a truncated run reports ~90 cases and zero failures, which is the shape that used to pass" >&2
         fails=$((fails + 1)) ;;
 esac
 case "$test_run" in
-    *"floor is 85"*)
-        echo "ok    the executed-case floor is present" ;;
-    *)  echo "FAIL  no executed-case floor: a truncated run reports zero failures, so nothing that looks for a failure can see it" >&2
-        fails=$((fails + 1)) ;;
+    *"floor is 240"*) echo "ok    and it says so when it fires" ;;
+    *) echo "FAIL  the floor fires without naming itself, so a red run will not explain which defect it caught" >&2
+       fails=$((fails + 1)) ;;
 esac
 
 if [ "$fails" -eq 0 ]; then

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -144,6 +144,26 @@ for job in scripts; do
     fi
 done
 
+# ------------------------------------------- the suite that cannot run here
+# The app-hosted target is skipped because CODE_SIGNING_ALLOWED=NO leaves its
+# host app without entitlements, so `xcodebuild` hangs in "preparing to run
+# tests". Both halves are asserted: the skip, and the floor that stops the
+# remaining suites truncating silently — the failure being replaced reported
+# NO failures at all, so only a count can see it.
+test_run="$(ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); s=d["jobs"]["test"]["steps"].find{|x| x["name"]=="Test"}; print s["run"]' "$WORKFLOW" 2>/dev/null)"
+case "$test_run" in
+    *"-skip-testing DiskJockeyTests"*)
+        echo "ok    the app-hosted target is skipped, and the workflow says why" ;;
+    *)  echo "FAIL  DiskJockeyTests is not skipped: it is app-hosted, the host is built unsigned, and xcodebuild hangs in 'preparing to run tests'" >&2
+        fails=$((fails + 1)) ;;
+esac
+case "$test_run" in
+    *"floor is 85"*)
+        echo "ok    the executed-case floor is present" ;;
+    *)  echo "FAIL  no executed-case floor: a truncated run reports zero failures, so nothing that looks for a failure can see it" >&2
+        fails=$((fails + 1)) ;;
+esac
+
 if [ "$fails" -eq 0 ]; then
     echo "ci-long-steps-are-bounded: all checks passed"
 else

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -101,12 +101,48 @@ job_level="$(ruby -ryaml -e '
   doc = YAML.safe_load(File.read(ARGV[0]), aliases: true)
   print doc["jobs"]["test"]["timeout-minutes"].inspect
 ' "$REPO/.github/workflows/ci.yml" 2>/dev/null)"
+# THIS CHECK USED TO ASSERT THE OPPOSITE, and the reversal is deliberate.
+#
+# It read: the bound belongs on the step, not on the job, because the job also
+# runs `Build libraries` "whose cold cost is unmeasured, so a job bound cannot
+# be tight enough". The first half of that reasoning was right and the
+# conclusion did not follow: the alternative to a loose bound was not a step
+# bound, it was NO bound. On 2026-09-10 a post-merge run hung in `Set up Go` —
+# step 8 of 25, nowhere near the bounded step — and ran for TWO HOURS on the
+# only macos-26 runner in the pool, starving the pull requests queued behind
+# it, until a person cancelled it by hand.
+#
+# And the cold cost is no longer unmeasured. Eight successful `Build & Test`
+# jobs on 2026-09-10: 19m08s, 16m48s, 16m45s, 16m31s, 7m56s, 2m10s, 2m07s,
+# 1m50s. The slowest good job is **19m08s**, so the job ceiling has to clear
+# that with room and the floor below keeps a later reader from tightening it
+# into a flaky failure.
 if [ "$job_level" = "nil" ]; then
-    ok "the bound is on the step, not on the job"
+    fail "ci.yml's test job has no job-level timeout-minutes: a hang in any step \
+other than the bounded one runs to GitHub's 360-minute default, which is what \
+happened on 2026-09-10 in Set up Go"
+elif [ "$job_level" -lt 30 ] 2>/dev/null; then
+    fail "ci.yml's test job ceiling is ${job_level}m, under the 30m floor: the \
+slowest good job measured is 19m08s and a tight ceiling turns a slow runner into \
+a red build"
 else
-    fail "ci.yml's test job carries a job-level timeout-minutes ($job_level); it also runs \
-Build libraries, whose cold cost is unmeasured, so a job bound cannot be tight enough"
+    ok "the test job has a ceiling (${job_level}m) above the 19m08s slowest good run"
 fi
+
+# ---------------------------------------------------------------- job bounds
+# The ubuntu job needs one too, for the same reason and at a different scale:
+# seven seconds in practice, so five minutes is a hang rather than a slow
+# runner — and an unbounded ubuntu job is cheap enough to be forgotten for
+# hours, which is how the macOS one was.
+for job in scripts; do
+    got="$(ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); print(d["jobs"][ARGV[1]]["timeout-minutes"].to_i)' "$WORKFLOW" "$job" 2>/dev/null)"
+    if [ "${got:-0}" -gt 0 ] 2>/dev/null; then
+        echo "ok    the '$job' job has a ceiling of ${got} minutes"
+    else
+        echo "FAIL  the '$job' job has no timeout-minutes: a hang outside a bounded step runs for GitHub's default 360" >&2
+        fails=$((fails + 1))
+    fi
+done
 
 if [ "$fails" -eq 0 ]; then
     echo "ci-long-steps-are-bounded: all checks passed"


### PR DESCRIPTION
**This is why you read a timeout today.** A post-merge run on `main` (`34476431479`, head `d271db4d`) hung in **`Set up Go` — step 8 of 25**, nowhere near the bounded step, and ran for **two hours** on the only `macos-26` runner in the pool. It was still going when I cancelled it. Everything queued behind it — the PRs you want merged — was waiting for that runner.

`Test` has carried `timeout-minutes: 25` since #117, because that step was the one observed hanging. **A step bound is not a job bound.**

```
test     timeout-minutes: 40
scripts  timeout-minutes: 5
```

**40 is measured, not picked.** Eight successful `Build & Test` jobs today: **19m08s**, 16m48s, 16m45s, 16m31s, 7m56s, 2m10s, 2m07s, 1m50s. The slowest good job is 19m08s, so the ceiling clears it with room. The per-step bound stays where it is, because a bound that fires tells you *which step*.

**The guard asserted the opposite, and reversing it is the substantive part of this PR.** `scripts/tests/ci-long-steps-are-bounded.sh` contained:

> `ok "the bound is on the step, not on the job"` — else fail, because the job "also runs Build libraries, whose cold cost is unmeasured, so a job bound cannot be tight enough"

The first half of that was right and the conclusion did not follow: **the alternative to a loose bound was not a step bound, it was no bound at all** — GitHub's 360-minute default, at 10× macOS billing. The check now asserts the job *has* a ceiling **and** that the ceiling is at least 30 minutes, so the concern it was protecting — a tight bound turning a slow runner into a red build — is still enforced, by a floor instead of by absence. The reversal, the two-hour incident and the eight measurements are recorded where the old assertion stood, so the next reader sees a decision rather than a contradiction.

**Three arms, each failing exactly one named check**: removing the job bound, tightening it to 20 minutes, and removing the ubuntu job's bound.

Worth separating from `#139`: that one is the truncation defect — the suite reporting ~90 executed cases of 250 with zero failures. This is different and it is what let #139's deepest mode burn two hours instead of failing at a boundary. They interact but they are not the same row.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm