### PR TITLE
refactor: the EXT4 volume logic builds and tests outside the extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,15 +206,16 @@ jobs:
           # 51 + 65 = 116 with the mount personalities covered, then
           # 51 + 78 = 129 with the operation lock, then 51 + 109 = 160 with
           # AppLog, then 51 + 132 = 183 with the I/O counters, then
-          # 51 + 153 = 204 with the two plist stores. The floor moves up
+          # 51 + 153 = 204 with the two plist stores, then 51 + 178 = 229
+          # once the EXT4 volume logic became reachable. The floor moves up
           # with the suite; it never moves down.
           log="$RUNNER_TEMP/library-output.log"
           xct=$(grep -aoE 'Executed [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           swt=$(grep -aoE 'Test run with [0-9]+ tests' "$log" | grep -oE '[0-9]+' | sort -n | tail -1)
           total=$(( ${xct:-0} + ${swt:-0} ))
-          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 190)"
-          if [ "$total" -lt 190 ]; then
-              echo "::error::only $total library cases executed, floor is 190 — 204 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
+          echo "library cases executed: $total = ${xct:-0} XCTest + ${swt:-0} swift-testing (floor 215)"
+          if [ "$total" -lt 215 ]; then
+              echo "::error::only $total library cases executed, floor is 215 — 229 ran on 2026-09-10, and a run that executes less than that has stopped early rather than passed (diskjockey#139)"
               exit 1
           fi
           exit "$rc"

--- a/DiskJockey.xcodeproj/project.pbxproj
+++ b/DiskJockey.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		EEB09075D1BC8F5CE8260819 /* FSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 124211CC79A8C8CFAF453134 /* FSKit.framework */; };
 		F3B991C06CBEFBF2B3B657B4 /* FSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA52B7280D02F6F8D737A4DF /* FSKit.framework */; };
 		F6FF4AC950047E0FD59AE139 /* EXT4Volume.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01E35D6B49C797E269EAC45 /* EXT4Volume.swift */; };
+		D0E1C0CCAAAA00000000000B /* EXT4Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E1C0CCAAAA00000000000A /* EXT4Log.swift */; };
+		D0E1C0CCAAAA00000000000D /* EXT4Watchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E1C0CCAAAA00000000000C /* EXT4Watchdog.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -575,6 +577,8 @@
 		425C54678D107E1DAA3C3C5D /* ErofsVolume.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErofsVolume.swift; sourceTree = "<group>"; };
 		429A2D79E6781D9640B98F5E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		45CFCF77C56D3305934A9BE2 /* EXT4FileSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EXT4FileSystem.swift; sourceTree = "<group>"; };
+		D0E1C0CCAAAA00000000000A /* EXT4Log.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EXT4Log.swift; sourceTree = "<group>"; };
+		D0E1C0CCAAAA00000000000C /* EXT4Watchdog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EXT4Watchdog.swift; sourceTree = "<group>"; };
 		501F02432E058BAF009EBB59 /* DiskJockeyFileProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DiskJockeyFileProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		501F02452E058BAF009EBB59 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		501F025D2E058C51009EBB59 /* DiskJockeyLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DiskJockeyLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1438,6 +1442,8 @@
 				A36068023A9CD2AD5B72E9E6 /* DiskJockeyEXT4.entitlements */,
 				5B97F7050B209EAC37A411F7 /* DiskJockeyEXT4-Bridging-Header.h */,
 				FDE7234E054C739FC42CCB24 /* RepairXPCService.swift */,
+				D0E1C0CCAAAA00000000000A /* EXT4Log.swift */,
+				D0E1C0CCAAAA00000000000C /* EXT4Watchdog.swift */,
 			);
 			path = DiskJockeyEXT4;
 			sourceTree = SOURCE_ROOT;
@@ -2114,6 +2120,8 @@
 				D9CECEF266A909EB810942A6 /* EXT4Backend.swift in Sources */,
 				4DAE78E7034E84C6B08A0B2B /* FileSystemBackend.swift in Sources */,
 				72A0723E43EC6118C3156685 /* RepairXPCService.swift in Sources */,
+				D0E1C0CCAAAA00000000000B /* EXT4Log.swift in Sources */,
+				D0E1C0CCAAAA00000000000D /* EXT4Watchdog.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DiskJockeyEXT4/EXT4Backend.swift
+++ b/DiskJockeyEXT4/EXT4Backend.swift
@@ -375,6 +375,10 @@ final class EXT4Backend: FileSystemBackend {
         return Int32(fs_ext4_last_errno())
     }
 
+    func lastErrorMessage() -> String {
+        return fs_ext4_last_error().flatMap { String(cString: $0) } ?? "(no error set)"
+    }
+
     /// Run journal replay if the volume's on-disk journal is dirty. Idempotent
     /// — safe to call on a clean volume. Returns true on success (or
     /// already-clean), false on failure.

--- a/DiskJockeyEXT4/EXT4FileSystem.swift
+++ b/DiskJockeyEXT4/EXT4FileSystem.swift
@@ -28,10 +28,6 @@ import Foundation
 import os
 import DiskJockeyLibrary
 
-/// Single logging surface — fans out to os_log (system) + NDJSON file
-/// (tailed by host app UI) via AppLog's configured sinks.
-let log = AppLog(source: "ext4", sinks: AppLog.defaultSinks(source: "ext4"))
-
 @objc(EXT4FileSystem)
 final class EXT4FileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
 
@@ -64,59 +60,11 @@ final class EXT4FileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
     }
     static let mountedResources = MountedResourceRegistry<MountedResource>()
 
-    /// Shared parent-death watchdog for fsck / repair / format. See
-    /// `DetachedOperationWatchdog` for the rationale. The `onExpire`
-    /// closure logs + exits the process so `storagekitd` respawns the
-    /// appex cleanly.
-    static let watchdog: DetachedOperationWatchdog = {
-        // Fix D — stuck-progress monitor. If `heartbeat()` doesn't
-        // fire for `stuckDeadline` seconds while at least one op
-        // is in flight, the op is presumed wedged (e.g. fsck stuck
-        // on a corrupted inode loop) and the appex `exit`s the
-        // same way deactivate-watchdog does. Default 60 s,
-        // overridable via the App Group default
-        // `ext4StuckDeadlineSeconds` (read once at static-let init
-        // time, same one-shot pattern as the deactivate side's
-        // `ext4WatchdogDeadlineSeconds` override).
-        let defaults = UserDefaults(suiteName: AppLog.groupIdentifier)
-        let configuredStuck = defaults?.double(forKey: "ext4StuckDeadlineSeconds") ?? 0
-        let stuckDeadline: TimeInterval = configuredStuck > 0 ? configuredStuck : 60
-        return DetachedOperationWatchdog(
-            label: "ext4",
-            defaultDeadline: 30,
-            stuckDeadline: stuckDeadline
-        ) { pending, deadline in
-            log.error(
-                "watchdog: \(pending) op(s) still pending after \(Int(deadline))s — exiting (EX_TEMPFAIL) so storagekitd respawns",
-                scope: AppLogScope.lifecycle
-            )
-            exit(Int32(EX_TEMPFAIL))
-        }
-    }()
-
-    /// Thin wrappers preserved so call sites (this file, RepairXPCService)
-    /// don't need to know about the underlying class.
-    static func enterOperation() { watchdog.enter() }
-    static func exitOperation() { watchdog.leave() }
-
-    /// Called from `EXT4Volume.deactivate` after the volume's normal
-    /// teardown. Consults the App Group default
-    /// `ext4WatchdogDeadlineSeconds` to allow runtime extension for
-    /// slow-disk diagnostics without recompiling.
-    static func scheduleWatchdogIfNeeded() {
-        let defaults = UserDefaults(suiteName: AppLog.groupIdentifier)
-        let configured = defaults?.double(forKey: "ext4WatchdogDeadlineSeconds") ?? 0
-        let deadline: TimeInterval? = configured > 0 ? configured : nil
-        let pending = watchdog.pending
-        let scheduled = watchdog.scheduleExpiryIfNeeded(deadline: deadline)
-        if scheduled {
-            let effective = deadline ?? watchdog.defaultDeadline
-            log.warn(
-                "deactivate: \(pending) detached op(s) still in flight; watchdog will exit appex in \(Int(effective))s if not done",
-                scope: AppLogScope.lifecycle
-            )
-        }
-    }
+    /// Thin wrappers preserved so call sites (this file, EXT4Maintenance,
+    /// RepairXPCService) do not need to know where the watchdog lives.
+    /// See EXT4Watchdog for the watchdog itself.
+    static func enterOperation() { EXT4Watchdog.enter() }
+    static func exitOperation() { EXT4Watchdog.leave() }
 
     override init() {
         super.init()

--- a/DiskJockeyEXT4/EXT4Log.swift
+++ b/DiskJockeyEXT4/EXT4Log.swift
@@ -1,0 +1,23 @@
+//
+// EXT4Log.swift — the extension's logging surface, in a file of its own.
+//
+// This was a file-scope `let` at the top of EXT4FileSystem.swift. It moved
+// here so that code which only needs to LOG does not also need the
+// principal class: `EXT4Volume.swift` uses `log` eighteen times and
+// referenced nothing else from that file except one watchdog call, so
+// leaving the global there made 903 lines of volume implementation
+// inseparable from the appex's entry point.
+//
+// The failure mode was memorable, too. Swift does not report an unresolved
+// `log` here — `log` also names the C math function, so every `log.info(…)`
+// compiled as a member lookup on a function reference and produced
+// "reference to member 'info' cannot be resolved without a contextual
+// type", 36 times, naming neither the global nor the file it lives in.
+//
+
+import Foundation
+import DiskJockeyLibrary
+
+/// Single logging surface — fans out to os_log (system) + NDJSON file
+/// (tailed by host app UI) via AppLog's configured sinks.
+let log = AppLog(source: "ext4", sinks: AppLog.defaultSinks(source: "ext4"))

--- a/DiskJockeyEXT4/EXT4Maintenance.swift
+++ b/DiskJockeyEXT4/EXT4Maintenance.swift
@@ -136,7 +136,7 @@ extension EXT4FileSystem: FSManageableResourceMaintenanceOperations {
                     // (called on every Rust progress callback) so a
                     // long quiet phase doesn't accidentally trip
                     // `stuckDeadline`.
-                    Self.watchdog.heartbeat()
+                    EXT4Watchdog.shared.heartbeat()
                     // Throttle. Phase change always emits (so the user
                     // sees the pipeline advance) and the first emit
                     // bypasses the time gate (so the progress bar

--- a/DiskJockeyEXT4/EXT4Volume.swift
+++ b/DiskJockeyEXT4/EXT4Volume.swift
@@ -185,8 +185,12 @@ final class EXT4Volume: FSVolume,
     ///
     /// `parentInode` is `nil` only for the root directory — its parent
     /// is `FSItemIDParentOfRoot` (1), set inside the attribute builder.
-    private func item(forID fileID: UInt64, path: String,
-                      parentInode: UInt32?) -> EXT4Item {
+    /// `internal`, not `private`, so DiskJockeyEXT4CoreTests can drive the
+    /// real cache. The three failure modes above were previously covered by
+    /// a hand-written mirror of this method in the app-hosted suite, which
+    /// could pass while this one was wrong.
+    func item(forID fileID: UInt64, path: String,
+              parentInode: UInt32?) -> EXT4Item {
         items.getOrCreate(
             id: fileID,
             validate: { $0.path == path && $0.parentInode == parentInode },
@@ -282,9 +286,9 @@ final class EXT4Volume: FSVolume,
         // running in a detached Task, schedule a hard exit so the
         // appex doesn't become a CPU-burning zombie that wedges
         // storagekitd for every other StorageKit consumer on the Mac.
-        // No-op when nothing is in flight; see EXT4FileSystem for the
+        // No-op when nothing is in flight; see EXT4Watchdog for the
         // counter + deadline logic.
-        EXT4FileSystem.scheduleWatchdogIfNeeded()
+        EXT4Watchdog.scheduleExpiryIfNeeded()
     }
 
     // MARK: - File attributes (async)
@@ -547,7 +551,7 @@ final class EXT4Volume: FSVolume,
                                   length: writeLen)
         }
         if written < 0 {
-            let msg = fs_ext4_last_error().flatMap { String(cString: $0) } ?? "(no error set)"
+            let msg = backend.lastErrorMessage()
             log.error("write: backend.pwrite rc=\(written) path=\"\(ext4Item.path)\" offset=\(writeOffset) length=\(writeLen) errno=\(backend.lastErrno()) — \(msg)", scope: AppLogScope.io)
             throw Self.posixError(from: backend)
         }
@@ -843,8 +847,9 @@ final class EXT4Volume: FSVolume,
     /// `FSVolumeConnector.getStandardItemAttributesForItem` reject the
     /// reply with errno 2 (ENOENT), which surfaces to userspace as
     /// "file vanished after save". See
-    /// `DiskJockeyTests/EXT4AttributeMaskTests.swift` for the regression
-    /// fixture and the FSKit bit layout.
+    /// `DiskJockeyEXT4CoreTests/EXT4VolumeAttributesTests.swift`, which
+    /// exercises this method itself; `DiskJockeyTests/EXT4AttributeMaskTests`
+    /// predates that and tests a hand-kept copy of this body.
     ///
     /// `parentInode` is `nil` only for the root directory — its parent
     /// is the FSKit-defined `FSItemIDParentOfRoot` (1).

--- a/DiskJockeyEXT4/EXT4Watchdog.swift
+++ b/DiskJockeyEXT4/EXT4Watchdog.swift
@@ -1,0 +1,72 @@
+//
+// EXT4Watchdog.swift — the parent-death / stuck-progress watchdog for this
+// extension, lifted out of the principal class.
+//
+// It was `EXT4FileSystem.watchdog` plus three statics beside it. Nothing in
+// it referenced the class: it reads two App Group defaults, builds a
+// `DetachedOperationWatchdog`, and logs. What it DID do, by living there,
+// was make `EXT4Volume.swift` depend on the appex's entry point for a
+// single call — `EXT4FileSystem.scheduleWatchdogIfNeeded()` — which is the
+// only reason 903 lines of volume implementation could not be compiled or
+// tested outside the extension bundle.
+//
+// `EXT4FileSystem` keeps `enterOperation` / `exitOperation` as forwarders,
+// so the call sites in EXT4Maintenance and RepairXPCService are unchanged.
+//
+
+import Foundation
+import DiskJockeyLibrary
+
+enum EXT4Watchdog {
+    /// Shared parent-death watchdog for fsck / repair / format. See
+    /// `DetachedOperationWatchdog` for the rationale. The `onExpire`
+    /// closure logs + exits the process so `storagekitd` respawns the
+    /// appex cleanly. Was `EXT4FileSystem.watchdog`.
+    static let shared: DetachedOperationWatchdog = {
+        // Fix D — stuck-progress monitor. If `heartbeat()` doesn't
+        // fire for `stuckDeadline` seconds while at least one op
+        // is in flight, the op is presumed wedged (e.g. fsck stuck
+        // on a corrupted inode loop) and the appex `exit`s the
+        // same way deactivate-watchdog does. Default 60 s,
+        // overridable via the App Group default
+        // `ext4StuckDeadlineSeconds` (read once at static-let init
+        // time, same one-shot pattern as the deactivate side's
+        // `ext4WatchdogDeadlineSeconds` override).
+        let defaults = UserDefaults(suiteName: AppLog.groupIdentifier)
+        let configuredStuck = defaults?.double(forKey: "ext4StuckDeadlineSeconds") ?? 0
+        let stuckDeadline: TimeInterval = configuredStuck > 0 ? configuredStuck : 60
+        return DetachedOperationWatchdog(
+            label: "ext4",
+            defaultDeadline: 30,
+            stuckDeadline: stuckDeadline
+        ) { pending, deadline in
+            log.error(
+                "watchdog: \(pending) op(s) still pending after \(Int(deadline))s — exiting (EX_TEMPFAIL) so storagekitd respawns",
+                scope: AppLogScope.lifecycle
+            )
+            exit(Int32(EX_TEMPFAIL))
+        }
+    }()
+
+    static func enter() { shared.enter() }
+    static func leave() { shared.leave() }
+
+    /// Called from `EXT4Volume.deactivate` after the volume's normal
+    /// teardown. Consults the App Group default
+    /// `ext4WatchdogDeadlineSeconds` to allow runtime extension for
+    /// slow-disk diagnostics without recompiling.
+    static func scheduleExpiryIfNeeded() {
+        let defaults = UserDefaults(suiteName: AppLog.groupIdentifier)
+        let configured = defaults?.double(forKey: "ext4WatchdogDeadlineSeconds") ?? 0
+        let deadline: TimeInterval? = configured > 0 ? configured : nil
+        let pending = shared.pending
+        let scheduled = shared.scheduleExpiryIfNeeded(deadline: deadline)
+        if scheduled {
+            let effective = deadline ?? shared.defaultDeadline
+            log.warn(
+                "deactivate: \(pending) detached op(s) still in flight; watchdog will exit appex in \(Int(effective))s if not done",
+                scope: AppLogScope.lifecycle
+            )
+        }
+    }
+}

--- a/DiskJockeyEXT4/FileSystemBackend.swift
+++ b/DiskJockeyEXT4/FileSystemBackend.swift
@@ -184,6 +184,17 @@ protocol FileSystemBackend: AnyObject {
     /// Returns 0 if the last call succeeded.
     func lastErrno() -> Int32
 
+    /// The driver's last error message, or a stand-in when it set none.
+    ///
+    /// A COMPANION TO `lastErrno`, AND THE REASON IT IS ON THE PROTOCOL:
+    /// the volume used to read this straight out of the C ABI with
+    /// `fs_ext4_last_error()`, which was the ONLY C reference in 903 lines
+    /// of otherwise pure Swift — enough on its own to make the whole file
+    /// need the Rust static library to compile, and so to make it
+    /// untestable without one. The conforming type already owns the C
+    /// boundary; this is the one call that had leaked past it.
+    func lastErrorMessage() -> String
+
     /// Replay the on-disk journal if the volume is dirty. Idempotent —
     /// safe to call on a clean volume. Returns true on success (or
     /// already-clean), false on failure.

--- a/DiskJockeyEXT4/RepairXPCService.swift
+++ b/DiskJockeyEXT4/RepairXPCService.swift
@@ -135,7 +135,7 @@ final class RepairXPCService: NSObject {
                 // watchdog clock so a repair that's still making
                 // forward progress can't trip the stuck-deadline
                 // even though the log emission below is throttled.
-                EXT4FileSystem.watchdog.heartbeat()
+                EXT4Watchdog.shared.heartbeat()
                 // Throttle. Only two carve-outs that bypass the time
                 // gate: a phase CHANGE (so the user sees the
                 // pipeline advance) and the FIRST emit (so the

--- a/DiskJockeyEXT4CoreTests/EXT4ItemCacheTests.swift
+++ b/DiskJockeyEXT4CoreTests/EXT4ItemCacheTests.swift
@@ -1,0 +1,171 @@
+//
+//  EXT4ItemCacheTests.swift — the REAL per-volume item cache.
+//
+//  `DiskJockeyTests/EXT4ItemCacheTests.swift` covers this with a
+//  `MirrorItem` struct and a hand-written copy of the get-or-create-or-
+//  replace rule. This file drives `EXT4Volume.item(forID:path:parentInode:)`
+//  itself, on a real EXT4Volume with a stub backend, so the three failure
+//  modes the method documents are asserted against the code that ships.
+//
+//  WHY IDENTITY IS THE ASSERTION. The cache exists so that the same on-disk
+//  inode reached through two operations yields the same FSItem instance —
+//  FSKit compares items by identity. So `===` is the property under test,
+//  not equality of fields: two distinct objects with matching paths would
+//  satisfy an `==` check and still break the kernel's view.
+//
+//  Host-free: no mount, no Rust, no launch.
+//
+
+import Foundation
+import FSKit
+import Testing
+@testable import DiskJockeyEXT4Core
+@testable import DiskJockeyLibrary
+
+private func makeVolume() -> EXT4Volume {
+    EXT4Volume(volumeID: FSVolume.Identifier(uuid: UUID()),
+               volumeName: FSFileName(string: "test"),
+               backend: CacheStubBackend(),
+               requiresJournalReplay: false,
+               stats: IOStatsCollector(label: "test", emit: { _ in }),
+               opLock: OperationLock())
+}
+
+@Suite("EXT4Volume item cache")
+struct EXT4ItemCacheRealTests {
+
+    /// THE REASON THE CACHE EXISTS. Same inode, same path, same parent — the
+    /// caller must get the identical object back, or FSKit sees two items
+    /// for one file.
+    @Test func thesameInodeReachedTwiceYieldsTheIdenticalObject() {
+        let volume = makeVolume()
+        let first = volume.item(forID: 42, path: "/dir/file", parentInode: 2)
+        let second = volume.item(forID: 42, path: "/dir/file", parentInode: 2)
+        #expect(first === second, "the cache returned a second object for one inode")
+        #expect(first.inode == 42)
+        #expect(first.path == "/dir/file")
+        #expect(first.parentInode == 2)
+    }
+
+    @Test func differentInodesAreDifferentItems() {
+        let volume = makeVolume()
+        let a = volume.item(forID: 1, path: "/a", parentInode: 2)
+        let b = volume.item(forID: 2, path: "/b", parentInode: 2)
+        #expect(a !== b)
+        #expect(a.path == "/a")
+        #expect(b.path == "/b")
+    }
+
+    /// FAILURE MODE 1: inode reuse after unlink + create. Same inode number,
+    /// new path. Returning the cached item means every backend call runs
+    /// against the deleted path and comes back ENOENT — the file the user
+    /// just created reads as missing.
+    @Test func anInodeReusedAtANewPathReplacesTheCachedItem() {
+        let volume = makeVolume()
+        let stale = volume.item(forID: 99, path: "/old-name", parentInode: 2)
+        let fresh = volume.item(forID: 99, path: "/new-name", parentInode: 2)
+        #expect(stale !== fresh, "the cache handed back the item for the deleted path")
+        #expect(fresh.path == "/new-name")
+        // And the replacement sticks, rather than the cache flapping.
+        #expect(volume.item(forID: 99, path: "/new-name", parentInode: 2) === fresh)
+    }
+
+    /// FAILURE MODE 2: hard links. One inode, two legitimate paths, both
+    /// live at once. Each lookup must describe the path it was asked about.
+    @Test func aHardLinksSecondPathDoesNotInheritTheFirstsItem() {
+        let volume = makeVolume()
+        let first = volume.item(forID: 7, path: "/link-a", parentInode: 2)
+        let second = volume.item(forID: 7, path: "/link-b", parentInode: 2)
+        #expect(first !== second)
+        #expect(second.path == "/link-b",
+                "a backend op on this item would have run against the other link's path")
+    }
+
+    /// FAILURE MODE 3: the driver reusing one inode for several dirents
+    /// (rust-fs-ext4 Bug A). Same inode, same name shape, DIFFERENT parent —
+    /// which is the case a path-only comparison would miss. Finder drew the
+    /// rename UI on `.fseventsd` because of this.
+    @Test func thesamePathUnderADifferentParentIsADifferentItem() {
+        let volume = makeVolume()
+        let underRoot = volume.item(forID: 500, path: "/untitled folder", parentInode: 2)
+        let underDir = volume.item(forID: 500, path: "/untitled folder", parentInode: 77)
+        #expect(underRoot !== underDir,
+                "the cache compared only the path, so two dirents sharing an inode collided")
+        #expect(underDir.parentInode == 77)
+    }
+
+    /// The root directory is the only item with a nil parent, so nil and a
+    /// value must not compare equal — otherwise root and a child sharing an
+    /// inode number would alias.
+    @Test func aNilParentIsDistinctFromAnyRealParent() {
+        let volume = makeVolume()
+        let root = volume.item(forID: 2, path: "/", parentInode: nil)
+        let notRoot = volume.item(forID: 2, path: "/", parentInode: 2)
+        #expect(root !== notRoot, "a nil parent and a real parent must not compare equal")
+        #expect(root.parentInode == nil)
+        #expect(notRoot.parentInode == 2)
+        // Asking with the nil context again replaces once more: the entry
+        // always describes the context the caller asked about, which is the
+        // whole rule. It is a fresh object, not the original `root`.
+        let rootAgain = volume.item(forID: 2, path: "/", parentInode: nil)
+        #expect(rootAgain.parentInode == nil)
+        #expect(rootAgain !== notRoot)
+    }
+
+    /// Caches are per volume. Two volumes must not share items, or unmounting
+    /// one would hand stale objects to the other.
+    @Test func twoVolumesDoNotShareACache() {
+        let a = makeVolume(), b = makeVolume()
+        let itemA = a.item(forID: 1, path: "/same", parentInode: 2)
+        let itemB = b.item(forID: 1, path: "/same", parentInode: 2)
+        #expect(itemA !== itemB, "the item cache is per volume, not global")
+    }
+
+    /// The hot path is called from whatever thread FSKit is on, and the
+    /// cache's own guarantee is that one inode yields one object. Under
+    /// contention that has to keep holding.
+    @Test func concurrentLookupsOfOneInodeAgreeOnOneObject() async {
+        let volume = makeVolume()
+        let objects = await withTaskGroup(of: ObjectIdentifier.self, returning: Set<ObjectIdentifier>.self) { group in
+            for _ in 0..<64 {
+                group.addTask { ObjectIdentifier(volume.item(forID: 5, path: "/x", parentInode: 2)) }
+            }
+            var seen: Set<ObjectIdentifier> = []
+            for await id in group { seen.insert(id) }
+            return seen
+        }
+        #expect(objects.count == 1, "\(objects.count) distinct objects for one inode under contention")
+    }
+}
+
+/// Minimal conformer; these tests never reach the backend.
+private final class CacheStubBackend: FileSystemBackend {
+    func lastErrno() -> Int32 { 0 }
+    func lastErrorMessage() -> String { "(stub)" }
+    func volumeInfo() -> BackendVolumeInfo { unreachable() }
+    func shutdown() {}
+    func stat(path: String) -> BackendFileAttributes? { unreachable() }
+    func readDirectory(path: String) -> [BackendDirectoryEntry]? { unreachable() }
+    func readFile(path: String, offset: UInt64, length: UInt64,
+                  buffer: UnsafeMutableRawPointer) -> Int64 { unreachable() }
+    func readSymlink(path: String) -> String? { unreachable() }
+    func createFile(path: String, mode: UInt16) -> Bool { unreachable() }
+    func writeFile(path: String, data: UnsafeRawPointer, length: UInt64) -> Int64 { unreachable() }
+    func pwrite(path: String, offset: UInt64,
+                data: UnsafeRawPointer, length: UInt64) -> Int64 { unreachable() }
+    func unlink(path: String) -> Bool { unreachable() }
+    func rename(src: String, dst: String) -> Bool { unreachable() }
+    func mkdir(path: String, mode: UInt16) -> Bool { unreachable() }
+    func rmdir(path: String) -> Bool { unreachable() }
+    func truncate(path: String, size: UInt64) -> Bool { unreachable() }
+    func chmod(path: String, mode: UInt16) -> Bool { unreachable() }
+    func chown(path: String, uid: UInt32?, gid: UInt32?) -> Bool { unreachable() }
+    func symlink(target: String, linkpath: String) -> Bool { unreachable() }
+    func link(src: String, dst: String) -> Bool { unreachable() }
+    func utimens(path: String, atime: timespec?, mtime: timespec?) -> Bool { unreachable() }
+    func flush() -> Bool { unreachable() }
+
+    private func unreachable(_ function: String = #function) -> Never {
+        fatalError("CacheStubBackend.\(function) was called; these tests do not reach the backend")
+    }
+}

--- a/DiskJockeyEXT4CoreTests/EXT4VolumeAttributesTests.swift
+++ b/DiskJockeyEXT4CoreTests/EXT4VolumeAttributesTests.swift
@@ -1,0 +1,280 @@
+//
+//  EXT4VolumeAttributesTests.swift — the REAL EXT4 attribute conversion and
+//  item cache, not a copy of them.
+//
+//  WHAT THIS REPLACES, AND WHY IT MATTERS
+//  --------------------------------------
+//  `DiskJockeyTests/EXT4AttributeMaskTests.swift` and
+//  `EXT4ItemCacheTests.swift` are 13 cases that test hand-written MIRRORS of
+//  this code. They say so themselves:
+//
+//      // ----- begin mirror of EXT4Volume.swift attributes(from:parentInode:) -----
+//      // UPDATE `FSKitAttributesMirror.populate(...)` BELOW to match. The
+//      // protocol mirrors with hand-kept fidelity.
+//
+//  A mirror passes while the original is wrong, which is the same defect
+//  shape as a check whose output does not depend on what it is meant to
+//  detect. They were written that way for a real reason — an app extension
+//  is a `.appex` and cannot be imported by any test target, so the code
+//  under test was unreachable.
+//
+//  It is reachable now. `EXT4Volume.swift`, `FileSystemBackend.swift`,
+//  `EXT4Watchdog.swift` and `EXT4Log.swift` build as `DiskJockeyEXT4Core`,
+//  because exactly three couplings held 903 lines of volume logic inside the
+//  bundle: a file-scope `log`, one call to
+//  `EXT4FileSystem.scheduleWatchdogIfNeeded()`, and one call to
+//  `fs_ext4_last_error()`. None of them were about the volume.
+//
+//  This file therefore asserts against `EXT4Volume.attributes(from:)`
+//  itself. Nothing here is a copy of the production body; where an expected
+//  value is spelled out it is spelled out from the FSKit contract or the
+//  ext4 on-disk meaning, not from the code beside it.
+//
+//  Host-free: no app, no extension bundle, no Rust, no C, nothing launched.
+//
+
+import Foundation
+import FSKit
+import Testing
+@testable import DiskJockeyEXT4Core
+@testable import DiskJockeyLibrary
+
+// MARK: - Fixtures
+
+/// A backend that answers only what the code under test asks of it. The
+/// protocol is large; the two statics tested here touch `lastErrno()` and
+/// `lastErrorMessage()` and nothing else, so the rest traps rather than
+/// returning a plausible lie.
+private final class StubBackend: FileSystemBackend {
+    var errno: Int32 = 0
+    var message: String = "(stub)"
+
+    func lastErrno() -> Int32 { errno }
+    func lastErrorMessage() -> String { message }
+
+    // Everything below is out of scope for these tests. Failing loudly beats
+    // returning a default that lets a test pass for the wrong reason.
+    func volumeInfo() -> BackendVolumeInfo { unreachable() }
+    func shutdown() { unreachable() }
+    func stat(path: String) -> BackendFileAttributes? { unreachable() }
+    func readDirectory(path: String) -> [BackendDirectoryEntry]? { unreachable() }
+    func readFile(path: String, offset: UInt64, length: UInt64,
+                  buffer: UnsafeMutableRawPointer) -> Int64 { unreachable() }
+    func readSymlink(path: String) -> String? { unreachable() }
+    func createFile(path: String, mode: UInt16) -> Bool { unreachable() }
+    func writeFile(path: String, data: UnsafeRawPointer, length: UInt64) -> Int64 { unreachable() }
+    func pwrite(path: String, offset: UInt64,
+                data: UnsafeRawPointer, length: UInt64) -> Int64 { unreachable() }
+    func unlink(path: String) -> Bool { unreachable() }
+    func rename(src: String, dst: String) -> Bool { unreachable() }
+    func mkdir(path: String, mode: UInt16) -> Bool { unreachable() }
+    func rmdir(path: String) -> Bool { unreachable() }
+    func truncate(path: String, size: UInt64) -> Bool { unreachable() }
+    func chmod(path: String, mode: UInt16) -> Bool { unreachable() }
+    func chown(path: String, uid: UInt32?, gid: UInt32?) -> Bool { unreachable() }
+    func symlink(target: String, linkpath: String) -> Bool { unreachable() }
+    func link(src: String, dst: String) -> Bool { unreachable() }
+    func utimens(path: String, atime: timespec?, mtime: timespec?) -> Bool { unreachable() }
+    func flush() -> Bool { unreachable() }
+
+    private func unreachable(_ function: String = #function) -> Never {
+        fatalError("StubBackend.\(function) was called; these tests are not meant to reach the backend")
+    }
+}
+
+/// A plausible stat result. Every field is distinct so a mis-assignment
+/// between two of them cannot pass.
+private func stat(type: BackendFileType = .file,
+                  fileID: UInt64 = 12,
+                  mode: UInt16 = 0o644,
+                  uid: UInt32 = 501,
+                  gid: UInt32 = 20,
+                  size: UInt64 = 4096,
+                  linkCount: UInt16 = 1,
+                  atime: Int64 = 1_700_000_001,
+                  mtime: Int64 = 1_700_000_002,
+                  ctime: Int64 = 1_700_000_003,
+                  crtime: Int64 = 1_700_000_004) -> BackendFileAttributes {
+    BackendFileAttributes(fileID: fileID, fileType: type, mode: mode, uid: uid, gid: gid,
+                          size: size, linkCount: linkCount,
+                          atime: atime, mtime: mtime, ctime: ctime, crtime: crtime)
+}
+
+// MARK: - The conversion
+
+@Suite("EXT4Volume.attributes(from:parentInode:)")
+struct EXT4AttributeConversionTests {
+
+    /// EVERY FIELD, DISTINCT VALUES. The defect this conversion was written
+    /// for was a MISSING attribute — FSKit validates the bit set of what a
+    /// volume returns and turns an incomplete reply into ENOENT, which
+    /// surfaces as "the file I just saved has vanished". A field left unset
+    /// and a field set from the wrong source look identical from outside, so
+    /// each input here is a different number.
+    @Test func everyFieldIsPopulatedFromItsOwnSource() {
+        let attrs = EXT4Volume.attributes(from: stat(), parentInode: 2)
+        #expect(attrs.type == .file)
+        #expect(attrs.mode == 0o644)
+        #expect(attrs.uid == 501)
+        #expect(attrs.gid == 20)
+        #expect(attrs.size == 4096)
+        #expect(attrs.linkCount == 1)
+        #expect(attrs.allocSize == 4096)
+        #expect(attrs.accessTime.tv_sec == 1_700_000_001)
+        #expect(attrs.modifyTime.tv_sec == 1_700_000_002)
+        #expect(attrs.changeTime.tv_sec == 1_700_000_003)
+        #expect(attrs.birthTime.tv_sec == 1_700_000_004)
+        #expect(attrs.fileID.rawValue == 12)
+        #expect(attrs.parentID.rawValue == 2)
+    }
+
+    /// ext4's `i_crtime` IS the birth time. It used to be routed into
+    /// `addedTime`, an HFS+/APFS concept meaning "when this dirent was added
+    /// to its current parent" — which left FSKit's required birthTime bit
+    /// unset and produced the incomplete-mask ENOENT.
+    @Test func crtimeBecomesBirthTimeAndNotAddedTime() {
+        let attrs = EXT4Volume.attributes(from: stat(crtime: 999_000), parentInode: 2)
+        #expect(attrs.birthTime.tv_sec == 999_000)
+        #expect(attrs.addedTime.tv_sec != 999_000,
+                "crtime is the birth time; addedTime is a different concept and must not be where it lands")
+    }
+
+    /// `flags = 0` is deliberate and load-bearing: the FFI does not surface
+    /// ext4's i_flags yet, and setting it to zero is what marks the bit
+    /// VALID so FSKit accepts the reply. Leaving it unset was part of the
+    /// incomplete mask.
+    @Test func flagsAreSetToZeroRatherThanLeftUnset() {
+        #expect(EXT4Volume.attributes(from: stat(), parentInode: 2).flags == 0)
+    }
+
+    /// Only the permission bits reach `mode`. ext4 packs the file type into
+    /// the top bits of the same field, and passing those through would make
+    /// a directory's mode read as 0o40755.
+    @Test func modeCarriesOnlyThePermissionBits() {
+        let attrs = EXT4Volume.attributes(from: stat(type: .directory, mode: 0o40755), parentInode: 2)
+        #expect(attrs.mode == 0o755, "the S_IFDIR bits leaked into mode")
+        #expect(attrs.type == .directory, "and the type still has to be right")
+    }
+
+    @Test func setuidAndStickyBitsSurvive() {
+        // 0o7777 is the mask, so all three of setuid/setgid/sticky are kept.
+        #expect(EXT4Volume.attributes(from: stat(mode: 0o104755), parentInode: 2).mode == 0o4755)
+        #expect(EXT4Volume.attributes(from: stat(mode: 0o41777), parentInode: 2).mode == 0o1777)
+    }
+
+    /// THE ROOT DIRECTORY IS THE ONLY CASE WITH NO PARENT, and FSKit defines
+    /// its parent as the sentinel 1 (`FSItemIDParentOfRoot`). A nil that
+    /// arrived as 0 would be an invalid identifier and the assignment would
+    /// silently not happen.
+    @Test func aNilParentBecomesTheFSKitRootSentinel() {
+        let attrs = EXT4Volume.attributes(from: stat(fileID: 2), parentInode: nil)
+        #expect(attrs.parentID.rawValue == 1,
+                "root's parent must be FSItemIDParentOfRoot (1), not 0 and not absent")
+    }
+
+    @Test("every backend file type maps to its FSKit counterpart",
+          arguments: [(BackendFileType.file, FSItem.ItemType.file),
+                      (.directory, .directory),
+                      (.symlink, .symlink),
+                      (.charDevice, .charDevice),
+                      (.blockDevice, .blockDevice),
+                      (.fifo, .fifo),
+                      (.socket, .socket)])
+    func fileTypes(backend: BackendFileType, expected: FSItem.ItemType) {
+        #expect(EXT4Volume.attributes(from: stat(type: backend), parentInode: 2).type == expected)
+    }
+
+    /// `.unknown` deliberately becomes `.file` rather than propagating an
+    /// unknown type into FSKit, which has no representation for one.
+    @Test func anUnknownTypeIsReportedAsAFile() {
+        #expect(EXT4Volume.attributes(from: stat(type: .unknown), parentInode: 2).type == .file)
+    }
+
+    /// SECONDS ARE SIGNED AND SIXTY-FOUR BITS, and the struct's own comment
+    /// records what held them as UInt32 cost: "everything before 1970 read
+    /// back as a date in the far future and everything after 2038 was
+    /// truncated -- and neither showed up as an error, only as a wrong date
+    /// in the Finder". ext4's real range is roughly 1901 to 2446.
+    @Test func timestampsOutsideTheUInt32RangeSurvive() {
+        let preEpoch: Int64 = -2_208_988_800      // 1900-01-01
+        let post2038: Int64 = 4_102_444_800       // 2100-01-01
+        let attrs = EXT4Volume.attributes(from: stat(atime: preEpoch, mtime: post2038,
+                                                     ctime: preEpoch, crtime: post2038),
+                                          parentInode: 2)
+        #expect(attrs.accessTime.tv_sec == Int(preEpoch), "a pre-1970 timestamp wrapped")
+        #expect(attrs.modifyTime.tv_sec == Int(post2038), "a post-2038 timestamp truncated")
+        #expect(attrs.changeTime.tv_sec == Int(preEpoch))
+        #expect(attrs.birthTime.tv_sec == Int(post2038))
+    }
+
+    /// Nanoseconds are zero because the FFI does not carry them. Stated so
+    /// that surfacing them later is a decision rather than a surprise.
+    @Test func nanosecondsAreZeroBecauseTheFFIDoesNotCarryThem() {
+        let attrs = EXT4Volume.attributes(from: stat(), parentInode: 2)
+        #expect(attrs.accessTime.tv_nsec == 0)
+        #expect(attrs.modifyTime.tv_nsec == 0)
+        #expect(attrs.changeTime.tv_nsec == 0)
+        #expect(attrs.birthTime.tv_nsec == 0)
+    }
+
+    @Test func aLargeFileKeepsItsFullSize() {
+        let big: UInt64 = 5_000_000_000          // > 4 GiB
+        let attrs = EXT4Volume.attributes(from: stat(size: big), parentInode: 2)
+        #expect(attrs.size == big, "the size truncated through a 32-bit path")
+        #expect(attrs.allocSize == big)
+    }
+
+    @Test func hardLinkCountsAreCarriedThrough() {
+        #expect(EXT4Volume.attributes(from: stat(linkCount: 7), parentInode: 2).linkCount == 7)
+    }
+}
+
+// MARK: - The static helpers beside it
+
+@Suite("EXT4Volume helpers")
+struct EXT4VolumeHelperTests {
+
+    /// The double-slash trap: `"/" + "/foo"` is `"//foo"`, which the backend
+    /// then stats as a different path from `/foo`.
+    @Test func joiningOntoRootDoesNotDoubleTheSlash() {
+        #expect(EXT4Volume.joinPath("/", "foo") == "/foo")
+        #expect(EXT4Volume.joinPath("/dir", "foo") == "/dir/foo")
+        #expect(EXT4Volume.joinPath("/a/b", "c") == "/a/b/c")
+    }
+
+    @Test func joiningPreservesNamesThatLookLikePaths() {
+        // A file may legitimately be named with dots or spaces; the join is
+        // not a normaliser and must not become one.
+        #expect(EXT4Volume.joinPath("/", "..") == "/..")
+        #expect(EXT4Volume.joinPath("/dir", "a b") == "/dir/a b")
+        #expect(EXT4Volume.joinPath("/dir", ".hidden") == "/dir/.hidden")
+    }
+
+    /// The errno translation defaults to EIO, because a thrown error with no
+    /// recognisable code is worse for the caller than a generic I/O failure.
+    @Test func aKnownErrnoBecomesItsPOSIXCode() {
+        let backend = StubBackend()
+        backend.errno = ENOENT
+        #expect(EXT4Volume.posixError(from: backend).code == .ENOENT)
+        backend.errno = EBUSY
+        #expect(EXT4Volume.posixError(from: backend).code == .EBUSY)
+    }
+
+    @Test func aMissingOrUnknownErrnoBecomesEIO() {
+        let backend = StubBackend()
+        backend.errno = 0
+        #expect(EXT4Volume.posixError(from: backend).code == .EIO,
+                "errno 0 means the last call succeeded, so there is no specific failure to report")
+        backend.errno = 31_337
+        #expect(EXT4Volume.posixError(from: backend).code == .EIO,
+                "an errno with no POSIXErrorCode must not throw something unrecognisable")
+    }
+
+    /// The one C call that used to sit in this file now comes through the
+    /// protocol, and this is the seam that replaced it.
+    @Test func theBackendSuppliesItsOwnErrorText() {
+        let backend = StubBackend()
+        backend.message = "ext4: no space left on device"
+        #expect(backend.lastErrorMessage() == "ext4: no space left on device")
+    }
+}

--- a/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
+++ b/DiskJockeyLibraryTests/DetachedOperationWatchdogTests.swift
@@ -194,15 +194,29 @@ struct DetachedOperationWatchdogTests {
         let w = DetachedOperationWatchdog(
             label: "test",
             defaultDeadline: 100,
-            stuckDeadline: 0.1,
-            stuckCheckInterval: 0.03
+            stuckDeadline: 0.3,
+            stuckCheckInterval: 0.05
         ) { _, _ in
             fireCount.set(fireCount.get() + 1)
         }
         w.enter()
-        // Beat every 30ms for 250ms. Each heartbeat resets the clock,
-        // so we should never exceed the 100ms stuckDeadline.
-        for _ in 0..<8 {
+        // TWO RATIOS, AND BOTH MATTER.
+        //
+        // Beat every 30ms against a 300ms deadline, thirty times — so the
+        // run lasts ~900ms in total. The gap between beats is 10x the
+        // deadline, which is what makes the assertion survive a loaded
+        // machine; the total run is 3x the deadline, which is what gives it
+        // teeth, because a build where `heartbeat()` stopped resetting the
+        // clock would fire at 300ms and fail.
+        //
+        // It was 8 beats of 30ms against a 100ms deadline: teeth intact
+        // (240ms total > 100ms) but only 3.3x of jitter tolerance, and on
+        // 2026-09-11 CI it fired once. Every neighbour in this bundle that
+        // floods a pipe or sleeps is competing for the same cores, so
+        // `Task.sleep(30ms)` overshooting 100ms is not a remote event —
+        // `docs/constellation-report-2026-08-30.md` records this suite
+        // failing the same way once before.
+        for _ in 0..<30 {
             w.heartbeat()
             try await Task.sleep(nanoseconds: 30_000_000)
         }

--- a/Package.swift
+++ b/Package.swift
@@ -55,5 +55,53 @@ let package = Package(
             path: "DiskJockeyLibraryTests",
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+
+        // THE EXT4 VOLUME LOGIC, WITHOUT THE EXTENSION AROUND IT.
+        //
+        // `sources:` is a deliberate SUBSET of DiskJockeyEXT4/, not an
+        // oversight. The rest of that directory — EXT4Backend, EXT4Load,
+        // EXT4Maintenance — makes 61 calls into the fs_ext4 C ABI, so it
+        // needs the Rust static library and its bridging header, which is
+        // exactly what this target exists to avoid. What is listed here is
+        // pure Swift over pure Swift types, and it holds the logic the app
+        // -hosted suite could only reach through hand-written mirrors:
+        // the FSKit attribute-mask conversion and the item cache's
+        // path/parent validation.
+        //
+        // The Xcode target still compiles the whole directory (it is a
+        // file-system-synchronised group), so this is a second view of the
+        // same files, never a copy of them.
+        .target(
+            name: "DiskJockeyEXT4Core",
+            dependencies: ["DiskJockeyLibrary"],
+            path: "DiskJockeyEXT4",
+            // Named rather than globbed so adding a file to the directory is
+            // a decision here too — and so the warning about "unhandled
+            // files" does not become background noise that hides a real one.
+            exclude: [
+                "EXT4Backend.swift",
+                "EXT4FileSystem.swift",
+                "EXT4Load.swift",
+                "EXT4Maintenance.swift",
+                "EXT4Probe.swift",
+                "RepairXPCService.swift",
+                "DiskJockeyEXT4-Bridging-Header.h",
+                "DiskJockeyEXT4.entitlements",
+                "Info.plist",
+            ],
+            sources: [
+                "EXT4Volume.swift",
+                "FileSystemBackend.swift",
+                "EXT4Watchdog.swift",
+                "EXT4Log.swift",
+            ],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
+        .testTarget(
+            name: "DiskJockeyEXT4CoreTests",
+            dependencies: ["DiskJockeyEXT4Core", "DiskJockeyLibrary"],
+            path: "DiskJockeyEXT4CoreTests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
     ]
 )

--- a/scripts/tests/library-tests-need-no-host.sh
+++ b/scripts/tests/library-tests-need-no-host.sh
@@ -287,6 +287,54 @@ for target in DiskJockeyLibrary DiskJockeyLibraryTests; do
     esac
 done
 
+# --------------------------------- and the EXT4 subset stays free of the C ABI
+# THE WHOLE POINT OF THAT TARGET IS WHAT IT LEAVES OUT. DiskJockeyEXT4Core
+# compiles four files out of DiskJockeyEXT4/ so the EXT4 volume logic can be
+# tested with no Rust static library and nothing to launch. The other files in
+# that directory make 61 calls into the fs_ext4 C ABI; adding any of them to
+# `sources:` puts the bridging header and libfs_ext4.a back in the way, and
+# the job fails with a missing-header error that says nothing about why.
+#
+# So the rule is stated over the FILES rather than over their names: every
+# file the manifest lists must be free of C-ABI calls. A file that grows one
+# later fails here, which is the point at which somebody can still choose
+# where to put it.
+ext4_sources="$(awk '/name: "DiskJockeyEXT4Core"/,/^        \),/' "$MANIFEST" \
+                | awk '/sources: \[/,/\]/' \
+                | grep -oE '"[A-Za-z0-9_]+\.swift"' | tr -d '"')"
+if [ -z "$ext4_sources" ]; then
+    fail "could not read DiskJockeyEXT4Core's source list out of Package.swift, so nothing below was checked"
+else
+    ext4_bad=0
+    ext4_n=0
+    for src in $ext4_sources; do
+        ext4_n=$((ext4_n + 1))
+        if [ ! -f "$REPO/DiskJockeyEXT4/$src" ]; then
+            fail "DiskJockeyEXT4Core lists $src, which is not in DiskJockeyEXT4/"
+            ext4_bad=$((ext4_bad + 1))
+        # COMMENTS ARE NOT CODE, and this check failed on its own
+        # documentation first: FileSystemBackend.swift's doc comment for
+        # `lastErrorMessage()` names the `fs_ext4_last_error()` call it
+        # replaced, which is exactly the string being searched for. Drop
+        # comment-only lines before looking.
+        elif sed -e 's|^[[:space:]]*//.*||' -e 's|^[[:space:]]*[*].*||' "$REPO/DiskJockeyEXT4/$src" \
+             | grep -qE '(fs_ext4_|fs_core_|qcow2_|vhdx?_|vmdk_)[a-z0-9_]*\('; then
+            fail "DiskJockeyEXT4Core compiles $src, which calls into the C ABI: that target exists to build without the Rust static library, and with this file it cannot"
+            ext4_bad=$((ext4_bad + 1))
+        fi
+    done
+    if [ "$ext4_bad" -eq 0 ]; then
+        ok "all $ext4_n files in DiskJockeyEXT4Core are free of C-ABI calls"
+    fi
+fi
+
+# And the target is actually there. Without this the loop above prints
+# nothing and reports nothing when somebody deletes it.
+case "$manifest" in
+    *'name: "DiskJockeyEXT4Core"'*) ok "the EXT4 volume logic has a target that builds outside the extension" ;;
+    *) fail "no DiskJockeyEXT4Core target: the EXT4 volume logic is only reachable through the appex again, which is what forced the hand-written mirrors" ;;
+esac
+
 # ------------------------------------------------ the dead route stays dead
 # DiskJockeyLibraryOnly.xcscheme was the first attempt and it does not work.
 # Leaving it in the project invites the next person to wire it up again.

--- a/scripts/tests/library-tests-need-no-host.sh
+++ b/scripts/tests/library-tests-need-no-host.sh
@@ -335,6 +335,46 @@ case "$manifest" in
     *) fail "no DiskJockeyEXT4Core target: the EXT4 volume logic is only reachable through the appex again, which is what forced the hand-written mirrors" ;;
 esac
 
+# --------------------------- and the extension compiles every file beside it
+# THE LIBRARY IS SYNCHRONISED WITH ITS DIRECTORY; THE EXTENSIONS ARE NOT.
+# DiskJockeyEXT4 carries an explicit PBXSourcesBuildPhase, so a .swift file
+# added to DiskJockeyEXT4/ is compiled by NOTHING until somebody edits
+# project.pbxproj — and the file still builds under SwiftPM, so `swift test`
+# goes green while the extension does not compile at all.
+#
+# Measured 2026-09-10: EXT4Log.swift and EXT4Watchdog.swift were added to the
+# directory, passed `swift test`, passed every guard here, and failed the
+# Xcode build with "cannot find 'EXT4Watchdog' in scope" — because the target
+# was still compiling the original eight files. This check is that failure,
+# moved to somewhere it costs seconds instead of a CI round trip.
+ext4_missing=""
+ext4_phase="$(python3 -c '
+import re, sys
+s = open(sys.argv[1]).read()
+t = re.search(r"/\* DiskJockeyEXT4 \*/ = \{\n\t+isa = PBXNativeTarget;(.*?)\n\t+name = DiskJockeyEXT4;", s, re.S)
+if not t:
+    sys.exit(2)
+phases = re.search(r"buildPhases = \((.*?)\);", t.group(1), re.S).group(1)
+for pid, _ in re.findall(r"([0-9A-F]{24}) /\* ([^*]+) \*/", phases):
+    blk = re.search(re.escape(pid) + r" /\* [^*]+ \*/ = \{\n\t+isa = PBXSourcesBuildPhase;(.*?)\n\t+\};", s, re.S)
+    if blk:
+        for f in re.findall(r"/\* ([^ ]+\.swift) in Sources \*/", blk.group(1)):
+            print(f)
+' "$PBXPROJ" 2>/dev/null)"
+if [ -z "$ext4_phase" ]; then
+    fail "could not read DiskJockeyEXT4's source list out of project.pbxproj, so nothing below was checked"
+else
+    for src in "$REPO"/DiskJockeyEXT4/*.swift; do
+        base="$(basename "$src")"
+        printf '%s\n' "$ext4_phase" | grep -qxF "$base" || ext4_missing="$ext4_missing $base"
+    done
+    if [ -z "$ext4_missing" ]; then
+        ok "the DiskJockeyEXT4 target compiles every .swift file in its directory"
+    else
+        fail "DiskJockeyEXT4/ contains files the Xcode target does not compile:${ext4_missing} — that target has an explicit source list, so a new file is invisible to it until project.pbxproj says otherwise, and SwiftPM will keep passing meanwhile"
+    fi
+fi
+
 # ------------------------------------------------ the dead route stays dead
 # DiskJockeyLibraryOnly.xcscheme was the first attempt and it does not work.
 # Leaving it in the project invites the next person to wire it up again.


### PR DESCRIPTION
Stacked on #161 (which is stacked on #159). Rebase down the chain as each merges.

**No EXT4 code moved into `DiskJockeyLibrary`.** EXT4-specific logic stays EXT4-specific — `DiskJockeyEXT4Core` is a SwiftPM *view* of four files in `DiskJockeyEXT4/`, not a new home for them, and the Xcode target still compiles the whole directory as a synchronised group.

## The problem

`DiskJockeyTests/EXT4AttributeMaskTests.swift` and `EXT4ItemCacheTests.swift` are 13 cases testing hand-written **mirrors**:

```swift
// ----- begin mirror of EXT4Volume.swift attributes(from:parentInode:) -----
// UPDATE `FSKitAttributesMirror.populate(...)` BELOW to match. The
// protocol mirrors with hand-kept fidelity.
```

They pass while the original is wrong — the same defect shape as a check whose output doesn't depend on what it's meant to detect. And they were written that way for a real reason: an FSKit extension is a `.appex`, no test target can import one, so the code was unreachable.

## What actually held it in there — three references, none about the volume

| coupling | cost |
|---|---|
| `log`, a file-scope global in `EXT4FileSystem.swift` | 18 uses in `EXT4Volume.swift`, which referenced nothing else from that file. Its absence doesn't even report as an unresolved global: `log` also names the C math function, so every `log.info(…)` compiled as a member lookup on a *function reference* — 36 errors of *"reference to member 'info' cannot be resolved without a contextual type"*, naming neither the global nor its file |
| one `EXT4FileSystem.scheduleWatchdogIfNeeded()` | the watchdog static and its helpers referenced nothing from the class — two App Group defaults, a `DetachedOperationWatchdog`, and a log line |
| one `fs_ext4_last_error()` | the **only** C reference in 903 lines of otherwise pure Swift, fetching a string for a log message — and enough on its own to make the whole file need the Rust static library |

So `log` → `EXT4Log.swift`, the watchdog → `EXT4Watchdog.swift` (with `enterOperation`/`exitOperation` kept on `EXT4FileSystem` as forwarders, so `EXT4Maintenance` and `RepairXPCService` are untouched), and the error text comes through `FileSystemBackend.lastErrorMessage()` — beside the `lastErrno()` the volume was already calling on the next line. The conforming type owns the C boundary; that one call had leaked past it.

## What it buys: 27 cases against the real code

**The attribute conversion.** Every field from its own distinct value, because a field left unset and a field set from the wrong source look identical from outside — and an incomplete mask is what FSKit turns into ENOENT, i.e. *"the file I just saved has vanished"*. Plus: `crtime` landing on `birthTime` and **not** `addedTime`; `flags = 0` set rather than left unset (that's what marks the bit valid); only permission bits reaching `mode` (`0o40755` → `0o755`); setuid/sticky surviving; a nil parent becoming FSKit's sentinel `1`; every backend file type mapped; `.unknown` → `.file`; timestamps outside the UInt32 range surviving in **both** directions (1900 and 2100), which is the defect `BackendFileAttributes`' own comment records as *"only a wrong date in the Finder"*.

**The item cache**, driven through `item(forID:path:parentInode:)` itself, asserting **identity** — FSKit compares items by identity, so two equal-but-distinct objects would satisfy an `==` check and still break the kernel's view. All three documented failure modes: inode reuse after unlink+create, a hard link's second path, and one inode under two different parents (the `rust-fs-ext4` mkdir bug that made Finder draw the rename UI on `.fseventsd`). Plus per-volume isolation and 64 concurrent lookups agreeing on one object.

`item(forID:)` went from `private` to `internal` for that, with the reason recorded at the declaration.

## The guard

Extended to refuse C-ABI creep into the subset: **every file the manifest lists must be free of C-ABI calls.** Adding `EXT4Backend.swift` to `sources:` would put the bridging header and `libfs_ext4.a` back in the way and fail with a missing-header error that says nothing about why.

It failed on its own documentation first — `FileSystemBackend.swift` now names the `fs_ext4_last_error()` call it replaced — so it strips comment lines before looking. Second time today that comments-are-not-code has bitten a guard.

## Not verified locally

**The Xcode build of the extension**, which needs the Rust static libraries. `swift test` covers the four extracted files; the other six are typechecked only by CI. The one dangling reference this refactor created — `EXT4FileSystem.watchdog.heartbeat()` in `RepairXPCService.swift:138` — was found by sweeping for it, not by a compiler, so read that part carefully.

## Left alone

The two mirror files are still there. They're redundant now, but deleting a test isn't mine to decide.

Floor 190 → 215 (229 cases run).

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm