### PR TITLE
test: expand library coverage from 90 cases to 160

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,15 +204,15 @@ jobs:
           # for the bundle, so take the largest) and swift-testing says
           # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90, then
           # 51 + 65 = 116 with the mount personalities covered, then
-          # 51 + 78 = 129 with the operation lock. The floor moves up with
-          # the suite; it never moves down.
+          # 51 + 78 = 129 with the operation lock, then 51 + 109 = 160 with
+          # AppLog. The floor moves up with the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 120)"
-          if [ "$total" -lt 120 ]; then
-              echo "::error::only $total library cases executed, floor is 120 — 129 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 150)"
+          if [ "$total" -lt 150 ]; then
+              echo "::error::only $total library cases executed, floor is 150 — 160 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,14 +202,16 @@ jobs:
           # Both test frameworks are in this target and each prints its own
           # total: XCTest says "Executed N tests" (once per suite plus once
           # for the bundle, so take the largest) and swift-testing says
-          # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90.
+          # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90, then
+          # 51 + 65 = 116 once the mount personalities got covered. The floor
+          # moves up with the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 85)"
-          if [ "$total" -lt 85 ]; then
-              echo "::error::only $total library cases executed, floor is 85 — 90 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 110)"
+          if [ "$total" -lt 110 ]; then
+              echo "::error::only $total library cases executed, floor is 110 — 116 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,15 +203,16 @@ jobs:
           # total: XCTest says "Executed N tests" (once per suite plus once
           # for the bundle, so take the largest) and swift-testing says
           # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90, then
-          # 51 + 65 = 116 once the mount personalities got covered. The floor
-          # moves up with the suite; it never moves down.
+          # 51 + 65 = 116 with the mount personalities covered, then
+          # 51 + 78 = 129 with the operation lock. The floor moves up with
+          # the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 110)"
-          if [ "$total" -lt 110 ]; then
-              echo "::error::only $total library cases executed, floor is 110 — 116 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 120)"
+          if [ "$total" -lt 120 ]; then
+              echo "::error::only $total library cases executed, floor is 120 — 129 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,14 +205,15 @@ jobs:
           # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90, then
           # 51 + 65 = 116 with the mount personalities covered, then
           # 51 + 78 = 129 with the operation lock, then 51 + 109 = 160 with
-          # AppLog. The floor moves up with the suite; it never moves down.
+          # AppLog, then 51 + 132 = 183 with the I/O counters. The floor
+          # moves up with the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 150)"
-          if [ "$total" -lt 150 ]; then
-              echo "::error::only $total library cases executed, floor is 150 — 160 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 170)"
+          if [ "$total" -lt 170 ]; then
+              echo "::error::only $total library cases executed, floor is 170 — 183 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,15 +205,16 @@ jobs:
           # "Test run with N tests". Measured 2026-09-10: 51 + 39 = 90, then
           # 51 + 65 = 116 with the mount personalities covered, then
           # 51 + 78 = 129 with the operation lock, then 51 + 109 = 160 with
-          # AppLog, then 51 + 132 = 183 with the I/O counters. The floor
-          # moves up with the suite; it never moves down.
+          # AppLog, then 51 + 132 = 183 with the I/O counters, then
+          # 51 + 153 = 204 with the two plist stores. The floor moves up
+          # with the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 170)"
-          if [ "$total" -lt 170 ]; then
-              echo "::error::only $total library cases executed, floor is 170 — 183 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 190)"
+          if [ "$total" -lt 190 ]; then
+              echo "::error::only $total library cases executed, floor is 190 — 204 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/DiskJockeyLibrary/AppLog.swift
+++ b/DiskJockeyLibrary/AppLog.swift
@@ -267,12 +267,33 @@ public final class NDJSONFileSink: AppLogSink {
     private let handle: FileHandle?
     private let queue: DispatchQueue
 
-    public init(source: String) {
+    /// - Parameters:
+    ///   - source: names the file, one per emitting process.
+    ///   - directory: where to write. Defaults to the shared container's
+    ///     `Logs/`, which is what every real call site wants and none of
+    ///     them pass.
+    ///
+    ///     IT EXISTS FOR THE TESTS, and the alternative was worse. The
+    ///     default resolves through
+    ///     `containerURL(forSecurityApplicationGroupIdentifier:)`, which
+    ///     returns a real path even to a process that holds no app-group
+    ///     entitlement — so a test could not steer this by arranging for
+    ///     the container to be absent, and testing the wire format meant
+    ///     either writing into the developer's own container or
+    ///     duplicating this path logic in the test. A duplicated path is
+    ///     the same defect shape as a duplicated implementation: it passes
+    ///     while the real one is wrong.
+    public init(source: String, directory: URL? = nil) {
         self.queue = DispatchQueue(label: "com.antimatterstudios.diskjockey.applog.file.\(source)")
         let fm = FileManager.default
-        let base = fm.containerURL(forSecurityApplicationGroupIdentifier: AppLog.groupIdentifier)
-            ?? fm.temporaryDirectory
-        let dir = base.appendingPathComponent(AppLog.logDirName, isDirectory: true)
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else {
+            let base = fm.containerURL(forSecurityApplicationGroupIdentifier: AppLog.groupIdentifier)
+                ?? fm.temporaryDirectory
+            dir = base.appendingPathComponent(AppLog.logDirName, isDirectory: true)
+        }
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
         self.fileURL = dir.appendingPathComponent("\(source).ndjson")
         if !fm.fileExists(atPath: fileURL.path) {

--- a/DiskJockeyLibrary/NetworkFS/MountConfigStore.swift
+++ b/DiskJockeyLibrary/NetworkFS/MountConfigStore.swift
@@ -30,19 +30,40 @@ public struct MountConfigStore: Sendable {
     public static let groupIdentifier = "group.com.antimatterstudios.diskjockey"
     private static let subdirName = "MountConfigs"
 
-    public init() {}
+    private let directory: URL?
+
+    /// - Parameter directory: where the plists live. Defaults to the shared
+    ///   app-group container's `MountConfigs/`, which is what every real call
+    ///   site wants and none of them pass.
+    ///
+    ///   IT EXISTS FOR THE TESTS. The default resolves through
+    ///   `containerURL(forSecurityApplicationGroupIdentifier:)`, which
+    ///   returns a real path even to a process holding no app-group
+    ///   entitlement, so a test cannot steer this by arranging for the
+    ///   container to be absent — it would write into the developer's own
+    ///   container instead. The alternative was to duplicate this path
+    ///   logic in the test, which is the same defect shape as duplicating
+    ///   an implementation: it passes while the real one is wrong.
+    public init(directory: URL? = nil) {
+        self.directory = directory
+    }
 
     /// The parent directory every stored config lives under. Created
     /// on demand. Intentionally a method, not a stored property, so
     /// permission changes mid-session are picked up.
     private func configsDir() throws -> URL {
         let fm = FileManager.default
-        guard let base = fm.containerURL(
-            forSecurityApplicationGroupIdentifier: Self.groupIdentifier
-        ) else {
-            throw MountConfigStoreError.groupContainerUnavailable
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else {
+            guard let base = fm.containerURL(
+                forSecurityApplicationGroupIdentifier: Self.groupIdentifier
+            ) else {
+                throw MountConfigStoreError.groupContainerUnavailable
+            }
+            dir = base.appendingPathComponent(Self.subdirName, isDirectory: true)
         }
-        let dir = base.appendingPathComponent(Self.subdirName, isDirectory: true)
         if !fm.fileExists(atPath: dir.path) {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true)
         }

--- a/DiskJockeyLibrary/NetworkFS/MountPolicy.swift
+++ b/DiskJockeyLibrary/NetworkFS/MountPolicy.swift
@@ -79,16 +79,37 @@ public struct MountPolicyStore: Sendable {
     public static let groupIdentifier = "group.com.antimatterstudios.diskjockey"
     private static let subdirName = "MountPolicies"
 
-    public init() {}
+    private let directory: URL?
+
+    /// - Parameter directory: where the plists live. Defaults to the shared
+    ///   app-group container's `MountPolicies/`, which is what every real call
+    ///   site wants and none of them pass.
+    ///
+    ///   IT EXISTS FOR THE TESTS. The default resolves through
+    ///   `containerURL(forSecurityApplicationGroupIdentifier:)`, which
+    ///   returns a real path even to a process holding no app-group
+    ///   entitlement, so a test cannot steer this by arranging for the
+    ///   container to be absent — it would write into the developer's own
+    ///   container instead. The alternative was to duplicate this path
+    ///   logic in the test, which is the same defect shape as duplicating
+    ///   an implementation: it passes while the real one is wrong.
+    public init(directory: URL? = nil) {
+        self.directory = directory
+    }
 
     private func policiesDir() throws -> URL {
         let fm = FileManager.default
-        guard let base = fm.containerURL(
-            forSecurityApplicationGroupIdentifier: Self.groupIdentifier
-        ) else {
-            throw MountPolicyStoreError.groupContainerUnavailable
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else {
+            guard let base = fm.containerURL(
+                forSecurityApplicationGroupIdentifier: Self.groupIdentifier
+            ) else {
+                throw MountPolicyStoreError.groupContainerUnavailable
+            }
+            dir = base.appendingPathComponent(Self.subdirName, isDirectory: true)
         }
-        let dir = base.appendingPathComponent(Self.subdirName, isDirectory: true)
         if !fm.fileExists(atPath: dir.path) {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true)
         }

--- a/DiskJockeyLibraryTests/AppLogTests.swift
+++ b/DiskJockeyLibraryTests/AppLogTests.swift
@@ -1,0 +1,464 @@
+//
+//  AppLogTests.swift — the logging surface, its wire format, and the two
+//  places consumers outside Swift depend on it.
+//
+//  WHY THIS FILE EXISTS
+//  --------------------
+//  AppLog is the largest untested file in the library, and most of it is a
+//  FORMAT rather than a behaviour — which is the kind of thing that breaks
+//  quietly. Three consumers read what this produces:
+//
+//    * the host app's LogTailService / LogRepository, which tails the
+//      NDJSON file and routes on `kind`, `fields` and `scope`;
+//    * the UI's scope toggles, which enumerate `AppLogScope.all`;
+//    * "backends outside Swift (Rust, Go)", which the header says "can
+//      produce the same NDJSON wire format with plain file I/O".
+//
+//  None of those are compiled against this type. A renamed key, a changed
+//  level spelling, or a scope missing from `all` is a silent break in
+//  another process or another language.
+//
+//  HOW IT IS TESTED WITHOUT A CONTAINER. `AppLogSink` is a public protocol,
+//  so the tests below plug in a capturing sink and read what was emitted.
+//  `formatEvent` is `private static` and cannot be called directly at all;
+//  it is exercised through `event(kind:fields:)`, which is the only way any
+//  caller reaches it either.
+//
+//  NDJSONFileSink IS tested for real, in a temporary directory of the
+//  test's own. Its `directory:` parameter exists for that: the default
+//  resolves through `containerURL(forSecurityApplicationGroupIdentifier:)`,
+//  which returns a real path even to a process holding no app-group
+//  entitlement — measured, `~/Library/Group Containers/...` — so a test
+//  cannot steer it by arranging for the container to be missing. The
+//  choices were to write into the developer's own container, to duplicate
+//  the sink's path logic here (the same defect shape as duplicating an
+//  implementation: it passes while the real one is wrong), or to let the
+//  caller say where. The parameter is defaulted, so no production call
+//  site changed.
+//
+//  NOT TESTED HERE, DELIBERATELY: StderrSink (capturing fd 2 is fragile
+//  enough to be worse than the coverage) and OSLogSink (its output goes to
+//  the unified log, which is not readable back without entitlements).
+//
+
+import Foundation
+import Testing
+@testable import DiskJockeyLibrary
+
+// MARK: - A sink that remembers
+
+/// Collects every line it is handed. `AppLog` snapshots its sink array under
+/// a lock and then emits outside it, so this has to be safe to call from
+/// several threads at once.
+private final class CapturingSink: AppLogSink, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [AppLogLine] = []
+
+    var lines: [AppLogLine] {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+
+    var last: AppLogLine? { lines.last }
+
+    func emit(_ line: AppLogLine) {
+        lock.lock(); defer { lock.unlock() }
+        storage.append(line)
+    }
+}
+
+private func makeLog(source: String = "test") -> (AppLog, CapturingSink) {
+    let sink = CapturingSink()
+    return (AppLog(source: source, sinks: [sink]), sink)
+}
+
+// MARK: - The wire format
+
+@Suite("the NDJSON wire format")
+struct AppLogLineFormatTests {
+
+    /// UPPERCASE, AND ON THE WIRE. `level` is stored as the raw string, so
+    /// these spellings are what a Rust or Go emitter has to produce and what
+    /// LogRepository matches on.
+    @Test func levelsAreTheUppercaseSpellings() {
+        #expect(AppLogLevel.debug.rawValue == "DEBUG")
+        #expect(AppLogLevel.info.rawValue == "INFO")
+        #expect(AppLogLevel.warn.rawValue == "WARN")
+        #expect(AppLogLevel.error.rawValue == "ERROR")
+        #expect(AppLogLevel(rawValue: "WARN") == .warn)
+        #expect(AppLogLevel(rawValue: "warn") == nil,
+                "levels are case-sensitive on the wire; a lowercase one must not decode")
+    }
+
+    /// The timestamp shape is part of the format: internet date time with
+    /// fractional seconds. A consumer parsing it with a stricter formatter
+    /// breaks if the fraction disappears.
+    @Test func theTimestampCarriesFractionalSeconds() throws {
+        let line = AppLogLine(level: .info, source: "s", message: "m")
+        let pattern = #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$"#
+        #expect(line.ts.range(of: pattern, options: .regularExpression) != nil,
+                "timestamp \(line.ts) is not internet-date-time with fractional seconds")
+    }
+
+    @Test func theLineCarriesTheEmittingProcess() {
+        let line = AppLogLine(level: .info, source: "s", message: "m")
+        #expect(line.pid == ProcessInfo.processInfo.processIdentifier)
+    }
+
+    @Test func aLineRoundTripsThroughJSON() throws {
+        let line = AppLogLine(level: .warn, source: "ext4", message: "hello",
+                              kind: "fsck.progress",
+                              fields: ["bsd": "disk4s1", "done": "3", "total": "9"],
+                              scope: AppLogScope.fsck)
+        let back = try JSONDecoder().decode(AppLogLine.self,
+                                            from: try JSONEncoder().encode(line))
+        #expect(back.ts == line.ts)
+        #expect(back.level == "WARN")
+        #expect(back.source == "ext4")
+        #expect(back.message == "hello")
+        #expect(back.kind == "fsck.progress")
+        #expect(back.fields == line.fields)
+        #expect(back.scope == "fsck")
+        #expect(back.pid == line.pid)
+    }
+
+    /// THE OPTIONAL KEYS ARE ABSENT, NOT NULL, when unset. Consumers in
+    /// other languages have to handle one or the other, and which one is
+    /// decided here.
+    @Test func unsetOptionalsAreOmittedRatherThanEncodedAsNull() throws {
+        let plain = AppLogLine(level: .info, source: "s", message: "m")
+        let json = try #require(String(data: try JSONEncoder().encode(plain), encoding: .utf8))
+        for key in ["kind", "fields", "scope"] {
+            #expect(!json.contains("\"\(key)\""),
+                    "\(key) is present in a plain line's JSON: \(json)")
+        }
+        // And the mandatory ones are there.
+        for key in ["ts", "level", "source", "message", "pid"] {
+            #expect(json.contains("\"\(key)\""), "\(key) is missing: \(json)")
+        }
+    }
+
+    @Test func aLineDecodesFromJSONWithoutTheOptionalKeys() throws {
+        let wire = #"{"ts":"2026-09-10T12:00:00.000Z","level":"INFO","source":"go","message":"m","pid":42}"#
+        let line = try JSONDecoder().decode(AppLogLine.self, from: Data(wire.utf8))
+        #expect(line.kind == nil)
+        #expect(line.fields == nil)
+        #expect(line.scope == nil)
+        #expect(line.pid == 42, "a line produced by a non-Swift emitter must decode")
+    }
+}
+
+// MARK: - Scopes
+
+@Suite("AppLogScope")
+struct AppLogScopeTests {
+
+    /// `all` DRIVES THE UI, so a scope missing from it is a scope the user
+    /// cannot toggle — and the constants and the list are maintained by
+    /// hand, separately.
+    @Test func everyScopeConstantIsInTheDisplayList() {
+        // Spelled out rather than leading-dot: these are `static let`
+        // Strings on a namespace enum, not enum cases, so `.probe` would
+        // resolve against String and not compile.
+        let constants: [String] = [AppLogScope.lifecycle, AppLogScope.probe,
+                                   AppLogScope.fsck, AppLogScope.volume,
+                                   AppLogScope.enumerate, AppLogScope.io,
+                                   AppLogScope.stats]
+        for scope in constants {
+            #expect(AppLogScope.all.contains(scope),
+                    "\(scope) is a canonical scope but is not in AppLogScope.all, so no panel can toggle it")
+        }
+        #expect(AppLogScope.all.count == constants.count,
+                "AppLogScope.all has \(AppLogScope.all.count) entries against \(constants.count) constants")
+    }
+
+    @Test func theScopeStringsAreTheDocumentedOnes() {
+        #expect(AppLogScope.all == ["lifecycle", "probe", "fsck", "volume",
+                                    "enumerate", "io", "stats"])
+    }
+
+    @Test func noScopeIsListedTwice() {
+        #expect(Set(AppLogScope.all).count == AppLogScope.all.count)
+    }
+}
+
+// MARK: - Emitting
+
+@Suite("AppLog emit")
+struct AppLogEmitTests {
+
+    @Test("each level helper emits its own level",
+          arguments: [("debug", "DEBUG"), ("info", "INFO"), ("warn", "WARN"), ("error", "ERROR")])
+    func levelHelpers(name: String, expected: String) throws {
+        let (log, sink) = makeLog()
+        switch name {
+        case "debug": log.debug("m")
+        case "info":  log.info("m")
+        case "warn":  log.warn("m")
+        default:      log.error("m")
+        }
+        let line = try #require(sink.last)
+        #expect(line.level == expected)
+        #expect(line.message == "m")
+        #expect(line.kind == nil, "a plain message is not a structured event")
+    }
+
+    @Test func theSourceIsStampedOnEveryLine() throws {
+        let (log, sink) = makeLog(source: "fileprovider")
+        log.info("one")
+        log.warn("two")
+        #expect(sink.lines.count == 2)
+        #expect(sink.lines.allSatisfy { $0.source == "fileprovider" })
+    }
+
+    /// "One call site, N sinks" is the file's opening claim.
+    @Test func everySinkReceivesEveryLine() {
+        let a = CapturingSink(), b = CapturingSink(), c = CapturingSink()
+        let log = AppLog(source: "s", sinks: [a, b, c])
+        log.info("m")
+        #expect(a.lines.count == 1)
+        #expect(b.lines.count == 1)
+        #expect(c.lines.count == 1)
+    }
+
+    @Test func configureSwapsTheSinkList() {
+        let before = CapturingSink(), after = CapturingSink()
+        let log = AppLog(source: "s", sinks: [before])
+        log.info("first")
+        log.configure([after])
+        log.info("second")
+        #expect(before.lines.map(\.message) == ["first"],
+                "a replaced sink must stop receiving")
+        #expect(after.lines.map(\.message) == ["second"])
+    }
+
+    @Test func configuringNoSinksDropsLinesWithoutFailing() {
+        let (log, sink) = makeLog()
+        log.configure([])
+        log.info("into the void")
+        #expect(sink.lines.isEmpty)
+    }
+
+    /// AppLog snapshots its sinks under a lock and emits outside it, so
+    /// concurrent callers must not lose lines.
+    @Test func concurrentEmitsAllArrive() async {
+        let (log, sink) = makeLog()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<200 {
+                group.addTask { log.info("m\(i)") }
+            }
+        }
+        #expect(sink.lines.count == 200)
+        #expect(Set(sink.lines.map(\.message)).count == 200, "lines were lost or duplicated")
+    }
+}
+
+// MARK: - Structured events
+
+@Suite("structured events")
+struct AppLogEventTests {
+
+    /// THE DERIVED MESSAGE IS SORTED, which is what makes it reproducible:
+    /// dictionary order is not defined, so an unsorted rendering would
+    /// produce a different human-readable line every run.
+    @Test func theDerivedMessageIsKindThenFieldsInKeyOrder() throws {
+        let (log, sink) = makeLog()
+        log.event(kind: "fsck.progress", fields: ["total": "9", "bsd": "disk4s1", "done": "3"])
+        let line = try #require(sink.last)
+        #expect(line.message == "fsck.progress bsd=disk4s1 done=3 total=9")
+    }
+
+    @Test func repeatedRenderingsOfTheSameFieldsAreIdentical() {
+        let (log, sink) = makeLog()
+        let fields = ["z": "1", "a": "2", "m": "3", "b": "4", "y": "5"]
+        for _ in 0..<12 { log.event(kind: "k", fields: fields) }
+        #expect(Set(sink.lines.map(\.message)).count == 1,
+                "the derived message is not stable across emits: \(Set(sink.lines.map(\.message)))")
+    }
+
+    @Test func anEventWithNoFieldsIsJustItsKind() throws {
+        let (log, sink) = makeLog()
+        log.event(kind: "fsck.start")
+        let line = try #require(sink.last)
+        #expect(line.message == "fsck.start")
+        #expect(line.fields == [:])
+    }
+
+    @Test func anExplicitMessageWinsButTheStructureSurvives() throws {
+        let (log, sink) = makeLog()
+        log.event(kind: "volume.dirty", fields: ["bsd": "disk4s1"],
+                  message: "the journal needs replaying")
+        let line = try #require(sink.last)
+        #expect(line.message == "the journal needs replaying")
+        #expect(line.kind == "volume.dirty", "an overridden message must not drop the kind")
+        #expect(line.fields == ["bsd": "disk4s1"])
+    }
+
+    @Test func anEventIsInfoUnlessToldOtherwise() throws {
+        let (log, sink) = makeLog()
+        log.event(kind: "k")
+        #expect(try #require(sink.last).level == "INFO")
+        log.event(kind: "k", level: .error)
+        #expect(try #require(sink.last).level == "ERROR")
+    }
+
+    @Test func theScopeIsCarriedThrough() throws {
+        let (log, sink) = makeLog()
+        log.event(kind: "k", scope: AppLogScope.io)
+        #expect(try #require(sink.last).scope == "io")
+        log.info("plain", scope: AppLogScope.lifecycle)
+        #expect(try #require(sink.last).scope == "lifecycle")
+    }
+}
+
+// MARK: - TaggedLogger
+
+@Suite("TaggedLogger")
+struct TaggedLoggerTests {
+
+    /// The whole point: consumers can route on `fields["mount"]` without
+    /// every call site remembering to pass it.
+    @Test func itsFieldsAreAttachedToEveryLine() throws {
+        let (log, sink) = makeLog()
+        let tagged = TaggedLogger(log, fields: ["mount": "UUID-1"], kind: "fileprovider.mount")
+        tagged.info("fetchContents")
+        tagged.warn("slow")
+        tagged.error("failed")
+        tagged.debug("detail")
+        #expect(sink.lines.count == 4)
+        #expect(sink.lines.allSatisfy { $0.fields == ["mount": "UUID-1"] })
+        #expect(sink.lines.allSatisfy { $0.kind == "fileprovider.mount" })
+        #expect(sink.lines.map(\.level) == ["INFO", "WARN", "ERROR", "DEBUG"])
+    }
+
+    @Test func extraFieldsMergeOverTheDefaults() throws {
+        let (log, sink) = makeLog()
+        let tagged = TaggedLogger(log, fields: ["mount": "UUID-1", "bsd": "disk4"], kind: "k")
+        tagged.event(fields: ["phase": "scan", "bsd": "disk9"])
+        let line = try #require(sink.last)
+        #expect(line.fields == ["mount": "UUID-1", "bsd": "disk9", "phase": "scan"],
+                "a per-call field must win over the logger's default of the same name")
+    }
+
+    @Test func theKindCanBeOverriddenPerEvent() throws {
+        let (log, sink) = makeLog()
+        let tagged = TaggedLogger(log, fields: [:], kind: "fsck")
+        tagged.event(kind: "fsck.progress")
+        #expect(try #require(sink.last).kind == "fsck.progress")
+        tagged.info("back to the default")
+        #expect(try #require(sink.last).kind == "fsck")
+    }
+
+    @Test func theDefaultScopeAppliesAndAPerCallScopeOverridesIt() throws {
+        let (log, sink) = makeLog()
+        let tagged = TaggedLogger(log, fields: [:], kind: "k", scope: AppLogScope.fsck)
+        tagged.info("uses the default")
+        #expect(try #require(sink.last).scope == "fsck")
+        tagged.info("overridden", scope: AppLogScope.io)
+        #expect(try #require(sink.last).scope == "io")
+        tagged.event(kind: "k2")
+        #expect(try #require(sink.last).scope == "fsck",
+                "an event with no scope must fall back to the logger's default")
+    }
+
+    @Test func aLoggerWithNoScopeLeavesLinesUntagged() throws {
+        let (log, sink) = makeLog()
+        TaggedLogger(log, fields: [:], kind: "k").info("m")
+        #expect(try #require(sink.last).scope == nil,
+                "an untagged line is visible in every panel; that is what nil means here")
+    }
+}
+
+// MARK: - The file sink
+
+@Suite("NDJSONFileSink")
+struct NDJSONFileSinkTests {
+
+    /// A directory this test owns, removed when it finishes.
+    private func scratch() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("applog-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func records(in dir: URL, source: String) throws -> [AppLogLine] {
+        let url = dir.appendingPathComponent("\(source).ndjson")
+        let text = try #require(try? String(contentsOf: url, encoding: .utf8),
+                                "no log file at \(url.path)")
+        #expect(text.hasSuffix("\n"), "the last record must be newline-terminated too")
+        return try text.split(separator: "\n", omittingEmptySubsequences: true)
+            .map { try JSONDecoder().decode(AppLogLine.self, from: Data($0.utf8)) }
+    }
+
+    /// One JSON object per line, newline-terminated, appended. This is the
+    /// format LogTailService reads and the one a Rust or Go emitter has to
+    /// match, so it is asserted on the bytes rather than on the API.
+    @Test func itWritesOneNewlineTerminatedJSONObjectPerLine() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let log = AppLog(source: "one", sinks: [NDJSONFileSink(source: "one", directory: dir)])
+        log.info("first")
+        log.event(kind: "fsck.progress", fields: ["done": "1"], scope: AppLogScope.fsck)
+        log.error("third")
+
+        let decoded = try records(in: dir, source: "one")
+        #expect(decoded.count == 3, "expected three records, got \(decoded.count)")
+        #expect(decoded.map(\.message) == ["first", "fsck.progress done=1", "third"],
+                "records are out of order or malformed")
+        #expect(decoded[1].kind == "fsck.progress")
+        #expect(decoded[1].scope == "fsck")
+        #expect(decoded[0].kind == nil)
+        #expect(decoded.allSatisfy { $0.source == "one" })
+    }
+
+    /// A second sink on the same file appends rather than truncating —
+    /// which is what has to happen when FSKit respawns an extension per
+    /// resource operation, as the sink's own comment describes.
+    @Test func aReopenedSinkAppendsRatherThanTruncating() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        AppLog(source: "re", sinks: [NDJSONFileSink(source: "re", directory: dir)]).info("before")
+        AppLog(source: "re", sinks: [NDJSONFileSink(source: "re", directory: dir)]).info("after")
+        #expect(try records(in: dir, source: "re").map(\.message) == ["before", "after"],
+                "a respawned process truncated the log instead of appending")
+    }
+
+    /// Messages containing newlines would break NDJSON if written raw. JSON
+    /// encoding escapes them, and that is worth pinning: one record must
+    /// stay one line, or every consumer's line-splitting reader desyncs.
+    @Test func aMessageContainingNewlinesStaysOneRecord() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let log = AppLog(source: "nl", sinks: [NDJSONFileSink(source: "nl", directory: dir)])
+        log.error("line one\nline two\nline three")
+        let decoded = try records(in: dir, source: "nl")
+        #expect(decoded.count == 1, "a multi-line message became \(decoded.count) NDJSON records")
+        #expect(decoded[0].message == "line one\nline two\nline three")
+    }
+
+    /// The directory is created if it does not exist, which is what happens
+    /// on a first launch into a fresh container.
+    @Test func itCreatesADirectoryThatIsNotThereYet() throws {
+        let parent = try scratch()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let nested = parent.appendingPathComponent("does/not/exist/yet", isDirectory: true)
+        AppLog(source: "fresh", sinks: [NDJSONFileSink(source: "fresh", directory: nested)]).info("m")
+        #expect(try records(in: nested, source: "fresh").map(\.message) == ["m"])
+    }
+
+    /// And concurrent emits do not interleave inside a record. The sink
+    /// serialises on its own queue; without that, two writes could split
+    /// each other's bytes and no line would parse.
+    @Test func concurrentEmitsProduceWholeRecords() async throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let log = AppLog(source: "race", sinks: [NDJSONFileSink(source: "race", directory: dir)])
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<120 { group.addTask { log.info("message number \(i)") } }
+        }
+        let decoded = try records(in: dir, source: "race")
+        #expect(decoded.count == 120, "\(decoded.count) records survived of 120")
+        #expect(Set(decoded.map(\.message)).count == 120, "records were lost or duplicated")
+    }
+}

--- a/DiskJockeyLibraryTests/IOStatsRecorderTests.swift
+++ b/DiskJockeyLibraryTests/IOStatsRecorderTests.swift
@@ -1,0 +1,390 @@
+//
+//  IOStatsRecorderTests.swift — the per-mount I/O counters, their wire
+//  format, and the four near-identical recorders.
+//
+//  WHY THIS FILE EXISTS
+//  --------------------
+//  This type exists BECAUSE of a copy-paste problem: its own header says it
+//  "replaces three near-identical per-extension copies". What it kept is
+//  four near-identical methods — recordRead, recordWrite, recordBdevRead,
+//  recordBdevWrite — each incrementing a different triple of fields out of
+//  sixteen, with an error branch that must increment the error counter and
+//  NOTHING else. That shape is only correct by inspection, and nothing
+//  inspected it.
+//
+//  The consequence of getting one wrong is a wrong number in the UI, which
+//  is the least alarming way for a defect to present: no crash, no error,
+//  just a sparkline that lies. So the tests below assert per-field that a
+//  recorder touches exactly the three counters it owns and leaves the other
+//  thirteen alone.
+//
+//  `asFields()` is a wire format read by the host-side `IOCounters(fields:)`
+//  decoder, which is not compiled against this file. The key names and the
+//  field count are pinned for that reason.
+//
+//  Host-free: no mount, no block device, no extension.
+//
+
+import Foundation
+import Testing
+@testable import DiskJockeyLibrary
+
+// MARK: - Helpers
+
+/// Collects the dictionaries handed to a recorder's emitter. The emitter is
+/// called from the recorder's own dispatch queue, so this locks.
+private final class EmitCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [[String: String]] = []
+
+    var emissions: [[String: String]] {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+    var count: Int { emissions.count }
+    var last: [String: String]? { emissions.last }
+
+    func take(_ fields: [String: String]) {
+        lock.lock(); defer { lock.unlock() }
+        storage.append(fields)
+    }
+}
+
+/// The sixteen wire keys, spelled out here so a rename in either place is a
+/// failure rather than a silent divergence from the host-side decoder.
+private let wireKeys: Set<String> = [
+    "bytes_read", "bytes_written", "ops_read", "ops_written",
+    "errors_read", "errors_written", "read_latency_ns", "write_latency_ns",
+    "bdev_bytes_read", "bdev_bytes_written", "bdev_ops_read", "bdev_ops_written",
+    "bdev_read_latency_ns", "bdev_write_latency_ns",
+    "bdev_errors_read", "bdev_errors_written",
+]
+
+/// Every wire key whose value is not "0", i.e. what a recorder actually
+/// touched. Comparing these sets is what catches a recorder incrementing a
+/// counter belonging to another.
+private func nonZeroKeys(_ counters: IOStatsCounters) -> Set<String> {
+    Set(counters.asFields().filter { $0.value != "0" }.map(\.key))
+}
+
+// MARK: - The wire format
+
+@Suite("IOStatsCounters.asFields")
+struct IOStatsWireFormatTests {
+
+    @Test func itCarriesExactlySixteenNamedFields() {
+        let fields = IOStatsCounters().asFields()
+        #expect(Set(fields.keys) == wireKeys,
+                "wire keys drifted: extra \(Set(fields.keys).subtracting(wireKeys)), missing \(wireKeys.subtracting(Set(fields.keys)))")
+        #expect(fields.count == 16)
+    }
+
+    @Test func freshCountersRenderAsZeroesRatherThanAbsences() {
+        let fields = IOStatsCounters().asFields()
+        #expect(fields.values.allSatisfy { $0 == "0" })
+        #expect(fields.count == 16,
+                "an idle mount still emits every field; the host decoder is one path for FSKit and FileProvider alike")
+    }
+
+    /// Values are decimal strings, because the whole log wire format is
+    /// map<string,string> and the host coerces back.
+    @Test func valuesAreDecimalStringsTheHostCanCoerce() {
+        var c = IOStatsCounters()
+        c.bytesRead = 1
+        c.bdevWriteLatencyNs = UInt64.max
+        let fields = c.asFields()
+        #expect(fields["bytes_read"] == "1")
+        #expect(fields["bdev_write_latency_ns"] == "18446744073709551615")
+        for (key, value) in fields {
+            #expect(UInt64(value) != nil, "\(key) = \(value) does not parse as UInt64")
+        }
+    }
+
+    /// Each of the sixteen struct fields must reach its own wire key. Set one
+    /// at a time and check that exactly one key is non-zero.
+    @Test func everyStructFieldMapsToItsOwnKey() {
+        let cases: [(String, (inout IOStatsCounters) -> Void)] = [
+            ("bytes_read",            { $0.bytesRead = 7 }),
+            ("bytes_written",         { $0.bytesWritten = 7 }),
+            ("ops_read",              { $0.opsRead = 7 }),
+            ("ops_written",           { $0.opsWritten = 7 }),
+            ("errors_read",           { $0.errorsRead = 7 }),
+            ("errors_written",        { $0.errorsWritten = 7 }),
+            ("read_latency_ns",       { $0.readLatencyNs = 7 }),
+            ("write_latency_ns",      { $0.writeLatencyNs = 7 }),
+            ("bdev_bytes_read",       { $0.bdevBytesRead = 7 }),
+            ("bdev_bytes_written",    { $0.bdevBytesWritten = 7 }),
+            ("bdev_ops_read",         { $0.bdevOpsRead = 7 }),
+            ("bdev_ops_written",      { $0.bdevOpsWritten = 7 }),
+            ("bdev_read_latency_ns",  { $0.bdevReadLatencyNs = 7 }),
+            ("bdev_write_latency_ns", { $0.bdevWriteLatencyNs = 7 }),
+            ("bdev_errors_read",      { $0.bdevErrorsRead = 7 }),
+            ("bdev_errors_written",   { $0.bdevErrorsWritten = 7 }),
+        ]
+        #expect(cases.count == 16, "one case per wire key")
+        for (key, mutate) in cases {
+            var c = IOStatsCounters()
+            mutate(&c)
+            #expect(nonZeroKeys(c) == [key],
+                    "setting the field behind \(key) produced \(nonZeroKeys(c))")
+        }
+    }
+
+    @Test func countersCompareByValue() {
+        var a = IOStatsCounters(), b = IOStatsCounters()
+        #expect(a == b, "Equatable is what the duplicate-emit suppression keys on")
+        a.opsRead = 1
+        #expect(a != b)
+        b.opsRead = 1
+        #expect(a == b)
+    }
+}
+
+// MARK: - The hot-path recorders
+
+@Suite("hot-path recorders")
+struct IOStatsRecorderHotPathTests {
+
+    /// Drive one recorder method, then force a flush and return what the
+    /// emitter was handed.
+    private func fieldsAfter(_ body: (IOStatsRecorder) -> Void) -> [String: String] {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "test") { collector.take($0) }
+        body(recorder)
+        recorder.stop()          // forces a final flush
+        return collector.last ?? [:]
+    }
+
+    private func nonZero(_ fields: [String: String]) -> Set<String> {
+        Set(fields.filter { $0.value != "0" }.map(\.key))
+    }
+
+    /// EACH RECORDER OWNS EXACTLY THREE COUNTERS. This is the check the four
+    /// near-identical methods needed: a bdev recorder that incremented a
+    /// logical counter would show up as a plausible number in the wrong
+    /// half of the UI, with nothing else to notice it.
+    @Test func aSuccessfulReadTouchesOnlyItsOwnThreeCounters() {
+        let fields = fieldsAfter { $0.recordRead(bytes: 4096, latencyNs: 500, error: false) }
+        #expect(nonZero(fields) == ["bytes_read", "ops_read", "read_latency_ns"])
+        #expect(fields["bytes_read"] == "4096")
+        #expect(fields["ops_read"] == "1")
+        #expect(fields["read_latency_ns"] == "500")
+    }
+
+    @Test func aSuccessfulWriteTouchesOnlyItsOwnThreeCounters() {
+        let fields = fieldsAfter { $0.recordWrite(bytes: 512, latencyNs: 90, error: false) }
+        #expect(nonZero(fields) == ["bytes_written", "ops_written", "write_latency_ns"])
+        #expect(fields["bytes_written"] == "512")
+        #expect(fields["ops_written"] == "1")
+        #expect(fields["write_latency_ns"] == "90")
+    }
+
+    @Test func aSuccessfulBlockDeviceReadStaysOnTheBdevSide() {
+        let fields = fieldsAfter { $0.recordBdevRead(bytes: 8192, latencyNs: 12, error: false) }
+        #expect(nonZero(fields) == ["bdev_bytes_read", "bdev_ops_read", "bdev_read_latency_ns"],
+                "a block-device read must not move the logical counters")
+    }
+
+    @Test func aSuccessfulBlockDeviceWriteStaysOnTheBdevSide() {
+        let fields = fieldsAfter { $0.recordBdevWrite(bytes: 8192, latencyNs: 12, error: false) }
+        #expect(nonZero(fields) == ["bdev_bytes_written", "bdev_ops_written", "bdev_write_latency_ns"])
+    }
+
+    /// AN ERRORED OPERATION MOVED NO BYTES. It increments the error counter
+    /// and nothing else — not the op count, not the byte count, and not the
+    /// latency total, which would otherwise pull the average latency towards
+    /// however long the failure took.
+    @Test("an error increments only its error counter",
+          arguments: [("errors_read",         0),
+                      ("errors_written",      1),
+                      ("bdev_errors_read",    2),
+                      ("bdev_errors_written", 3)])
+    func errorsCountAlone(key: String, which: Int) {
+        let fields = fieldsAfter { r in
+            switch which {
+            case 0: r.recordRead(bytes: 4096, latencyNs: 999, error: true)
+            case 1: r.recordWrite(bytes: 4096, latencyNs: 999, error: true)
+            case 2: r.recordBdevRead(bytes: 4096, latencyNs: 999, error: true)
+            default: r.recordBdevWrite(bytes: 4096, latencyNs: 999, error: true)
+            }
+        }
+        #expect(nonZero(fields) == [key],
+                "an errored operation moved bytes or latency: \(nonZero(fields))")
+        #expect(fields[key] == "1")
+    }
+
+    /// `max(0, bytes)` is a guard, and this is what it guards against: a
+    /// negative count from a driver would otherwise convert into an enormous
+    /// UInt64 and the byte total would jump by exabytes.
+    @Test func aNegativeByteCountContributesNothingRatherThanWrapping() {
+        let fields = fieldsAfter { $0.recordRead(bytes: -1, latencyNs: 5, error: false) }
+        #expect(fields["bytes_read"] == "0", "a negative byte count wrapped into the total")
+        #expect(fields["ops_read"] == "1", "the operation still happened, so it still counts")
+        #expect(fields["read_latency_ns"] == "5")
+    }
+
+    /// `&+=` is a wrapping add, deliberately: a trap on overflow would crash
+    /// a filesystem extension on a long-lived busy mount. Three adds of
+    /// Int.max exceed UInt64.max, so this reaches the wrap.
+    @Test func theTotalsWrapRatherThanTrapping() {
+        let fields = fieldsAfter { r in
+            for _ in 0..<3 { r.recordRead(bytes: Int.max, latencyNs: 0, error: false) }
+        }
+        let total = UInt64(fields["bytes_read"] ?? "x")
+        #expect(total != nil, "bytes_read stopped being a number")
+        // 3 * Int.max mod 2^64
+        let expected = UInt64(Int.max) &* 3
+        #expect(total == expected, "wrapping arithmetic changed: got \(total as UInt64?), expected \(expected)")
+        #expect(fields["ops_read"] == "3")
+    }
+
+    @Test func repeatedOperationsAccumulate() {
+        let fields = fieldsAfter { r in
+            for _ in 0..<10 { r.recordRead(bytes: 100, latencyNs: 7, error: false) }
+            for _ in 0..<3  { r.recordRead(bytes: 0, latencyNs: 0, error: true) }
+        }
+        #expect(fields["bytes_read"] == "1000")
+        #expect(fields["ops_read"] == "10")
+        #expect(fields["read_latency_ns"] == "70")
+        #expect(fields["errors_read"] == "3")
+    }
+
+    /// The counters sit behind an unfair lock and the recorders are on the
+    /// hot path, called from whatever thread FSKit hands them.
+    @Test func concurrentRecordingLosesNothing() async {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "race") { collector.take($0) }
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<200 {
+                group.addTask { recorder.recordRead(bytes: 10, latencyNs: 1, error: false) }
+                group.addTask { recorder.recordBdevWrite(bytes: 3, latencyNs: 2, error: false) }
+            }
+        }
+        recorder.stop()
+        let fields = collector.last ?? [:]
+        #expect(fields["ops_read"] == "200")
+        #expect(fields["bytes_read"] == "2000")
+        #expect(fields["read_latency_ns"] == "200")
+        #expect(fields["bdev_ops_written"] == "200")
+        #expect(fields["bdev_bytes_written"] == "600")
+    }
+}
+
+// MARK: - Flushing
+
+@Suite("flush behaviour")
+struct IOStatsFlushTests {
+
+    /// "On stop we force a final flush so the host sees the closing tally."
+    /// Including from a recorder that was never started and never touched —
+    /// the closing zero tally is still a message the host needs.
+    @Test func stopAlwaysFlushesEvenWithNothingToSay() {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "stop") { collector.take($0) }
+        recorder.stop()
+        #expect(collector.count == 1)
+        #expect(collector.last?.values.allSatisfy { $0 == "0" } == true)
+    }
+
+    @Test func stopFlushesTheFinalTally() {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "tally") { collector.take($0) }
+        recorder.recordWrite(bytes: 77, latencyNs: 3, error: false)
+        recorder.stop()
+        #expect(collector.last?["bytes_written"] == "77")
+    }
+
+    /// "Idle volumes self-suppress." The first tick emits because there is
+    /// no previous snapshot; every idle tick after it is suppressed. So an
+    /// idle started recorder emits exactly once no matter how many times the
+    /// timer fires, which is what keeps the NDJSON sink from being flooded
+    /// by every mounted volume doing nothing.
+    @Test func anIdleRecorderEmitsOnceHoweverManyTimesTheTimerFires() async throws {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "idle") { collector.take($0) }
+        recorder.start()
+        // The cadence is 1 Hz; wait long enough for several ticks.
+        try await Task.sleep(nanoseconds: 3_400_000_000)
+        let duringRun = collector.count
+        recorder.stop()
+        #expect(duringRun == 1,
+                "an idle recorder emitted \(duringRun) times; duplicate suppression is not working")
+    }
+
+    /// And activity between ticks is not suppressed.
+    @Test func activityBetweenTicksIsEmitted() async throws {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "busy") { collector.take($0) }
+        recorder.start()
+        try await Task.sleep(nanoseconds: 1_400_000_000)
+        recorder.recordRead(bytes: 1, latencyNs: 1, error: false)
+        try await Task.sleep(nanoseconds: 1_400_000_000)
+        let duringRun = collector.count
+        recorder.stop()
+        #expect(duringRun >= 2, "a changed snapshot was suppressed (\(duringRun) emissions)")
+    }
+
+    /// THE PREFLUSH OVERLAY IS PERSISTED, which the comment gives the reason
+    /// for: subsequent hot-path increments have to build on the
+    /// authoritative numbers "rather than re-overlaying the deltas every
+    /// tick". A hook that adds a constant each flush therefore produces a
+    /// running total; if the overlay were not written back, every flush
+    /// would report the same constant.
+    @Test func thePreflushOverlayIsWrittenBackNotReapplied() {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "overlay",
+                                       emit: { collector.take($0) },
+                                       preflush: { $0.bdevBytesRead &+= 100 })
+        recorder.stop()
+        #expect(collector.last?["bdev_bytes_read"] == "100")
+        recorder.stop()
+        #expect(collector.last?["bdev_bytes_read"] == "200",
+                "the overlay was not persisted, so each flush re-applied it to the same base")
+    }
+
+    @Test func aPreflushSeesTheHotPathCountersAndCanCorrectThem() {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "correct",
+                                       emit: { collector.take($0) },
+                                       preflush: { counters in
+                                           // What FileProvider does: replace the
+                                           // Swift-side guess with the Go-side truth.
+                                           #expect(counters.bytesRead == 50)
+                                           counters.bytesRead = 999
+                                       })
+        recorder.recordRead(bytes: 50, latencyNs: 1, error: false)
+        recorder.stop()
+        #expect(collector.last?["bytes_read"] == "999")
+    }
+
+    /// FSKit recorders pass nil, so that path has to work too.
+    @Test func noPreflushIsFine() {
+        let collector = EmitCollector()
+        let recorder = IOStatsRecorder(label: "nohook", emit: { collector.take($0) }, preflush: nil)
+        recorder.recordRead(bytes: 1, latencyNs: 1, error: false)
+        recorder.stop()
+        #expect(collector.last?["bytes_read"] == "1")
+    }
+}
+
+// MARK: - Odds and ends
+
+@Suite("IOStats helpers")
+struct IOStatsHelperTests {
+
+    /// The alias exists for the three per-extension copies this type
+    /// replaced. Removing it would break their call sites silently at
+    /// compile time in another target, so it is worth one line here.
+    @Test func theBackCompatAliasStillNamesTheSameType() {
+        #expect(IOStatsCollector.self == IOStatsRecorder.self)
+    }
+
+    @Test func monotonicNanosMovesForwardAndIsNotZero() {
+        let a = monotonicNanos()
+        #expect(a > 0)
+        var b = monotonicNanos()
+        var spins = 0
+        while b == a && spins < 1_000_000 { b = monotonicNanos(); spins += 1 }
+        #expect(b > a, "the clock did not advance in a million reads")
+    }
+}

--- a/DiskJockeyLibraryTests/MountPersistenceTests.swift
+++ b/DiskJockeyLibraryTests/MountPersistenceTests.swift
@@ -1,0 +1,321 @@
+//
+//  MountPersistenceTests.swift — the two plist stores the FileProvider
+//  extension reads at spawn, and the policy struct's upgrade path.
+//
+//  WHY THIS FILE EXISTS
+//  --------------------
+//  These files are the handoff between two processes: the host app writes
+//  them, the extension reads them, and nothing checks that the two agree
+//  because they are the same type on both sides — right up until an
+//  extension built yesterday reads a plist written today. Both types are
+//  built for that case and say so:
+//
+//    * MountPolicy decodes every field with `try?` and falls back to the
+//      default, "so a partially-populated plist (or a new field added
+//      later) decodes cleanly with sensible defaults instead of failing
+//      the whole load".
+//    * MountPolicyStore returns `.default` for a MISSING file, because
+//      "the missing-file case is the upgrade path for legacy mounts".
+//
+//  Neither leniency was tested, which is the usual state of an upgrade
+//  path: it is exercised once, by a user, on a version nobody has any
+//  more.
+//
+//  AND THE TWO STORES DISAGREE ON PURPOSE. A missing policy defaults; a
+//  missing config throws `.notFound`. That asymmetry is right — a mount
+//  with no policy is a mount with default policy, while a mount with no
+//  config is not a mount — but it is the kind of thing that gets
+//  "tidied" into consistency by someone who has not read both comments.
+//  Both directions are pinned below.
+//
+//  Both stores take a `directory:` parameter that defaults to the shared
+//  container; see either store's own doc comment for why that exists.
+//
+
+import Foundation
+import Testing
+@testable import DiskJockeyLibrary
+
+private func scratch() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mount-store-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+// MARK: - The policy struct
+
+@Suite("MountPolicy")
+struct MountPolicyTests {
+
+    @Test func everythingIsOnByDefault() {
+        let policy = MountPolicy()
+        #expect(policy.fetchThumbnails)
+        #expect(policy.backgroundFetch)
+        #expect(MountPolicy.default == policy,
+                "the `default` singleton must be the same thing the initialiser produces")
+    }
+
+    @Test func aRoundTripThroughABinaryPlistPreservesBothFlags() throws {
+        for (thumbs, background) in [(true, true), (true, false), (false, true), (false, false)] {
+            let policy = MountPolicy(fetchThumbnails: thumbs, backgroundFetch: background)
+            let encoder = PropertyListEncoder(); encoder.outputFormat = .binary
+            let back = try PropertyListDecoder().decode(MountPolicy.self,
+                                                        from: try encoder.encode(policy))
+            #expect(back == policy, "(\(thumbs), \(background)) did not survive a plist round-trip")
+        }
+    }
+
+    /// THE UPGRADE PATH. An extension reading a plist written before a field
+    /// existed must not fail the whole load — it fills in the default.
+    @Test func aPlistMissingAFieldDecodesToTheDefaultForIt() throws {
+        let onlyThumbs = try JSONDecoder().decode(
+            MountPolicy.self, from: Data(#"{"fetchThumbnails":false}"#.utf8))
+        #expect(onlyThumbs.fetchThumbnails == false, "the field that IS present must be honoured")
+        #expect(onlyThumbs.backgroundFetch == true, "the absent field takes its default")
+
+        let onlyBackground = try JSONDecoder().decode(
+            MountPolicy.self, from: Data(#"{"backgroundFetch":false}"#.utf8))
+        #expect(onlyBackground.fetchThumbnails == true)
+        #expect(onlyBackground.backgroundFetch == false)
+    }
+
+    @Test func anEmptyPlistDecodesToTheDefaultPolicy() throws {
+        let policy = try JSONDecoder().decode(MountPolicy.self, from: Data("{}".utf8))
+        #expect(policy == MountPolicy.default)
+    }
+
+    /// `try?` per field means a WRONG TYPE also falls back rather than
+    /// throwing. That is the same leniency and worth stating, because it is
+    /// the difference between a mount that loses one toggle and a mount that
+    /// will not load at all.
+    @Test func aFieldOfTheWrongTypeFallsBackRatherThanFailingTheLoad() throws {
+        let policy = try JSONDecoder().decode(
+            MountPolicy.self, from: Data(#"{"fetchThumbnails":"yes","backgroundFetch":false}"#.utf8))
+        #expect(policy.fetchThumbnails == true, "an unreadable field takes its default")
+        #expect(policy.backgroundFetch == false, "the readable field beside it still decodes")
+    }
+
+    /// RECORDED, NOT ENFORCED. `backgroundFetch`'s comment says it "implies
+    /// `fetchThumbnails == true`; if that's off this has nothing to
+    /// pre-warm" — but nothing in the type enforces the implication, so the
+    /// inconsistent combination is constructible and persists. Consumers
+    /// have to check `fetchThumbnails` first; this says so in a place that
+    /// will fail if the type ever starts normalising instead.
+    @Test func theImpliedInvariantIsNotEnforcedByTheType() throws {
+        let contradictory = MountPolicy(fetchThumbnails: false, backgroundFetch: true)
+        #expect(contradictory.backgroundFetch == true,
+                "if this now reads false, the type gained normalisation and callers no longer need to check fetchThumbnails first")
+        let encoder = PropertyListEncoder(); encoder.outputFormat = .binary
+        let back = try PropertyListDecoder().decode(MountPolicy.self,
+                                                    from: try encoder.encode(contradictory))
+        #expect(back == contradictory, "the contradiction survives persistence too")
+    }
+}
+
+// MARK: - The policy store
+
+@Suite("MountPolicyStore")
+struct MountPolicyStoreTests {
+
+    @Test func aMissingFileIsTheDefaultPolicyRatherThanAnError() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountPolicyStore(directory: dir)
+        #expect(try store.load(domainID: "never-saved") == MountPolicy.default,
+                "a legacy mount with no policy file must inherit the defaults, not fail to load")
+    }
+
+    @Test func whatWasSavedIsWhatLoads() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountPolicyStore(directory: dir)
+        let policy = MountPolicy(fetchThumbnails: false, backgroundFetch: false)
+        try store.save(policy, domainID: "domain-1")
+        #expect(try store.load(domainID: "domain-1") == policy)
+    }
+
+    @Test func policiesAreKeptPerDomain() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountPolicyStore(directory: dir)
+        try store.save(MountPolicy(fetchThumbnails: false, backgroundFetch: false), domainID: "a")
+        try store.save(MountPolicy(fetchThumbnails: true, backgroundFetch: false), domainID: "b")
+        #expect(try store.load(domainID: "a").fetchThumbnails == false)
+        #expect(try store.load(domainID: "b").fetchThumbnails == true)
+        #expect(try store.load(domainID: "c") == MountPolicy.default)
+    }
+
+    @Test func savingTwiceReplacesRatherThanAppends() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountPolicyStore(directory: dir)
+        try store.save(MountPolicy(fetchThumbnails: false, backgroundFetch: false), domainID: "d")
+        try store.save(MountPolicy(fetchThumbnails: true, backgroundFetch: true), domainID: "d")
+        #expect(try store.load(domainID: "d") == MountPolicy.default)
+    }
+
+    @Test func deletingReturnsTheDomainToTheDefaults() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountPolicyStore(directory: dir)
+        try store.save(MountPolicy(fetchThumbnails: false, backgroundFetch: false), domainID: "e")
+        try store.delete(domainID: "e")
+        #expect(try store.load(domainID: "e") == MountPolicy.default)
+    }
+
+    @Test func deletingSomethingThatIsNotThereIsNotAnError() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try MountPolicyStore(directory: dir).delete(domainID: "absent")
+    }
+
+    @Test func itCreatesItsDirectoryOnDemand() throws {
+        let parent = try scratch()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let nested = parent.appendingPathComponent("not/created/yet", isDirectory: true)
+        let store = MountPolicyStore(directory: nested)
+        try store.save(MountPolicy(fetchThumbnails: false), domainID: "f")
+        #expect(try store.load(domainID: "f").fetchThumbnails == false)
+    }
+}
+
+// MARK: - The config store
+
+@Suite("MountConfigStore")
+struct MountConfigStoreTests {
+
+    private func sample(_ scheme: DirectMountScheme) -> StoredMountConfig {
+        switch scheme {
+        case .ftp:      return .ftp(FTPMountConfig(host: "h", user: "u"))
+        case .sftp:     return .sftp(SFTPMountConfig(host: "h", port: 2222, user: "u"))
+        case .smb:      return .smb(SMBMountConfig(host: "h", share: "s", user: "u"))
+        case .dropbox:  return .dropbox(DropboxMountConfig(appKey: "k", accountLabel: "l"))
+        case .webdav:   return .webdav(WebDAVMountConfig(url: "https://d", user: "u"))
+        case .gdrive:   return .gdrive(GDriveMountConfig(clientID: "c", clientSecret: "s"))
+        case .s3:       return .s3(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k"))
+        case .onedrive: return .onedrive(OneDriveMountConfig(clientID: "c"))
+        }
+    }
+
+    /// EVERY SCHEME, because the plist root key is the enum case name and
+    /// each case's struct is decoded separately — so a Codable break is
+    /// per-scheme, not global, and a test of one scheme proves nothing
+    /// about the other seven.
+    @Test func everySchemeSurvivesTheDiskRoundTrip() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        for scheme in DirectMountScheme.allCases {
+            let config = sample(scheme)
+            try store.save(config, domainID: scheme.rawValue)
+            let back = try store.load(domainID: scheme.rawValue)
+            #expect(back == config, "\(scheme) did not survive the store")
+            #expect(back.scheme == scheme)
+        }
+        #expect(try store.allDomainIDs().sorted() == DirectMountScheme.allCases.map(\.rawValue).sorted())
+    }
+
+    /// THE ASYMMETRY WITH THE POLICY STORE, ON PURPOSE. A mount with no
+    /// policy is a mount with the default policy; a mount with no config is
+    /// not a mount.
+    @Test func aMissingConfigThrowsNotFoundRatherThanDefaulting() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        #expect(throws: MountConfigStoreError.self) {
+            _ = try store.load(domainID: "never-saved")
+        }
+        do {
+            _ = try store.load(domainID: "never-saved")
+            Issue.record("load of an absent config did not throw")
+        } catch let error as MountConfigStoreError {
+            guard case .notFound(let domainID) = error else {
+                Issue.record("expected .notFound, got \(error)")
+                return
+            }
+            #expect(domainID == "never-saved", "the error must name the domain that is missing")
+        }
+    }
+
+    /// `exists` is the non-throwing check the extension uses to decide
+    /// "direct path?" vs "XPC fallback?", so a wrong answer picks the wrong
+    /// mount strategy.
+    @Test func existsTracksTheFile() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        #expect(store.exists(domainID: "x") == false)
+        try store.save(sample(.smb), domainID: "x")
+        #expect(store.exists(domainID: "x") == true)
+        try store.delete(domainID: "x")
+        #expect(store.exists(domainID: "x") == false)
+    }
+
+    @Test func deletingSomethingThatIsNotThereIsNotAnError() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try MountConfigStore(directory: dir).delete(domainID: "absent")
+    }
+
+    /// `allDomainIDs` is what the host app reconciles against
+    /// NSFileProviderManager on startup, so a stray file in the directory
+    /// must not become a phantom domain.
+    @Test func allDomainIDsIgnoresAnythingThatIsNotAPlist() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        try store.save(sample(.ftp), domainID: "real-one")
+        try Data("junk".utf8).write(to: dir.appendingPathComponent("notes.txt"))
+        try Data("junk".utf8).write(to: dir.appendingPathComponent("no-extension"))
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("a-directory.plist"), withIntermediateDirectories: true)
+        let ids = try store.allDomainIDs()
+        #expect(ids.contains("real-one"))
+        #expect(!ids.contains("notes"))
+        #expect(!ids.contains("no-extension"))
+        // A DIRECTORY NAMED *.plist IS LISTED, which is worth knowing: the
+        // filter is on the extension, not on the file type, so reconciling
+        // will then fail to load it. Recorded rather than asserted away.
+        #expect(ids.contains("a-directory"),
+                "if this now fails, the filter learned to check for a regular file, and the reconcile path got safer")
+    }
+
+    @Test func anEmptyDirectoryHasNoDomains() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(try MountConfigStore(directory: dir).allDomainIDs().isEmpty)
+    }
+
+    @Test func aCorruptPlistIsReportedAsADecodeFailureNotAsAbsence() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        try Data("this is not a plist".utf8).write(to: dir.appendingPathComponent("broken.plist"))
+        do {
+            _ = try store.load(domainID: "broken")
+            Issue.record("a corrupt plist loaded successfully")
+        } catch let error as MountConfigStoreError {
+            guard case .decodeFailed = error else {
+                Issue.record("expected .decodeFailed, got \(error) — a corrupt config must not read as a missing one")
+                return
+            }
+        }
+    }
+
+    /// The domain identifier is interpolated straight into a path
+    /// component, and this is what that means: an id containing a
+    /// separator addresses a subdirectory rather than being rejected or
+    /// escaped. Real ids are NSFileProviderDomain UUIDs, so this is a
+    /// note about trust rather than a live defect — recorded so it is
+    /// known rather than discovered.
+    @Test func aDomainIdentifierIsTrustedToBeAPathComponent() throws {
+        let dir = try scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = MountConfigStore(directory: dir)
+        #expect(throws: (any Error).self) {
+            try store.save(sample(.ftp), domainID: "nested/id")
+        }
+        #expect(store.exists(domainID: "nested/id") == false)
+    }
+}

--- a/DiskJockeyLibraryTests/NetworkFSPersonalityTests.swift
+++ b/DiskJockeyLibraryTests/NetworkFSPersonalityTests.swift
@@ -1,0 +1,440 @@
+//
+//  NetworkFSPersonalityTests.swift — the eight mount personalities, their
+//  driver IDs, and the JSON each hands to its Go driver.
+//
+//  WHY THIS FILE EXISTS
+//  --------------------
+//  This layer had no tests at all. It is also the layer whose mistakes are
+//  the hardest to see from the outside, because every one of them fails
+//  SILENTLY on the far side of a C ABI:
+//
+//    * `driverType` is "part of the C ABI, not cosmetic" by its own comment.
+//      A wrong integer dispatches to a different Go driver, which then
+//      rejects a config it never expected. Nothing in Swift notices.
+//    * `mountJSON` keys are read out of `map[string]string` by each Go
+//      driver's `Mount()`. A renamed or missing key is a nil field on the
+//      Go side, not a compile error here.
+//    * `StoredMountConfig.scheme` is eight hand-written `case .x: return .x`
+//      lines. That is exactly the shape a copy-paste gets wrong, and getting
+//      it wrong routes a mount to the wrong driver.
+//    * Every value must be a STRING. Go decodes into map[string]string, so
+//      a numeric or boolean JSON value fails to decode there and here it is
+//      just a dictionary literal.
+//
+//  WHAT THESE TESTS DO NOT DO. They do not verify that the key names match
+//  what the Go drivers actually read — that lives in a sibling repository
+//  which this target deliberately does not clone. What they pin is that the
+//  keys, the driver IDs and the string-ness do not CHANGE without somebody
+//  saying so, and that the omit-when-empty branches behave as documented.
+//
+//  Host-free by construction: no app, no extension, no FSKit, no I/O.
+//
+
+import Foundation
+import Testing
+@testable import DiskJockeyLibrary
+
+// MARK: - Helpers
+
+/// Decode a personality's JSON back into a dictionary, asserting on the way
+/// that it is a JSON object whose every value is a string.
+private func mountDict(_ json: String,
+                       _ sourceLocation: SourceLocation = #_sourceLocation) throws -> [String: String] {
+    let data = Data(json.utf8)
+    let any = try JSONSerialization.jsonObject(with: data)
+    let object = try #require(any as? [String: Any], "not a JSON object: \(json)",
+                              sourceLocation: sourceLocation)
+    var out: [String: String] = [:]
+    for (key, value) in object {
+        let string = value as? String
+        #expect(string != nil,
+                "key \"\(key)\" is \(type(of: value)), not String; the Go drivers decode into map[string]string",
+                sourceLocation: sourceLocation)
+        out[key] = string ?? ""
+    }
+    return out
+}
+
+/// Every scheme paired with a config of that scheme, so a test can iterate
+/// the whole set rather than naming eight cases and forgetting the ninth.
+private let allStored: [StoredMountConfig] = [
+    .ftp(FTPMountConfig(host: "ftp.example.com", user: "u")),
+    .sftp(SFTPMountConfig(host: "sftp.example.com", user: "u")),
+    .smb(SMBMountConfig(host: "smb.example.com", share: "public", user: "u")),
+    .dropbox(DropboxMountConfig()),
+    .webdav(WebDAVMountConfig(url: "https://dav.example.com", user: "u")),
+    .gdrive(GDriveMountConfig(clientID: "cid", clientSecret: "csecret")),
+    .s3(S3MountConfig(endpoint: "s3.example.com", bucket: "b", accessKeyID: "AKIA")),
+    .onedrive(OneDriveMountConfig(clientID: "cid")),
+]
+
+// MARK: - The C ABI
+
+@Suite("driver type IDs")
+struct DriverTypeTests {
+
+    /// THE NUMBERS THEMSELVES, spelled out. `driverType`'s own comment says
+    /// "DO NOT change these — they're part of the C ABI, not cosmetic", and
+    /// a rule stated in a comment is not a rule anything enforces.
+    @Test func driverTypesAreTheDocumentedIntegers() {
+        #expect(DirectMountScheme.ftp.driverType == 1)
+        #expect(DirectMountScheme.sftp.driverType == 2)
+        #expect(DirectMountScheme.smb.driverType == 3)
+        #expect(DirectMountScheme.dropbox.driverType == 4)
+        #expect(DirectMountScheme.webdav.driverType == 5)
+        #expect(DirectMountScheme.gdrive.driverType == 6)
+        #expect(DirectMountScheme.s3.driverType == 7)
+        #expect(DirectMountScheme.onedrive.driverType == 8)
+    }
+
+    /// And a new case cannot silently reuse an existing driver's ID, which
+    /// would send its mounts to that driver.
+    @Test func everySchemeHasItsOwnDriverType() {
+        let ids = DirectMountScheme.allCases.map(\.driverType)
+        #expect(Set(ids).count == ids.count,
+                "two schemes share a driver_type: \(ids)")
+        #expect(!ids.contains(0), "0 is not a registered driver type")
+    }
+
+    /// CaseIterable is what lets the checks above cover a case nobody
+    /// remembered to add here. Pin the count so adding one is a decision.
+    @Test func theSchemeSetIsTheEightWeSupport() {
+        #expect(DirectMountScheme.allCases.count == 8)
+        let raws = DirectMountScheme.allCases.map(\.rawValue)
+        #expect(Set(raws).count == raws.count)
+    }
+
+    /// The raw value is the on-disk spelling (the enum is Codable), so it is
+    /// as much a compatibility surface as the integer is.
+    @Test func rawValuesAreTheOnDiskSpellings() {
+        #expect(DirectMountScheme(rawValue: "ftp") == .ftp)
+        #expect(DirectMountScheme(rawValue: "sftp") == .sftp)
+        #expect(DirectMountScheme(rawValue: "smb") == .smb)
+        #expect(DirectMountScheme(rawValue: "dropbox") == .dropbox)
+        #expect(DirectMountScheme(rawValue: "webdav") == .webdav)
+        #expect(DirectMountScheme(rawValue: "gdrive") == .gdrive)
+        #expect(DirectMountScheme(rawValue: "s3") == .s3)
+        #expect(DirectMountScheme(rawValue: "onedrive") == .onedrive)
+        #expect(DirectMountScheme(rawValue: "Dropbox") == nil,
+                "raw values are case-sensitive; a capitalised one must not decode")
+    }
+
+    @Test("every scheme has a label and an icon", arguments: DirectMountScheme.allCases)
+    func labelAndIcon(scheme: DirectMountScheme) {
+        #expect(!scheme.displayName.isEmpty)
+        guard case .asset(let name) = scheme.icon else { return }
+        #expect(!name.isEmpty, "\(scheme) has an empty asset name")
+    }
+}
+
+// MARK: - The envelope routes to the right driver
+
+@Suite("StoredMountConfig routing")
+struct StoredMountConfigRoutingTests {
+
+    /// EIGHT HAND-WRITTEN LINES OF `case .x: return .x`. This is the check
+    /// that makes a mis-pasted one visible, and it is why `allStored` pairs
+    /// each case with a config of that same protocol: the wrapped type
+    /// declares its own scheme statically, so the two can be compared
+    /// without restating either.
+    @Test func theEnvelopeReportsTheWrappedConfigsScheme() {
+        var seen: Set<DirectMountScheme> = []
+        for stored in allStored {
+            let wrapped: DirectMountScheme
+            switch stored {
+            case .ftp:      wrapped = FTPMountConfig.scheme
+            case .sftp:     wrapped = SFTPMountConfig.scheme
+            case .smb:      wrapped = SMBMountConfig.scheme
+            case .dropbox:  wrapped = DropboxMountConfig.scheme
+            case .webdav:   wrapped = WebDAVMountConfig.scheme
+            case .gdrive:   wrapped = GDriveMountConfig.scheme
+            case .s3:       wrapped = S3MountConfig.scheme
+            case .onedrive: wrapped = OneDriveMountConfig.scheme
+            }
+            #expect(stored.scheme == wrapped,
+                    "envelope says \(stored.scheme) but the wrapped config says \(wrapped)")
+            seen.insert(stored.scheme)
+        }
+        // AND THE FIXTURE COVERS EVERYTHING. Without this the loop above
+        // passes a fixture that quietly lost a case.
+        #expect(seen == Set(DirectMountScheme.allCases),
+                "the fixture does not cover every scheme: missing \(Set(DirectMountScheme.allCases).subtracting(seen))")
+    }
+
+    @Test func theEnvelopeForwardsDriverType() {
+        for stored in allStored {
+            #expect(stored.driverType == stored.scheme.driverType)
+        }
+    }
+
+    @Test func everySchemeHasADisplayLocation() {
+        for stored in allStored {
+            #expect(!stored.displayLocation.isEmpty, "\(stored.scheme) has no display location")
+        }
+        #expect(StoredMountConfig.smb(SMBMountConfig(host: "h", share: "s", user: "u")).displayLocation == "h/s")
+        #expect(StoredMountConfig.ftp(FTPMountConfig(host: "h", user: "u")).displayLocation == "h:21")
+        #expect(StoredMountConfig.s3(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k")).displayLocation == "e/b")
+    }
+}
+
+// MARK: - What the Go side receives
+
+@Suite("mountJSON")
+struct MountJSONTests {
+
+    /// ONE ASSERTION OVER ALL EIGHT, because "every value is a string" is a
+    /// property of the ABI rather than of any one protocol, and a per-driver
+    /// test would be the eighth place to forget it.
+    @Test func everyPersonalityEncodesAJSONObjectOfStrings() throws {
+        for stored in allStored {
+            let dict = try mountDict(stored.mountJSON(password: "pw"))
+            #expect(!dict.isEmpty, "\(stored.scheme) produced an empty config")
+        }
+    }
+
+    /// Booleans reach Go as the STRINGS "true"/"false" — the map is
+    /// map[string]string, so a real JSON boolean does not decode there.
+    @Test func booleansAreEncodedAsStrings() throws {
+        let ftps = try mountDict(FTPMountConfig(host: "h", user: "u", ftps: true).mountJSON(password: "p"))
+        #expect(ftps["ftps"] == "true")
+        let plain = try mountDict(FTPMountConfig(host: "h", user: "u", ftps: false).mountJSON(password: "p"))
+        #expect(plain["ftps"] == "false")
+
+        let agent = try mountDict(SFTPMountConfig(host: "h", user: "u", useSSHAgent: true).mountJSON(password: "p"))
+        #expect(agent["use_ssh_agent"] == "true")
+
+        let s3 = try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k",
+                                             secure: false, usePathStyle: true).mountJSON(password: "p"))
+        #expect(s3["secure"] == "false")
+        #expect(s3["use_path_style"] == "true")
+    }
+
+    /// Ports are integers in Swift and strings in the config map.
+    @Test func portsCrossAsStringsAndDefaultsAreTheDocumentedOnes() throws {
+        #expect(try mountDict(FTPMountConfig(host: "h", user: "u").mountJSON(password: "p"))["port"] == "21")
+        #expect(try mountDict(SFTPMountConfig(host: "h", user: "u").mountJSON(password: "p"))["port"] == "22")
+        #expect(try mountDict(SMBMountConfig(host: "h", share: "s", user: "u").mountJSON(password: "p"))["port"] == "445")
+        #expect(try mountDict(SFTPMountConfig(host: "h", port: 2222, user: "u").mountJSON(password: "p"))["port"] == "2222")
+    }
+
+    @Test func s3CarriesItsDocumentedDefaults() throws {
+        let dict = try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k").mountJSON(password: "p"))
+        #expect(dict["region"] == "us-east-1")
+        #expect(dict["secure"] == "true")
+        #expect(dict["use_path_style"] == "false")
+    }
+
+    /// THE PASSWORD GOES WHERE EACH DRIVER LOOKS FOR IT, and the key differs
+    /// per protocol. Getting this wrong is an authentication failure whose
+    /// only symptom is a rejected mount.
+    @Test func theSecretLandsUnderTheKeyItsDriverReads() throws {
+        let secret = "s3cr3t"
+        #expect(try mountDict(FTPMountConfig(host: "h", user: "u").mountJSON(password: secret))["pass"] == secret)
+        #expect(try mountDict(SFTPMountConfig(host: "h", user: "u").mountJSON(password: secret))["pass"] == secret)
+        #expect(try mountDict(SMBMountConfig(host: "h", share: "s", user: "u").mountJSON(password: secret))["pass"] == secret)
+        #expect(try mountDict(WebDAVMountConfig(url: "u", user: "u").mountJSON(password: secret))["pass"] == secret)
+        #expect(try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k").mountJSON(password: secret))["secret_access_key"] == secret)
+        #expect(try mountDict(GDriveMountConfig(clientID: "c", clientSecret: "s").mountJSON(password: secret))["refresh_token"] == secret)
+        #expect(try mountDict(OneDriveMountConfig(clientID: "c").mountJSON(password: secret))["refresh_token"] == secret)
+    }
+
+    /// S3's `access_key_id` is deliberately NOT the secret (see that file's
+    /// header), so it must not be confused with it.
+    @Test func s3SplitsIdentifierFromCredential() throws {
+        let dict = try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "AKIAIDENT").mountJSON(password: "thesecret"))
+        #expect(dict["access_key_id"] == "AKIAIDENT")
+        #expect(dict["secret_access_key"] == "thesecret")
+    }
+
+    /// A PASSWORD IS ARBITRARY BYTES. This dict is hand-built into JSON, and
+    /// a quote or a backslash in the wrong place produces a config the Go
+    /// side cannot parse at all — a mount that fails with a JSON error rather
+    /// than an auth error.
+    @Test func awkwardSecretsSurviveEncoding() throws {
+        for secret in [#"has "quotes""#,
+                       #"back\slash"#,
+                       "line\nbreak",
+                       "tab\there",
+                       "emoji 🔐 and ünïcødé",
+                       #"{"looks":"like json"}"#,
+                       ""] {
+            let dict = try mountDict(SFTPMountConfig(host: "h", user: "u").mountJSON(password: secret))
+            #expect(dict["pass"] == secret, "secret did not round-trip: \(secret.debugDescription)")
+        }
+    }
+
+    /// Awkward FIELD values too, not just secrets — a share name with a
+    /// quote in it is legal on the wire.
+    @Test func awkwardFieldValuesSurviveEncoding() throws {
+        let dict = try mountDict(SMBMountConfig(host: #"host"with"quotes"#, share: #"sh\are"#,
+                                                user: "üser", rootPath: "/a b/c").mountJSON(password: "p"))
+        #expect(dict["host"] == #"host"with"quotes"#)
+        #expect(dict["share"] == #"sh\are"#)
+        #expect(dict["user"] == "üser")
+        #expect(dict["root"] == "/a b/c")
+    }
+}
+
+// MARK: - The omit-when-empty branches
+
+@Suite("optional fields")
+struct OptionalFieldTests {
+
+    /// S3 omits both optional keys rather than sending them empty. An empty
+    /// `prefix` is not the same as no prefix on the Go side: one mounts the
+    /// whole bucket, the other mounts a directory named "".
+    @Test func s3OmitsEmptyOptionalsAndIncludesSetOnes() throws {
+        let bare = try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k").mountJSON(password: "p"))
+        #expect(bare["prefix"] == nil)
+        #expect(bare["session_token"] == nil)
+
+        let full = try mountDict(S3MountConfig(endpoint: "e", bucket: "b", accessKeyID: "k",
+                                               prefix: "data/", sessionToken: "tok").mountJSON(password: "p"))
+        #expect(full["prefix"] == "data/")
+        #expect(full["session_token"] == "tok")
+    }
+
+    /// Dropbox switches its whole credential model on whether an app key is
+    /// configured: a bare account sends a long-lived access token, a
+    /// registered app sends a refresh token. Two different keys, and only
+    /// one of them at a time.
+    @Test func dropboxPicksItsCredentialKeyFromWhetherAnAppKeyIsSet() throws {
+        let bare = try mountDict(DropboxMountConfig().mountJSON(password: "tok"))
+        #expect(bare["access_token"] == "tok")
+        #expect(bare["refresh_token"] == nil)
+        #expect(bare["app_key"] == nil)
+
+        let app = try mountDict(DropboxMountConfig(appKey: "kk").mountJSON(password: "refresh"))
+        #expect(app["app_key"] == "kk")
+        #expect(app["refresh_token"] == "refresh")
+        #expect(app["access_token"] == nil,
+                "an app-key mount must not also send a long-lived access token")
+    }
+
+    @Test func gdriveIncludesACachedTokenOnlyWhenThereIsOne() throws {
+        let cold = try mountDict(GDriveMountConfig(clientID: "c", clientSecret: "s").mountJSON(password: "r"))
+        #expect(cold["access_token"] == nil)
+        #expect(cold["client_id"] == "c")
+        #expect(cold["client_secret"] == "s")
+
+        let warm = try mountDict(GDriveMountConfig(clientID: "c", clientSecret: "s",
+                                                   cachedAccessToken: "at").mountJSON(password: "r"))
+        #expect(warm["access_token"] == "at")
+    }
+
+    /// OneDrive's client secret is optional (public clients use PKCE and
+    /// have none), so an empty one must be omitted rather than sent blank.
+    @Test func onedriveOmitsAnEmptyClientSecret() throws {
+        let publicClient = try mountDict(OneDriveMountConfig(clientID: "c").mountJSON(password: "r"))
+        #expect(publicClient["client_secret"] == nil)
+        #expect(publicClient["access_token"] == nil)
+        #expect(publicClient["client_id"] == "c")
+
+        let confidential = try mountDict(OneDriveMountConfig(clientID: "c", clientSecret: "s",
+                                                             cachedAccessToken: "at").mountJSON(password: "r"))
+        #expect(confidential["client_secret"] == "s")
+        #expect(confidential["access_token"] == "at")
+    }
+}
+
+// MARK: - What goes on disk
+
+@Suite("persistence")
+struct PersistenceTests {
+
+    /// The envelope is persisted as a plist per NSFileProviderDomain, so the
+    /// plist encoder is the one that matters. A round-trip through it is the
+    /// closest thing to "will the extension still read this after a restart".
+    @Test func everySchemeRoundTripsThroughAPropertyList() throws {
+        for stored in allStored {
+            let data = try PropertyListEncoder().encode(stored)
+            let back = try PropertyListDecoder().decode(StoredMountConfig.self, from: data)
+            #expect(back == stored, "\(stored.scheme) did not survive a plist round-trip")
+        }
+    }
+
+    @Test func everySchemeRoundTripsThroughJSON() throws {
+        for stored in allStored {
+            let data = try JSONEncoder().encode(stored)
+            let back = try JSONDecoder().decode(StoredMountConfig.self, from: data)
+            #expect(back == stored, "\(stored.scheme) did not survive a JSON round-trip")
+        }
+    }
+
+    /// THE KEYCHAIN OWNS CREDENTIALS, and this is the assertion that says so.
+    /// `mountJSON` takes the password as a parameter precisely so the plist on
+    /// disk never carries it. Asserted against the VALUE rather than against a
+    /// list of key names: a name check reads as stronger than it is, and the
+    /// thing that matters is whether the secret is on disk, whatever the field
+    /// happens to be called.
+    @Test func theSecretPassedToMountJSONIsNeverPersisted() throws {
+        let secret = "THE-KEYCHAIN-HALF-9f3a1c"
+        for stored in allStored {
+            // The secret is in the mount JSON, which is the point of it.
+            #expect(stored.mountJSON(password: secret).contains(secret),
+                    "\(stored.scheme) does not pass the secret to its driver at all")
+            // And not in what goes on disk.
+            let onDisk = try PropertyListEncoder().encode(stored)
+            #expect(!String(decoding: onDisk, as: UTF8.self).contains(secret),
+                    "\(stored.scheme)'s persisted form carries the secret that MountKeychain is supposed to own")
+        }
+    }
+
+    /// AND ONE SECRET IS ON DISK ANYWAY — recorded here rather than asserted
+    /// away, because it is a live finding and not a test bug (diskjockey#160).
+    ///
+    /// `GDriveMountConfig.cachedAccessToken` and OneDrive's equivalent are
+    /// ordinary Codable fields, so `OAuthRefreshSupervisor` writing a freshly
+    /// refreshed OAuth *access token* into the config puts that token in
+    /// cleartext into the per-domain plist in the app-group container. The
+    /// refresh token, which is the long-lived half, correctly goes to the
+    /// keychain — so the split is half-applied rather than absent.
+    ///
+    /// `withKnownIssue` keeps the suite green while the decision is open AND
+    /// makes the test fail the day it is fixed, which is when this comment
+    /// needs deleting. A plain `#expect(persisted)` would pin the behaviour as
+    /// desired; a deleted test would lose the finding.
+    @Test func anOAuthAccessTokenReachesTheDiskInCleartext() throws {
+        let token = "USER-ACCESS-TOKEN-4b7e"
+        let configs: [StoredMountConfig] = [
+            .gdrive(GDriveMountConfig(clientID: "c", clientSecret: "s", cachedAccessToken: token)),
+            .onedrive(OneDriveMountConfig(clientID: "c", cachedAccessToken: token)),
+        ]
+        for stored in configs {
+            let onDisk = String(decoding: try PropertyListEncoder().encode(stored), as: UTF8.self)
+            withKnownIssue("diskjockey#160: cachedAccessToken is persisted in the domain plist") {
+                #expect(!onDisk.contains(token),
+                        "\(stored.scheme) writes a live access token to disk")
+            }
+        }
+    }
+
+    /// The OAuth configs decode missing fields to "" rather than throwing,
+    /// which is what lets a plist written by an older build still load. That
+    /// leniency is deliberate and worth pinning: without it, adding a field
+    /// bricks every existing domain.
+    @Test func theOAuthConfigsToleratePlistsWrittenBeforeTheirFieldsExisted() throws {
+        let partial = Data(#"{"clientID":"only-this"}"#.utf8)
+        let gdrive = try JSONDecoder().decode(GDriveMountConfig.self, from: partial)
+        #expect(gdrive.clientID == "only-this")
+        #expect(gdrive.clientSecret == "")
+        #expect(gdrive.cachedAccessToken == "")
+
+        let onedrive = try JSONDecoder().decode(OneDriveMountConfig.self, from: partial)
+        #expect(onedrive.clientID == "only-this")
+        #expect(onedrive.clientSecret == "")
+
+        let empty = Data("{}".utf8)
+        let dropbox = try JSONDecoder().decode(DropboxMountConfig.self, from: empty)
+        #expect(dropbox.appKey == "")
+        #expect(dropbox.accountLabel == "")
+    }
+
+    /// And the non-OAuth ones are NOT lenient, which is the other half of the
+    /// same decision: a host or a share is not something to default.
+    @Test func aConfigMissingItsHostDoesNotDecode() {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(SFTPMountConfig.self, from: Data(#"{"user":"u"}"#.utf8))
+        }
+    }
+}

--- a/DiskJockeyLibraryTests/OperationLockTests.swift
+++ b/DiskJockeyLibraryTests/OperationLockTests.swift
@@ -1,0 +1,185 @@
+//
+//  OperationLockTests.swift — the cooperative mutex that keeps a verify and
+//  a repair off the same live mount.
+//
+//  WHY THIS ONE MATTERS MORE THAN ITS SIZE SUGGESTS
+//  -----------------------------------------------
+//  This is the whole coordination story between the two entry points that
+//  can reach a mounted volume at once: `startCheck` via fsck_fskit, and
+//  RepairXPCService driven from the host app. A verify reading the journal
+//  while a repair writes commits is the failure it exists to prevent, and
+//  the file says plainly that nothing in the OS enforces it — "the lock is
+//  **cooperative**: every caller must check it". Preemptive alternatives
+//  (unmount, O_EXCL, fcntl(F_SETLK)) are out, because the sandbox forbids
+//  them and the architecture mounts live during fsck.
+//
+//  So the lock is the only thing standing between those two operations, and
+//  it had no tests. In particular nothing exercised the property that makes
+//  it a mutex at all: that under a race, exactly ONE caller acquires.
+//
+//  ONE BEHAVIOUR HERE IS A SHARP EDGE, AND IT IS TESTED AS IT IS SPECIFIED
+//  rather than as it might be preferred. `release()` is documented as
+//  unconditional and is implemented that way, so a caller holding nothing
+//  can clear a holder's lock. That is recorded below as behaviour, not
+//  asserted as correct — a test that pretended otherwise would fail against
+//  the shipped code, and a test that skipped it would leave the sharpest
+//  edge in the file undocumented.
+//
+//  Host-free: no mount, no extension, no XPC.
+//
+
+import Foundation
+import Testing
+@testable import DiskJockeyLibrary
+
+@Suite("OperationLock")
+struct OperationLockTests {
+
+    @Test func aFreshLockIsIdle() {
+        #expect(OperationLock().current == nil)
+    }
+
+    @Test("acquiring from idle succeeds and records the holder",
+          arguments: [FsckOperation.verify, .repair])
+    func acquireFromIdle(op: FsckOperation) {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(op) == nil, "acquiring an idle lock must succeed")
+        #expect(lock.current == op)
+    }
+
+    /// THE REJECTION CARRIES THE CONFLICTING OPERATION, which is the whole
+    /// reason `tryAcquire` returns an optional operation rather than a Bool:
+    /// the caller surfaces it so the user is told *which* work is in flight.
+    @Test func aConflictingAcquireIsRejectedAndNamesTheHolder() {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(.verify) == nil)
+        #expect(lock.tryAcquire(.repair) == .verify,
+                "a rejected acquire must name the operation holding the lock")
+        #expect(lock.current == .verify,
+                "a failed acquire must not overwrite the holder")
+    }
+
+    @Test func theOtherDirectionIsRejectedToo() {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(.repair) == nil)
+        #expect(lock.tryAcquire(.verify) == .repair)
+        #expect(lock.current == .repair)
+    }
+
+    /// NOT RE-ENTRANT, and that is the useful behaviour: a second verify
+    /// starting while the first is still running is exactly the concurrent
+    /// access this lock exists to refuse, and it would be invisible if the
+    /// same operation could acquire twice.
+    @Test("the same operation cannot acquire twice",
+          arguments: [FsckOperation.verify, .repair])
+    func notReentrant(op: FsckOperation) {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(op) == nil)
+        #expect(lock.tryAcquire(op) == op,
+                "a second \(op.rawValue) must be rejected, not silently admitted")
+    }
+
+    @Test func releaseReturnsTheLockToIdleAndItCanBeTakenAgain() {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(.verify) == nil)
+        lock.release()
+        #expect(lock.current == nil)
+        #expect(lock.tryAcquire(.repair) == nil, "a released lock must be available to the other operation")
+        #expect(lock.current == .repair)
+    }
+
+    @Test func releasingAnIdleLockIsHarmless() {
+        let lock = OperationLock()
+        lock.release()
+        lock.release()
+        #expect(lock.current == nil)
+        #expect(lock.tryAcquire(.verify) == nil)
+    }
+
+    /// RECORDED BEHAVIOUR, NOT AN ENDORSEMENT. `release()` takes no
+    /// operation and checks nothing, so whoever calls it clears whatever is
+    /// held. The doc comment says to pair it with a successful `tryAcquire`
+    /// via `defer`; this test says what happens when someone does not, so
+    /// that the next reader finds the edge here rather than in a log.
+    @Test func releaseIsUnconditionalSoANonHolderCanClearIt() {
+        let lock = OperationLock()
+        #expect(lock.tryAcquire(.repair) == nil)
+        // A caller that never acquired anything releases:
+        lock.release()
+        #expect(lock.current == nil,
+                "release() is documented as unconditional; if this now fails, it grew an ownership check and this test should assert that instead")
+    }
+
+    /// THE PROPERTY THAT MAKES IT A MUTEX, and the one nothing tested.
+    /// Under contention exactly one caller may come away holding the lock —
+    /// no matter how the tasks interleave.
+    @Test func underContentionExactlyOneCallerAcquires() async {
+        for _ in 0..<20 {
+            let lock = OperationLock()
+            let winners = await withTaskGroup(of: Bool.self, returning: Int.self) { group in
+                for i in 0..<64 {
+                    group.addTask {
+                        lock.tryAcquire(i.isMultiple(of: 2) ? .verify : .repair) == nil
+                    }
+                }
+                var count = 0
+                for await won in group where won { count += 1 }
+                return count
+            }
+            #expect(winners == 1, "\(winners) callers acquired the same lock")
+            #expect(lock.current != nil, "the winner's hold was lost")
+        }
+    }
+
+    /// And release/acquire churn under contention leaves the lock in a legal
+    /// state rather than wedged — every acquire is paired, so the lock must
+    /// end idle.
+    @Test func pairedAcquireAndReleaseUnderContentionEndsIdle() async {
+        let lock = OperationLock()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<64 {
+                group.addTask {
+                    let op: FsckOperation = i.isMultiple(of: 2) ? .verify : .repair
+                    if lock.tryAcquire(op) == nil {
+                        lock.release()
+                    }
+                }
+            }
+        }
+        #expect(lock.current == nil, "every acquire was released, so the lock must be idle")
+    }
+
+    /// A REFERENCE TYPE ON PURPOSE. The class comment gives the reason:
+    /// `MountedResource` is a struct, and copies of it must share one lock —
+    /// if this were a value type, each copy would get its own and the mutex
+    /// would coordinate nothing.
+    @Test func copiesOfAHolderShareOneLock() {
+        struct Resource { let lock: OperationLock }
+        let original = Resource(lock: OperationLock())
+        let copy = original
+        #expect(original.lock.tryAcquire(.verify) == nil)
+        #expect(copy.lock.current == .verify,
+                "a copied holder sees its own lock; OperationLock must stay a reference type")
+        #expect(copy.lock.tryAcquire(.repair) == .verify)
+    }
+}
+
+@Suite("FsckOperation")
+struct FsckOperationTests {
+
+    /// The raw values reach log lines and rejection messages, so they are a
+    /// surface rather than an implementation detail.
+    @Test func rawValuesAreTheLoggedSpellings() {
+        #expect(FsckOperation.verify.rawValue == "verify")
+        #expect(FsckOperation.repair.rawValue == "repair")
+        #expect(FsckOperation(rawValue: "verify") == .verify)
+        #expect(FsckOperation(rawValue: "repair") == .repair)
+        #expect(FsckOperation(rawValue: "Verify") == nil)
+    }
+
+    @Test func displayNamesAreDistinctAndNonEmpty() {
+        let names = [FsckOperation.verify, .repair].map(\.displayName)
+        #expect(names == ["verify", "repair"])
+        #expect(Set(names).count == names.count)
+    }
+}

--- a/scripts/tests/library-tests-need-no-host.sh
+++ b/scripts/tests/library-tests-need-no-host.sh
@@ -216,14 +216,33 @@ fi
 # which reads as a pass. Only a count sees it. ASSERT THE COMPARISON, NOT THE
 # MESSAGE: the same check written against the words "floor is 85" survives
 # replacing the whole `if` with `if false`.
-case "$run" in
-    *'"$total" -lt 85'*) ok "the executed-case floor compares against 85" ;;
-    *) fail "no live comparison against a case floor: 90 cases ran on 2026-09-10, and a run that executes none of them exits 0 reporting no failures" ;;
-esac
-case "$run" in
-    *"floor is 85"*) ok "and it names itself when it fires" ;;
-    *) fail "the floor fires without saying what it is, so a red run will not explain what it caught" ;;
-esac
+# READ THE FLOOR OUT OF THE COMMAND rather than restating it here. Two copies
+# of a number that has to move with the suite is two things to forget: the
+# first version named 85 twice, so raising the floor after adding tests meant
+# editing the workflow, its message and both halves of this file.
+floor="$(printf '%s' "$run" | grep -oE '\-lt [0-9]+' | head -1 | awk '{print $2}')"
+if [ -n "$floor" ]; then
+    ok "the executed-case floor is a live comparison, against $floor"
+else
+    fail "no live comparison against a case floor: 116 cases ran on 2026-09-10, and a run that executes none of them exits 0 reporting no failures"
+fi
+# AND THE MESSAGE NAMES THE SAME NUMBER THE COMPARISON USES. A floor that
+# fires saying 85 while comparing against 110 sends the next reader to the
+# wrong measurement.
+if [ -n "$floor" ]; then
+    case "$run" in
+        *"floor is $floor"*) ok "and the message it prints names $floor too" ;;
+        *) fail "the floor compares against $floor but does not say so when it fires, so a red run will not explain what it caught" ;;
+    esac
+fi
+# A FLOOR THAT CAN BE LOWERED IS NOT A FLOOR. 90 cases existed on 2026-09-10
+# before anything was added, so a later floor under that would pass the run
+# shape this whole check exists to reject.
+if [ -n "$floor" ] && [ "$floor" -ge 85 ] 2>/dev/null; then
+    ok "and it is at or above the 85 that 2026-09-10's 90 cases justified"
+else
+    fail "the floor is ${floor:-unset}, below the 85 justified by the 90 cases measured on 2026-09-10: a truncated library run reports about that many and would pass"
+fi
 
 # Both frameworks are in this target, and each prints only its own total.
 # Counting one of them silently halves the floor's reach.


### PR DESCRIPTION
Stacked on #159 — that PR built the launch-free gate, this one uses it. Rebase onto `main` after #159 merges.

**90 → 160 cases (+70).** All host-free, so they all run in the ~35-second `Library tests` job. 96 of 196 library symbols were never named in any test when this started.

Three files, chosen because each is a layer whose mistakes are invisible from Swift:

## 1. The eight mount personalities (+26)

Every mistake here fails on the far side of a C ABI, in a Go driver, with no compile error and usually no message:

| what | why nothing caught it |
|---|---|
| `driverType` | says of itself *"DO NOT change these — they're part of the C ABI, not cosmetic"*. A rule in a comment is not a rule anything enforces |
| `mountJSON` keys | read out of `map[string]string` by each driver's `Mount()`. A renamed key is a nil field over there and a dictionary literal over here |
| `StoredMountConfig.scheme` | eight hand-written `case .x: return .x` lines — exactly the shape a copy-paste gets wrong, and getting it wrong routes a mount to the wrong driver |
| value types | Go decodes into `map[string]string`, so a boolean or number fails only at runtime, in another language |

The routing check compares the envelope against the wrapped type's *own static scheme*, and asserts the fixture covers all eight — so it cannot pass having quietly lost a case. Plus documented defaults, every omit-when-empty branch, which key each driver reads its secret from, and awkward secrets surviving encoding (a quote in a password produces a config the Go side cannot parse at all — a JSON error, not an auth error).

**The credential invariant is asserted against the value, not a list of field names**: the secret passed to `mountJSON(password:)` never appears in the persisted form, for all eight. The one that *fails* is **#160** — a refreshed OAuth access token reaches the domain plist in cleartext through `cachedAccessToken` — held with `withKnownIssue`, so the suite stays green while the decision is open and **fails the day it is fixed**.

## 2. OperationLock (+13)

The entire coordination story between the two entry points that can reach a live mount at once. The file states its own stakes: *"the lock is **cooperative**: every caller must check it. Nothing in the OS prevents bypass"* — because unmount, `O_EXCL` and `fcntl(F_SETLK)` are all incompatible with the sandbox.

Nothing exercised the property that makes it a mutex: **64 tasks race for it, twenty times over, and exactly one may come away holding it.** Also that a rejection returns the *conflicting operation* (which is how callers tell the user what's in flight), that a failed acquire doesn't overwrite the holder, that it is not re-entrant, and that struct copies share one lock — the documented reason it's a class.

`release()` is unconditional, so a non-holder can clear a holder's lock. Recorded as specified rather than as preferred, with a note in place saying that if an ownership check is ever added the test should assert *that* instead. Pretending otherwise would fail against shipped code; omitting it would leave the sharpest edge in the file undocumented.

## 3. AppLog (+31)

The largest untested file, and mostly a **format** rather than a behaviour — which breaks quietly, because none of its three consumers are compiled against it: LogTailService routes on `kind`/`fields`/`scope`, the UI enumerates `AppLogScope.all`, and *"backends outside Swift (Rust, Go)"* produce the same NDJSON by hand.

So the format is asserted where it is one: uppercase case-sensitive levels, fractional-second timestamps, and **unset optionals omitted rather than null** — with a line produced *without* them still decoding, which is the contract a non-Swift emitter must meet. `AppLogScope.all` and the constants are maintained separately by hand and `all` is what the UI enumerates, so both directions are checked: a scope missing from it is a scope nobody can toggle.

The derived event message is pinned as **sorted** — dictionary order is undefined, so an unsorted rendering gives a different human-readable line every run for the same event.

`formatEvent` is `private static` and unreachable from a test; it's exercised through `event(kind:fields:)`, which is how every caller reaches it too. Emission is observed through a capturing `AppLogSink` — what that public protocol is for.

### One production change

`NDJSONFileSink` gained a **defaulted** `directory:` parameter. Its default resolves through `containerURL(forSecurityApplicationGroupIdentifier:)`, which returns a real path — measured, `~/Library/Group Containers/…` — even to a process holding no app-group entitlement, so a test cannot steer it by arranging for the container to be absent. The options were to write into the developer's own container, to duplicate the sink's path logic in the test, or to let the caller say where. **Duplicated path logic is the same defect shape as a duplicated implementation: it passes while the real one is wrong.** No production call site changed.

With that the sink is tested for real: one newline-terminated JSON object per record, appended rather than truncated when a respawned extension reopens it, a multi-line message staying **one** record (or every line-splitting reader desyncs), a directory created when absent, and 120 concurrent emits producing 120 whole records.

## The floor

85 → 150, moved once per commit alongside the measurement. The guard reads the floor **out of the command** instead of restating it — two copies of a number that moves with the suite is two things to forget — and asserts the comparison is live, that the printed message names the same number, and that the floor never drops below the 85 the original 90 cases justified. 4 arms on those checks, all with teeth.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm