### PR TITLE
fix: isolate app-hosted tests and retain diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,27 @@ jobs:
           # an intermittent stall. What catches the stall without losing the
           # coverage is the floor below: a truncated run reports zero
           # failures, so only a count can see it.
+          #
+          # UNSIGNED, AND THE AD-HOC ALTERNATIVE WAS MEASURED WORSE.
+          #
+          # This branch first set CODE_SIGN_IDENTITY="-" with
+          # CODE_SIGNING_ALLOWED=YES, on the reasoning that an unsigned bundle
+          # cannot execute on Apple Silicon. What that actually changed is that
+          # ad-hoc signing APPLIES THE ENTITLEMENTS, and DiskJockey's include
+          # the App Sandbox. A sandboxed binary whose entitlements no profile
+          # authorises is refused at spawn, so the run went from intermittently
+          # failing to failing every time, in 5.053 seconds, on both bundles:
+          #
+          #   Could not launch "DiskJockeyTests"
+          #   Could not launch "DiskJockeyLibraryTests"
+          #   Runningboard has returned error 5
+          #     (Underlying Error: Launchd job spawn failed)
+          #
+          # CODE_SIGNING_ALLOWED=NO never applies entitlements at all, which is
+          # why this configuration launches at least some of the time. It is not
+          # a fix for #139 and is not claimed as one — the result bundle kept
+          # below is what this branch is for, and it is what produced the error
+          # quoted above.
           xcodebuild test \
             -project DiskJockey.xcodeproj \
             -scheme DiskJockey \
@@ -378,8 +399,8 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath "$RUNNER_TEMP/Test.xcresult" \
           | tee "$RUNNER_TEMP/test-output.log" \
           | xcbeautify --renderer github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,19 +410,42 @@ jobs:
           # A truncated run reports no failures at all — it simply stops
           # early — so nothing that greps for a failure can see it. Count
           # what executed and refuse a run that quietly did less.
-          # 240 against 244-250 observed across nine successful runs today:
-          # a floor, not a target. A library-only truncation reports ~90 and
-          # fails here, which is the whole point — that shape used to pass.
-          # Raise it as the suite grows; a run below it is the defect.
-          # ONE SPELLING. This counted 'Test Case .* passed\|✔', which matches
-          # both renderings of the same case: a complete run reported 273 where
-          # the distinct case count is 251. The floor still held, but the number
-          # it printed was not a case count, and the next person to size the
-          # floor would have sized it against a doubled figure.
-          executed=$(grep -c '✔' "$RUNNER_TEMP/test-output.log" 2>/dev/null || true)
-          echo "executed cases: ${executed:-0} (floor 240)"
+          #
+          # COUNTED FROM THE RESULT BUNDLE, NOT FROM THE OUTPUT, and two
+          # wrong answers in a row are why.
+          #
+          # It first counted `Test Case .* passed\|✔`, which matches BOTH
+          # renderings of the same case and reported 273 for a 250-case run.
+          # Sized against that doubled figure, the floor became 240.
+          # Then it counted `✔` alone — one spelling, and the wrong one:
+          # `✔` is swift-testing's, XCTest writes `Test Case '...' passed`,
+          # so on the raw stream that reads 222 for the same 250 cases and
+          # failed a run in which every single test passed.
+          #
+          # Both numbers were artefacts of a text format. The bundle this
+          # step already writes carries the count as data:
+          #
+          #   "passedTests": 250, "failedTests": 0, "result": "Passed"
+          #
+          # so ask it. No renderer in the path, nothing to double-count,
+          # and it reports the same number whether xcbeautify is in the
+          # pipeline or not. A missing or unreadable bundle yields 0, which
+          # the floor then refuses — the right answer when xcodebuild died
+          # before writing one.
+          summary=$(xcrun xcresulttool get test-results summary \
+                      --path "$RUNNER_TEMP/Test.xcresult" --format json 2>/dev/null || true)
+          executed=$(printf '%s' "$summary" | jq '(.passedTests//0)+(.failedTests//0)+(.expectedFailures//0)' 2>/dev/null || true)
+          verdict=$(printf '%s' "$summary" | jq -r '.result // "no result bundle"' 2>/dev/null || true)
+          echo "executed cases: ${executed:-0} (floor 240), bundle verdict: ${verdict:-unknown}"
           if [ "${executed:-0}" -lt 240 ]; then
-              echo "::error::only ${executed:-0} test cases executed, floor is 240 — a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
+              echo "::error::only ${executed:-0} test cases executed, floor is 240 — 250 ran on 2026-09-10, and a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
+              exit 1
+          fi
+          # THE BUNDLE'S OWN VERDICT, as a cross-check on the exit status.
+          # These have disagreed: the run measured above exited non-zero from
+          # the floor while the bundle said "Passed".
+          if [ "${verdict:-}" != "Passed" ]; then
+              echo "::error::the result bundle reports ${verdict:-unknown} rather than Passed"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,8 +378,9 @@ jobs:
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_ALLOWED=YES \
+            -resultBundlePath "$RUNNER_TEMP/Test.xcresult" \
           | tee "$RUNNER_TEMP/test-output.log" \
           | xcbeautify --renderer github-actions
           rc=${PIPESTATUS[0]}
@@ -392,10 +393,30 @@ jobs:
           # a floor, not a target. A library-only truncation reports ~90 and
           # fails here, which is the whole point — that shape used to pass.
           # Raise it as the suite grows; a run below it is the defect.
-          executed=$(grep -c 'Test Case .* passed\|✔' "$RUNNER_TEMP/test-output.log" 2>/dev/null || true)
+          # ONE SPELLING. This counted 'Test Case .* passed\|✔', which matches
+          # both renderings of the same case: a complete run reported 273 where
+          # the distinct case count is 251. The floor still held, but the number
+          # it printed was not a case count, and the next person to size the
+          # floor would have sized it against a doubled figure.
+          executed=$(grep -c '✔' "$RUNNER_TEMP/test-output.log" 2>/dev/null || true)
           echo "executed cases: ${executed:-0} (floor 240)"
           if [ "${executed:-0}" -lt 240 ]; then
               echo "::error::only ${executed:-0} test cases executed, floor is 240 — a run that stops early reports no failures, so this is the truncation defect (diskjockey#139) rather than a pass"
               exit 1
           fi
           exit "$rc"
+
+      # THE DIAGNOSTIC THIS DEFECT HAS BEEN MISSING. #139 has been diagnosed
+      # from beautified stdout all day, which is why nobody can say WHY the
+      # app-hosted bundle fails to launch: `xcodebuild` says only
+      # "The test runner timed out while preparing to run tests", and the
+      # .xcresult that holds the launch error was discarded at the end of every
+      # run. Keep it, and the next stall names its own cause.
+      - name: Keep the result bundle when the suite fails
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcresult-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/Test.xcresult
+          retention-days: 7
+          if-no-files-found: warn

--- a/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
+++ b/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
@@ -23,7 +23,12 @@ private final class LockBox<Value>: @unchecked Sendable {
     func set(_ v: Value) { lock.lock(); defer { lock.unlock() }; value = v }
 }
 
-@Suite("DetachedOperationWatchdog")
+// SERIALISED, because every test here asserts on a timer.
+// Run in parallel they starve each other, and the suite failed CI
+// twice on 2026-09-11 in BOTH directions: a monitor firing when it
+// should not have, then monitors not firing when they should
+// (`(fired.get() -> false) == true`, `reportedDeadline -> 0.0`).
+@Suite("DetachedOperationWatchdog", .serialized)
 struct DetachedOperationWatchdogTests {
 
     // ----- Counter arithmetic -----
@@ -55,13 +60,13 @@ struct DetachedOperationWatchdogTests {
 
     @Test func scheduleReturnsFalseAndNoFireWhenCounterIsZero() async throws {
         let fired = LockBox(false)
-        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.05) { _, _ in
+        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.4) { _, _ in
             fired.set(true)
         }
         let scheduled = w.scheduleExpiryIfNeeded()
         #expect(scheduled == false)
         // Wait long enough that, if it HAD scheduled, it would have fired.
-        try await Task.sleep(nanoseconds: 150_000_000)  // 0.15s
+        try await Task.sleep(nanoseconds: 1_200_000_000)  // 1.2s
         #expect(fired.get() == false)
     }
 
@@ -69,7 +74,7 @@ struct DetachedOperationWatchdogTests {
         let fired = LockBox(false)
         let reportedPending = LockBox(0)
         let reportedDeadline = LockBox(0.0)
-        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.05) { pending, deadline in
+        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.4) { pending, deadline in
             reportedPending.set(pending)
             reportedDeadline.set(deadline)
             fired.set(true)
@@ -78,15 +83,15 @@ struct DetachedOperationWatchdogTests {
         let scheduled = w.scheduleExpiryIfNeeded()
         #expect(scheduled == true)
         // Wait past the deadline.
-        try await Task.sleep(nanoseconds: 200_000_000)  // 0.2s
+        try await Task.sleep(nanoseconds: 1_600_000_000)  // 1.6s
         #expect(fired.get() == true)
         #expect(reportedPending.get() == 1)
-        #expect(reportedDeadline.get() == 0.05)
+        #expect(reportedDeadline.get() == 0.4)
     }
 
     @Test func scheduleDoesNotFireWhenCounterDropsToZeroBeforeDeadline() async throws {
         let fired = LockBox(false)
-        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.15) { _, _ in
+        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 1.2) { _, _ in
             fired.set(true)
         }
         w.enter()
@@ -94,7 +99,7 @@ struct DetachedOperationWatchdogTests {
         #expect(scheduled == true)
         // Op completes before deadline.
         w.leave()
-        try await Task.sleep(nanoseconds: 250_000_000)  // 0.25s, past the 0.15s deadline
+        try await Task.sleep(nanoseconds: 2_000_000_000)  // 2.0s, past the 1.2s deadline
         #expect(fired.get() == false)
     }
 
@@ -108,11 +113,11 @@ struct DetachedOperationWatchdogTests {
         w.enter()
         // Override the (long) default with a short one so we don't sit
         // around for 100s.
-        let scheduled = w.scheduleExpiryIfNeeded(deadline: 0.05)
+        let scheduled = w.scheduleExpiryIfNeeded(deadline: 0.4)
         #expect(scheduled == true)
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await Task.sleep(nanoseconds: 1_600_000_000)
         #expect(fired.get() == true)
-        #expect(reportedDeadline.get() == 0.05)
+        #expect(reportedDeadline.get() == 0.4)
     }
 
     @Test func multipleConcurrentSchedulesEachReChecksCounter() async throws {
@@ -120,14 +125,14 @@ struct DetachedOperationWatchdogTests {
         // Neither expiry should fire because both re-check the counter
         // at fire time.
         let fireCount = LockBox(0)
-        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.1) { _, _ in
+        let w = DetachedOperationWatchdog(label: "test", defaultDeadline: 0.8) { _, _ in
             fireCount.set(fireCount.get() + 1)
         }
         w.enter()
         w.scheduleExpiryIfNeeded()
         w.scheduleExpiryIfNeeded()  // second arm — still 1 pending
         w.leave()  // counter -> 0 before any expiry fires
-        try await Task.sleep(nanoseconds: 250_000_000)
+        try await Task.sleep(nanoseconds: 2_000_000_000)
         #expect(fireCount.get() == 0)
     }
 
@@ -142,7 +147,7 @@ struct DetachedOperationWatchdogTests {
         w.enter()
         // No heartbeats. With Fix D off, this should NOT fire even
         // though we sit silent indefinitely (within the test window).
-        try await Task.sleep(nanoseconds: 300_000_000)
+        try await Task.sleep(nanoseconds: 2_400_000_000)
         #expect(fired.get() == false)
     }
 
@@ -152,8 +157,8 @@ struct DetachedOperationWatchdogTests {
         let w = DetachedOperationWatchdog(
             label: "test",
             defaultDeadline: 100,
-            stuckDeadline: 0.1,
-            stuckCheckInterval: 0.03
+            stuckDeadline: 0.8,
+            stuckCheckInterval: 0.24
         ) { _, deadline in
             reportedDeadline.set(deadline)
             fired.set(true)
@@ -161,9 +166,9 @@ struct DetachedOperationWatchdogTests {
         w.enter()
         // No heartbeat() calls. After ~0.1s the stuck-progress monitor
         // should observe `now - lastHeartbeat > stuckDeadline` and fire.
-        try await Task.sleep(nanoseconds: 300_000_000)
+        try await Task.sleep(nanoseconds: 2_400_000_000)
         #expect(fired.get() == true)
-        #expect(reportedDeadline.get() == 0.1)
+        #expect(reportedDeadline.get() == 0.8)
     }
 
     @Test func stuckMonitorFiresOnceNotOncePerTick() async throws {
@@ -176,8 +181,8 @@ struct DetachedOperationWatchdogTests {
         let w = DetachedOperationWatchdog(
             label: "test",
             defaultDeadline: 100,
-            stuckDeadline: 0.05,
-            stuckCheckInterval: 0.02
+            stuckDeadline: 0.4,
+            stuckCheckInterval: 0.16
         ) { _, _ in
             fireCount.set(fireCount.get() + 1)
         }
@@ -185,7 +190,7 @@ struct DetachedOperationWatchdogTests {
         // 250 ms with 20 ms check interval = ~12 potential ticks past
         // the 50 ms deadline. Without one-shot cancellation we'd see
         // double-digit fires. With it, exactly 1.
-        try await Task.sleep(nanoseconds: 250_000_000)
+        try await Task.sleep(nanoseconds: 2_000_000_000)
         #expect(fireCount.get() == 1)
     }
 
@@ -194,16 +199,16 @@ struct DetachedOperationWatchdogTests {
         let w = DetachedOperationWatchdog(
             label: "test",
             defaultDeadline: 100,
-            stuckDeadline: 0.3,
-            stuckCheckInterval: 0.05
+            stuckDeadline: 2.4,
+            stuckCheckInterval: 0.4
         ) { _, _ in
             fireCount.set(fireCount.get() + 1)
         }
         w.enter()
         // TWO RATIOS, AND BOTH MATTER.
         //
-        // Beat every 30ms against a 300ms deadline, thirty times — so the
-        // run lasts ~900ms in total. The gap between beats is 10x the
+        // Beat every 240ms against a 2.4s deadline, thirty times — so the
+        // run lasts ~7.2s in total. The gap between beats is 10x the
         // deadline, which is what makes the assertion survive a loaded
         // machine; the total run is 3x the deadline, which is what gives it
         // teeth, because a build where `heartbeat()` stopped resetting the
@@ -218,7 +223,7 @@ struct DetachedOperationWatchdogTests {
         // failing the same way once before.
         for _ in 0..<30 {
             w.heartbeat()
-            try await Task.sleep(nanoseconds: 30_000_000)
+            try await Task.sleep(nanoseconds: 240_000_000)
         }
         #expect(fireCount.get() == 0)
     }
@@ -228,8 +233,8 @@ struct DetachedOperationWatchdogTests {
         let w = DetachedOperationWatchdog(
             label: "test",
             defaultDeadline: 100,
-            stuckDeadline: 0.05,
-            stuckCheckInterval: 0.02
+            stuckDeadline: 0.4,
+            stuckCheckInterval: 0.16
         ) { _, _ in
             fired.set(true)
         }
@@ -239,7 +244,7 @@ struct DetachedOperationWatchdogTests {
         // cancelled it would still tick and find pending==0, so
         // wouldn't fire — but more importantly: no timer should be
         // around to consume resources after `leave`.
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await Task.sleep(nanoseconds: 1_600_000_000)
         #expect(fired.get() == false)
     }
 }

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -155,6 +155,12 @@ done
 # intermittently fails to prepare. What must not come back is the truncated
 # pass — a run that dies early reports ZERO failures, so only a count sees it.
 test_run="$(ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); s=d["jobs"]["test"]["steps"].find{|x| x["name"]=="Test"}; print s["run"]' "$WORKFLOW" 2>/dev/null)"
+# THE COMMENTS ARE NOT THE COMMAND, and conflating them made this file fail on
+# its own explanation: the signing check below rejects CODE_SIGN_IDENTITY="-",
+# and the comment in ci.yml that records WHY quotes that string. Every
+# assertion about the shape of the command reads this instead — comment-only
+# lines dropped, everything else including the echoes kept verbatim.
+test_run="$(printf '%s\n' "$test_run" | grep -v '^[[:space:]]*#')"
 case "$test_run" in
     *"-skip-testing DiskJockeyTests"*)
         echo "FAIL  DiskJockeyTests is skipped: it executes 244-250 cases here when the host prepares, so skipping it discards ~160 passing cases to dodge an intermittent stall" >&2
@@ -194,14 +200,28 @@ else
     echo "FAIL  the result bundle is written and then discarded, which is the state that made #139 undiagnosable" >&2
     fails=$((fails + 1))
 fi
-# An unsigned bundle cannot execute on Apple Silicon, so the host app of an
-# app-hosted test target has to carry at least an ad-hoc signature.
+# THIS CHECK ASSERTED THE OPPOSITE FOR ONE COMMIT, and the reversal is what
+# measuring it produced. It read: an unsigned bundle cannot execute on Apple
+# Silicon, so the host app must carry at least an ad-hoc signature. That is
+# true of a bundle you double-click and false of this one. Ad-hoc signing
+# APPLIES THE ENTITLEMENTS, DiskJockey's include the App Sandbox, and a
+# sandboxed binary whose entitlements no profile authorises is refused at
+# spawn — so CODE_SIGN_IDENTITY="-" took the job from intermittently failing
+# to failing every time, in 5.053 seconds, on both bundles:
+#
+#   Could not launch "DiskJockeyTests" / "DiskJockeyLibraryTests"
+#   Runningboard has returned error 5 (Launchd job spawn failed)
+#
+# CODE_SIGNING_ALLOWED=NO never applies entitlements at all, which is why it
+# launches at least some of the time. Keep it, and keep the reason here so the
+# next person does not re-derive the same wrong inference from first
+# principles.
 case "$test_run" in
-    *'CODE_SIGNING_ALLOWED=NO'*)
-        echo "FAIL  CODE_SIGNING_ALLOWED=NO leaves the host app unsigned, and an unsigned bundle cannot launch on arm64" >&2
+    *'CODE_SIGN_IDENTITY="-"'*)
+        echo "FAIL  CODE_SIGN_IDENTITY=\"-\" ad-hoc signs the host app, which applies its App Sandbox entitlements; an unauthorised sandbox is refused at spawn with RunningBoard error 5, measured on every run" >&2
         fails=$((fails + 1)) ;;
-    *'CODE_SIGN_IDENTITY="-"'*) echo "ok    the host app is ad-hoc signed" ;;
-    *)  echo "FAIL  no ad-hoc signing identity for the host app" >&2
+    *'CODE_SIGNING_ALLOWED=NO'*) echo "ok    the host app is unsigned, so no entitlements are applied to be refused" ;;
+    *)  echo "FAIL  the test step neither disables signing nor explains what it signs with" >&2
         fails=$((fails + 1)) ;;
 esac
 

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -177,6 +177,34 @@ case "$test_run" in
        fails=$((fails + 1)) ;;
 esac
 
+# --------------------------------------- the launch failure must be capturable
+# #139 was diagnosed from beautified stdout for a whole day, which is why nobody
+# could say WHY the app-hosted bundle fails to launch: xcodebuild says only
+# "timed out while preparing to run tests", and the .xcresult holding the launch
+# error was thrown away at the end of every run. Both halves are asserted: the
+# bundle is written, and it is kept when the suite fails.
+case "$test_run" in
+    *"-resultBundlePath"*) echo "ok    the run writes a result bundle" ;;
+    *) echo "FAIL  no -resultBundlePath: the launch error stays invisible and #139 can only be guessed at" >&2
+       fails=$((fails + 1)) ;;
+esac
+if ruby -ryaml -e 'd=YAML.load_file(ARGV[0]); exit(d["jobs"]["test"]["steps"].any? { |s| s["if"].to_s.include?("failure") && s["uses"].to_s.include?("upload-artifact") } ? 0 : 1)' "$WORKFLOW" 2>/dev/null; then
+    echo "ok    and keeps it when the suite fails"
+else
+    echo "FAIL  the result bundle is written and then discarded, which is the state that made #139 undiagnosable" >&2
+    fails=$((fails + 1))
+fi
+# An unsigned bundle cannot execute on Apple Silicon, so the host app of an
+# app-hosted test target has to carry at least an ad-hoc signature.
+case "$test_run" in
+    *'CODE_SIGNING_ALLOWED=NO'*)
+        echo "FAIL  CODE_SIGNING_ALLOWED=NO leaves the host app unsigned, and an unsigned bundle cannot launch on arm64" >&2
+        fails=$((fails + 1)) ;;
+    *'CODE_SIGN_IDENTITY="-"'*) echo "ok    the host app is ad-hoc signed" ;;
+    *)  echo "FAIL  no ad-hoc signing identity for the host app" >&2
+        fails=$((fails + 1)) ;;
+esac
+
 if [ "$fails" -eq 0 ]; then
     echo "ci-long-steps-are-bounded: all checks passed"
 else

--- a/scripts/tests/ci-long-steps-are-bounded.sh
+++ b/scripts/tests/ci-long-steps-are-bounded.sh
@@ -171,15 +171,63 @@ esac
 # matched the string "floor is 240" — which survives replacing the whole
 # `if` with `if false`, so an arm that disarmed the floor passed it. The
 # comparison is the behaviour; the message is decoration.
+#
+# THE FLOOR IS READ OUT OF THE COMMAND rather than restated here, because two
+# copies of a number that moves with the suite are two things to forget.
+floor="$(printf '%s' "$test_run" | grep -oE '\-lt [0-9]+' | head -1 | awk '{print $2}')"
+if [ -n "$floor" ]; then
+    echo "ok    the executed-case floor is a live comparison, against $floor"
+else
+    echo "FAIL  no live comparison against a case floor: a truncated run reports far fewer cases and zero failures, which is the shape that used to pass" >&2
+    fails=$((fails + 1))
+fi
+if [ -n "$floor" ]; then
+    case "$test_run" in
+        *"floor is $floor"*) echo "ok    and the message it prints names $floor too" ;;
+        *) echo "FAIL  the floor compares against $floor but does not say so when it fires, so a red run will not explain which defect it caught" >&2
+           fails=$((fails + 1)) ;;
+    esac
+fi
+if [ -n "$floor" ] && [ "$floor" -ge 200 ] 2>/dev/null; then
+    echo "ok    and it is at or above 200, so a library-only truncation cannot clear it"
+else
+    echo "FAIL  the floor is ${floor:-unset}: the library half alone reports over a hundred cases, so a floor beneath that passes the truncation it exists to catch" >&2
+    fails=$((fails + 1))
+fi
+
+# ------------------------------------ AND THE COUNT COMES FROM THE BUNDLE
+# Two text-derived counts were wrong in a row, in opposite directions, and
+# both of them were artefacts of a rendering rather than of the run:
+#
+#   `Test Case .* passed\|✔`  matched both renderings of one case and
+#                             reported 273 for a 250-case run, which is the
+#                             figure the 240 floor was sized against.
+#   `✔` alone                 is swift-testing's spelling only; XCTest
+#                             writes `Test Case '...' passed`, so the raw
+#                             stream read 222 for the same 250 cases and
+#                             failed a run in which every test passed.
+#
+# The result bundle carries the number as data. Requiring it means the floor
+# is comparing a case count rather than a line count, which is the whole
+# reason the floor exists.
 case "$test_run" in
-    *'"${executed:-0}" -lt 240'*)
-        echo "ok    the executed-case floor compares against 240" ;;
-    *)  echo "FAIL  no live comparison against a 240 floor: a truncated run reports ~90 cases and zero failures, which is the shape that used to pass" >&2
-        fails=$((fails + 1)) ;;
+    *"xcresulttool"*) echo "ok    the case count is read from the result bundle" ;;
+    *) echo "FAIL  the case count is not read from the result bundle; every text-derived count so far has been an artefact of the renderer rather than the run" >&2
+       fails=$((fails + 1)) ;;
 esac
 case "$test_run" in
-    *"floor is 240"*) echo "ok    and it says so when it fires" ;;
-    *) echo "FAIL  the floor fires without naming itself, so a red run will not explain which defect it caught" >&2
+    *"grep -c"*'test-output.log'*)
+        echo "FAIL  the case count greps test-output.log again: that is the measurement that reported 273 and then 222 for the same 250 cases" >&2
+        fails=$((fails + 1)) ;;
+    *) echo "ok    and not by grepping the log" ;;
+esac
+# AND THE BUNDLE'S VERDICT IS CHECKED, not just its count. These have
+# disagreed: the 2026-09-10 run exited non-zero from the floor while the
+# bundle said "Passed". A count alone cannot catch the converse — a bundle
+# that says Failed on a run xcodebuild exited 0 from.
+case "$test_run" in
+    *'!= "Passed"'*) echo "ok    and the bundle's own verdict is compared against Passed" ;;
+    *) echo "FAIL  the bundle's verdict is read but never compared: a run whose bundle says Failed while xcodebuild exits 0 would pass" >&2
        fails=$((fails + 1)) ;;
 esac
 


### PR DESCRIPTION
Closes #139.

## Outcome

Retains the real app-hosted DiskJockey tests while avoiding a second redundant app/harness lifecycle for DiskJockeyLibraryTests. The complete library suite remains a required, host-free `swift test` job. Failed Xcode runs retain their `.xcresult`, and watchdog timing tests are serialized and scaled for shared CI runners.

## Evidence so far

- The original retained bundle exposed the actual RunningBoard launch refusal caused by ad-hoc signing; that signing experiment was reverted.
- Run 34949058950 disproved Xcode parallelization as the cause: both targets passed every test, then the library test host stalled while confirming harness shutdown until the 25-minute ceiling.
- The new regression was red before `-only-testing:DiskJockeyTests`: `Xcode still launches the redundant app-hosted library bundle`.
- The same regression is green after the workflow change.
- All seven shell regression scripts pass with an owned worktree TMPDIR.

## Current bounded experiment

The first app-only CI run deliberately retains the previous 240-case result-bundle floor. It should therefore fail after a successful app-only run and print the measured count. That count will set the permanent floor; it is not being guessed. The fix will not merge until repeated app-only runs complete cleanly and all required checks pass.

## Safety

The app-hosted DiskJockeyTests target is not skipped. Result-bundle case count and verdict remain required, and the failed-run artifact is uploaded for diagnosis.