### PR TITLE
fix: a pull request against another branch got no CI, and read as clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,26 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  # EVERY PULL REQUEST, NOT ONLY THE ONES TARGETING main.
+  #
+  # This carried `branches: [main]`, which means a pull request based on
+  # another branch got NO run at all -- and GitHub then reports that PR as
+  # `CLEAN`, because a PR with no checks has no failing checks. Measured
+  # 2026-09-10 on two stacked pull requests: `gh run list --branch <head>`
+  # returned nothing for either, while `gh pr view` called both mergeable.
+  #
+  # An absent check reads exactly like a passing one to anything that scans
+  # for failures, which is the whole reason this filter is a defect rather
+  # than a preference. Stacking is how the work arrives here -- a chain four
+  # deep was open when this was found -- so the shape that gets no coverage
+  # is the shape most of the queue is in, and the coverage arrives only after
+  # the base merges and the PR is retargeted at main. That is the wrong order:
+  # the point of the gate is to know BEFORE merging.
+  #
+  # The cost is bounded. A pull request gets one run either way; this changes
+  # which pull requests get one, not how many runs each gets, and the
+  # concurrency group below still cancels superseded runs per head branch.
   pull_request:
-    branches: [main]
 
 # Cancel an in-progress run when a newer commit supersedes it: keyed per source
 # branch for PRs (head_ref), per ref for main pushes (ref_name).

--- a/scripts/tests/tags-are-tested-not-built.sh
+++ b/scripts/tests/tags-are-tested-not-built.sh
@@ -59,6 +59,20 @@ check "ci.yml still runs on main" \
 check "ci.yml still runs on pull requests" \
       "true" "$(trigger "$CI" 'on.key?("pull_request")')"
 
+# AND EVERY PULL REQUEST IS RUN, WHICHEVER BRANCH IT TARGETS.
+#
+# `pull_request: branches: [main]` gave a stacked pull request NO run at all,
+# and GitHub then reports it as `CLEAN` -- a pull request with no checks has no
+# failing checks. Measured 2026-09-10 on two of them: `gh run list --branch
+# <head>` returned nothing while `gh pr view` called both mergeable. An absent
+# check reads exactly like a passing one to anything scanning for failures.
+#
+# Asserted as "no `branches` filter" rather than "main is in the filter",
+# because the failing shape is a filter that EXCLUDES a base, and any list at
+# all excludes every base not on it.
+check "ci.yml runs on a pull request against any base branch" \
+      "true" "$(trigger "$CI" '!(on["pull_request"] || {}).is_a?(Hash) || !(on["pull_request"] || {}).key?("branches")')"
+
 # A tag run must not cancel a main run. The group keys on ref_name, which for a
 # tag is the tag itself; if someone keys it on `github.workflow` alone, pushing
 # a tag cancels whatever main is doing.


### PR DESCRIPTION
`pull_request: branches: [main]` meant a **stacked pull request got no run at all** — and GitHub then reports it as `CLEAN`, because a PR with no checks has no failing checks.

**Measured** on the two stacked PRs open at the time (#161, #162):

```
$ gh run list --branch test/mount-personalities            → (nothing)
$ gh run list --branch test/ext4-volume-without-the-appex   → (nothing)
$ gh pr view 161 --json mergeStateStatus,statusCheckRollup
  CLEAN checks=
$ gh pr view 162 --json mergeStateStatus,statusCheckRollup
  CLEAN checks=
```

An absent check reads **exactly** like a passing one to anything scanning for failures. That's what makes this a defect rather than a preference — I reported both PRs as `CLEAN` earlier today meaning "green", and they were untested.

## Why it matters more here than it sounds

Stacking is how the work arrives in this repo — a chain four deep was open when this was found (`main ← #159 ← #161 ← #162`). So the shape that got no coverage is the shape most of the queue is in, and coverage arrived only *after* the base merged and the PR was retargeted at main. That's the wrong order: the point of the gate is to know **before** merging. The stated reason for building it was to be able to merge agent-authored branches without wondering whether they work.

## Cost

Bounded. A pull request gets one run either way — this changes *which* pull requests get one, not how many runs each gets. The `concurrency` group still cancels superseded runs per head branch.

## The guard

Asserts **no `branches` filter**, not "main is in the filter" — the failing shape is a filter that *excludes* a base, and any list at all excludes every base not on it.

Arms, all failing for their stated reason, baseline green before and after:

| arm | caught |
|---|---|
| `branches: [main]` restored | the filter is back |
| `branches: [main, develop]` | a longer list is still a list |
| `pull_request:` removed entirely | the pre-existing check for the trigger's existence |

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm