### PR TITLE
feat: the XPC helper is a target, so it stops disappearing

### DIFF
--- a/DiskJockey.xcodeproj/project.pbxproj
+++ b/DiskJockey.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DA9E17A00000000000000007 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E17A00000000000000000 /* main.swift */; };
+		DA9E17A00000000000000008 /* AgentImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E17A00000000000000001 /* AgentImpl.swift */; };
+		DA9E17A00000000000000009 /* DJAgentProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E17A00000000000000002 /* DJAgentProtocol.swift */; };
+		DA9E17A0000000000000000A /* ProcessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E17A00000000000000003 /* ProcessRunner.swift */; };
+		DA9E17A0000000000000000B /* DiskJockeyAgent in Copy LaunchAgents */ = {isa = PBXBuildFile; fileRef = DA9E17A00000000000000005 /* DiskJockeyAgent */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		022580FD53834B63CA736B5E /* ErofsVolume.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425C54678D107E1DAA3C3C5D /* ErofsVolume.swift */; };
 		027139E38C99564FE69885EA /* NTFSVolume.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAA4308D6EB33A49E406790 /* NTFSVolume.swift */; };
 		02A5ECFB350AC0A504E975EB /* FSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA52B7280D02F6F8D737A4DF /* FSKit.framework */; };
@@ -46,6 +51,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DA9E17A00000000000000014 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 50A51F8A2E05892200AC6D10 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA9E17A00000000000000012;
+			remoteInfo = DiskJockeyAgent;
+		};
 		501F02692E058C51009EBB59 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 50A51F8A2E05892200AC6D10 /* Project object */;
@@ -482,6 +494,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		DA9E17A0000000000000000E /* Copy LaunchAgents */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "Contents/Library/LaunchAgents";
+			dstSubfolderSpec = 1;
+			files = (
+				DA9E17A0000000000000000B /* DiskJockeyAgent in Copy LaunchAgents */,
+			);
+			name = "Copy LaunchAgents";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		501F02572E058BAF009EBB59 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -534,6 +557,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DA9E17A00000000000000000 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		DA9E17A00000000000000001 /* AgentImpl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentImpl.swift; sourceTree = "<group>"; };
+		DA9E17A00000000000000002 /* DJAgentProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DJAgentProtocol.swift; sourceTree = "<group>"; };
+		DA9E17A00000000000000003 /* ProcessRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProcessRunner.swift; sourceTree = "<group>"; };
+		DA9E17A00000000000000004 /* DiskJockeyAgent.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = DiskJockeyAgent.entitlements; sourceTree = "<group>"; };
+		DA9E17A00000000000000005 /* DiskJockeyAgent */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = DiskJockeyAgent; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BC347BB938FDDB740155389 /* DiskJockeyEXT4.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = DiskJockeyEXT4.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E5062D8CC66429138B1AE0E /* DiskJockeyEROFS.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = DiskJockeyEROFS.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FC57EEA658C5ABB35712078 /* DiskJockeyEROFS.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = DiskJockeyEROFS.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1224,6 +1253,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		DA9E17A0000000000000000D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		501F02402E058BAF009EBB59 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1331,6 +1367,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DA9E17A00000000000000006 /* DiskJockeyAgent */ = {
+			isa = PBXGroup;
+			children = (
+				DA9E17A00000000000000000 /* main.swift */,
+				DA9E17A00000000000000001 /* AgentImpl.swift */,
+				DA9E17A00000000000000002 /* DJAgentProtocol.swift */,
+				DA9E17A00000000000000003 /* ProcessRunner.swift */,
+				DA9E17A00000000000000004 /* DiskJockeyAgent.entitlements */,
+			);
+			path = DiskJockeyAgent;
+			sourceTree = "<group>";
+		};
 		0EB438E9BA213FCCBE974E88 /* DiskJockeyNTFS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1431,7 +1479,8 @@
 				9DFB5358C058B255853B0F95 /* DiskJockeyBTRFS */,
 				4F5621A298CDBDD304305E39 /* DiskJockeyXFS */,
 				19150E0A63FF8D677B3E7C39 /* DiskJockeySQUASHFS */,
-			);
+							DA9E17A00000000000000006 /* DiskJockeyAgent */,
+);
 			sourceTree = "<group>";
 		};
 		50A51F932E05892200AC6D10 /* Products */ = {
@@ -1452,7 +1501,8 @@
 				0FC57EEA658C5ABB35712078 /* DiskJockeyEROFS.appex */,
 				8C5B7CF534C315C2E9041E92 /* DiskJockeyBTRFS.appex */,
 				F9237570A5F61E8E2766A574 /* DiskJockeyXFS.appex */,
-			);
+							DA9E17A00000000000000005 /* DiskJockeyAgent */,
+);
 			name = Products;
 			sourceTree = "<group>";
 		};
@@ -1527,6 +1577,22 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		DA9E17A00000000000000012 /* DiskJockeyAgent */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA9E17A00000000000000011 /* Build configuration list for PBXNativeTarget "DiskJockeyAgent" */;
+			buildPhases = (
+				DA9E17A0000000000000000C /* Sources */,
+				DA9E17A0000000000000000D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DiskJockeyAgent;
+			productName = DiskJockeyAgent;
+			productReference = DA9E17A00000000000000005 /* DiskJockeyAgent */;
+			productType = "com.apple.product-type.tool";
+		};
 		3652767A4E95F56A42259420 /* DiskJockeySQUASHFS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 88A5F4B9EA80BA744E30831C /* Build configuration list for PBXNativeTarget "DiskJockeySQUASHFS" */;
@@ -1621,6 +1687,7 @@
 				501F02572E058BAF009EBB59 /* Embed Foundation Extensions */,
 				501F02772E058C51009EBB59 /* Embed Frameworks */,
 				EC707CEC95F594A0FBA80A25 /* Embed ExtensionKit Extensions */,
+				DA9E17A0000000000000000E /* Copy LaunchAgents */,
 			);
 			buildRules = (
 			);
@@ -1633,6 +1700,7 @@
 				56FD87773864447044F56701 /* PBXTargetDependency */,
 				4E23DDB0581672220281A2AC /* PBXTargetDependency */,
 				12E218A9352001743993B7B7 /* PBXTargetDependency */,
+				DA9E17A00000000000000013 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				50A51F942E05892200AC6D10 /* DiskJockeyApplication */,
@@ -1835,7 +1903,8 @@
 				8E3B20692D9B65313AFCAF97 /* DiskJockeyEROFS */,
 				CFF7FB1DEDE80CE41AB38F50 /* DiskJockeyBTRFS */,
 				B08D898525E61171F97416A2 /* DiskJockeyXFS */,
-			);
+							DA9E17A00000000000000012 /* DiskJockeyAgent */,
+);
 		};
 /* End PBXProject section */
 
@@ -1951,6 +2020,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		DA9E17A0000000000000000C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA9E17A00000000000000007 /* main.swift in Sources */,
+				DA9E17A00000000000000008 /* AgentImpl.swift in Sources */,
+				DA9E17A00000000000000009 /* DJAgentProtocol.swift in Sources */,
+				DA9E17A0000000000000000A /* ProcessRunner.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		501F023F2E058BAF009EBB59 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2059,6 +2139,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		DA9E17A00000000000000013 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DiskJockeyAgent;
+			target = DA9E17A00000000000000012 /* DiskJockeyAgent */;
+			targetProxy = DA9E17A00000000000000014 /* PBXContainerItemProxy */;
+		};
 		1996BE72C26966848BDD20AF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = DiskJockeyNTFS;
@@ -2158,6 +2244,52 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		DA9E17A0000000000000000F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = DiskJockeyAgent/DiskJockeyAgent.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 4;
+				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = 43UMKXZ8P4;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				MARKETING_VERSION = 1.2.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		DA9E17A00000000000000010 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = DiskJockeyAgent/DiskJockeyAgent.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 4;
+				DEAD_CODE_STRIPPING = NO;
+				DEVELOPMENT_TEAM = 43UMKXZ8P4;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				MARKETING_VERSION = 1.2.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		0768422891ABC91AC33637F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3193,6 +3325,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		DA9E17A00000000000000011 /* Build configuration list for PBXNativeTarget "DiskJockeyAgent" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA9E17A00000000000000010 /* Release */,
+				DA9E17A0000000000000000F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		501F02542E058BAF009EBB59 /* Build configuration list for PBXNativeTarget "DiskJockeyFileProvider" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/DiskJockeyApplication/Services/FSKitMountService.swift
+++ b/DiskJockeyApplication/Services/FSKitMountService.swift
@@ -771,13 +771,36 @@ private func plural(_ n: Int, _ word: String) -> String {
 
 extension LogRepository {
     /// Append a user-visible log entry tagged with the FSKit source.
-    /// The Logs panel filters on `category`, so we keep "error" / "info" etc
-    /// for classification and stuff the subsystem context into `source`.
+    ///
+    /// WRITTEN THROUGH AppLog, NOT STRAIGHT INTO THE ARRAY, and the
+    /// difference is the whole reason this comment is long.
+    ///
+    /// `LogRepository` is an in-memory store: `addLogEntry` inserts into a
+    /// published array for the Logs panel and touches nothing else. Every
+    /// message the attach/detach flow produced therefore existed only inside
+    /// the running process — not in `app.ndjson`, not in the unified log,
+    /// gone the moment the app quit. On 2026-09-10 a user reported "I try to
+    /// add a disk image and nothing happens", and the whole flow had left no
+    /// trace anywhere on disk to read: the helper it depends on was missing,
+    /// the throw was caught, the message went into an array nobody could see
+    /// from outside, and diagnosing it took hours of guessing instead of one
+    /// `grep`.
+    ///
+    /// `AppLog` writes the NDJSON file in the shared container, and
+    /// `LogTailService` watches that directory and feeds every `*.ndjson`
+    /// line back into this very repository — so routing through it keeps the
+    /// Logs panel working AND leaves the evidence on disk. One path, not two,
+    /// so there is nothing to keep in step.
     fileprivate func logFSKit(_ message: String, category: String) {
-        addLogEntry(LogEntry(
-            message: message,
-            category: category,
-            source: "FSKit"
-        ))
+        let level: AppLogLevel
+        switch category {
+        case "error": level = .error
+        case "warn":  level = .warn
+        case "debug": level = .debug
+        default:      level = .info
+        }
+        AppLog.shared.event(kind: "app.fskit", fields: ["source": "FSKit"],
+                            level: level, message: message,
+                            scope: AppLogScope.lifecycle)
     }
 }

--- a/scripts/tests/the-agent-is-a-target.sh
+++ b/scripts/tests/the-agent-is-a-target.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# the-agent-is-a-target.sh — the XPC helper is built, embedded, and reachable.
+#
+# WHAT THIS IS ABOUT, AND WHY IT IS WORTH A FILE OF ITS OWN.
+#
+# Mounting a disk image from the UI goes app -> DJAgentClient -> XPC ->
+# DiskJockeyAgent -> `hdiutil attach` -> DiskArbitration -> FSKit extension.
+# The agent is the only unsandboxed part; the sandboxed app cannot shell out
+# to hdiutil, and diskarbitrationd does the privileged mount, so nothing here
+# needs root.
+#
+# For most of the project's life that agent was NOT a target in the Xcode
+# project. It was compiled by hand once, dropped into a DerivedData bundle,
+# and installed as a user LaunchAgent whose plist pointed INTO DerivedData.
+# Anything that cleared DerivedData -- `dev.sh clean`, Xcode's own cleanup --
+# deleted the binary and orphaned the plist, and at the next login launchd
+# had nothing to run.
+#
+# The failure that produced was: the user picks a disk image and NOTHING
+# HAPPENS. The XPC connect fails, the throw is caught, and the message goes
+# into an in-memory array. On 2026-09-10 that cost an evening of guessing,
+# with `docs/driverkit-qcow2-architecture.md`'s DriverKit fallback and an
+# untested `FSPathURLResource` path both investigated before anyone noticed
+# the helper was simply absent.
+#
+# So every load-bearing piece of that arrangement is asserted here: the
+# target exists, it is unsandboxed, the app embeds it where launchd's plist
+# expects it, the app cannot be built without it, and the facts the two sides
+# duplicate by hand still agree.
+#
+# TEXT ONLY. Runs in the ubuntu `Shell scripts` job, so it reads the project
+# file and the sources; it does not build anything.
+#
+#   bash scripts/tests/the-agent-is-a-target.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PBX="$REPO/DiskJockey.xcodeproj/project.pbxproj"
+AGENT_DIR="$REPO/DiskJockeyAgent"
+fails=0
+ok()   { printf 'ok    %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+[ -f "$PBX" ] || { echo "no project file at $PBX" >&2; exit 1; }
+
+# ------------------------------------------------------------- the target
+target_json="$(python3 - "$PBX" <<'PY'
+import json, re, sys
+s = open(sys.argv[1]).read()
+out = {"exists": False, "productType": None, "sandbox": None, "entitlements": None,
+       "sources": [], "embedded_at": None, "app_depends": False}
+m = re.search(r'/\* DiskJockeyAgent \*/ = \{\n\t+isa = PBXNativeTarget;(.*?)\n\t+name = DiskJockeyAgent;', s, re.S)
+if m:
+    out["exists"] = True
+    body = m.group(1)
+    pt = re.search(r'productType = "([^"]+)"', s[m.end():m.end()+400])
+    out["productType"] = pt.group(1) if pt else None
+    cl = re.search(r'buildConfigurationList = ([0-9A-F]{24})', body)
+    if cl:
+        lst = re.search(re.escape(cl.group(1)) + r' /\*.*?\*/ = \{\n\t+isa = XCConfigurationList;\n\t+buildConfigurations = \((.*?)\);', s, re.S)
+        for cid, _ in re.findall(r'([0-9A-F]{24}) /\* (\w+) \*/', lst.group(1) if lst else ""):
+            blk = re.search(re.escape(cid) + r' /\* \w+ \*/ = \{\n\t+isa = XCBuildConfiguration;\n\t+buildSettings = \{(.*?)\n\t+\};', s, re.S)
+            if not blk: continue
+            sb = re.search(r'ENABLE_APP_SANDBOX = (\w+);', blk.group(1))
+            en = re.search(r'CODE_SIGN_ENTITLEMENTS = ([^;]+);', blk.group(1))
+            # PER CONFIGURATION, not one value. Taking a single reading let an
+            # arm that removed the setting from Release alone pass, because
+            # Debug still carried it.
+            out.setdefault("configs", []).append({
+                "sandbox": sb.group(1) if sb else None,
+                "entitlements": en.group(1).strip('"') if en else None,
+            })
+            if sb: out["sandbox"] = sb.group(1)
+            if en: out["entitlements"] = en.group(1).strip('"')
+    ph = re.search(r'buildPhases = \((.*?)\);', body, re.S)
+    for pid, _ in re.findall(r'([0-9A-F]{24}) /\* ([^*]+) \*/', ph.group(1) if ph else ""):
+        blk = re.search(re.escape(pid) + r' /\* [^*]+ \*/ = \{\n\t+isa = PBXSourcesBuildPhase;(.*?)\n\t+\};', s, re.S)
+        if blk:
+            out["sources"] = sorted(re.findall(r'/\* ([^ ]+\.swift) in Sources \*/', blk.group(1)))
+# how the app embeds it, and whether it depends on it
+app = re.search(r'/\* DiskJockey \*/ = \{\n\t+isa = PBXNativeTarget;(.*?)\n\t+name = DiskJockey;', s, re.S)
+if app:
+    ph = re.search(r'buildPhases = \((.*?)\);', app.group(1), re.S)
+    for pid, _ in re.findall(r'([0-9A-F]{24}) /\* ([^*]+) \*/', ph.group(1) if ph else ""):
+        blk = re.search(re.escape(pid) + r' /\* [^*]+ \*/ = \{\n\t+isa = PBXCopyFilesBuildPhase;(.*?)\n\t+\};', s, re.S)
+        if blk and "DiskJockeyAgent" in blk.group(1):
+            d = re.search(r'dstPath = "?([^";]*)"?;', blk.group(1))
+            out["embedded_at"] = d.group(1) if d else ""
+    dep = re.search(r'dependencies = \((.*?)\);', app.group(1), re.S)
+    for did, _ in re.findall(r'([0-9A-F]{24}) /\* ([^*]+) \*/', dep.group(1) if dep else ""):
+        blk = re.search(re.escape(did) + r' /\* PBXTargetDependency \*/ = \{(.*?)\n\t+\};', s, re.S)
+        if blk and "DiskJockeyAgent" in blk.group(1):
+            out["app_depends"] = True
+print(json.dumps(out))
+PY
+)"
+get() { printf '%s' "$target_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('$1'))"; }
+
+if [ "$(get exists)" = "True" ]; then
+    ok "DiskJockeyAgent is a target in the Xcode project"
+else
+    fail "DiskJockeyAgent is NOT an Xcode target: it has to be hand-compiled, so it disappears on the next clean and the disk-image UI silently stops working"
+    echo "the-agent-is-a-target: $fails check(s) failed" >&2
+    exit 1
+fi
+
+case "$(get productType)" in
+    com.apple.product-type.tool) ok "and it builds as a command-line tool" ;;
+    *) fail "the agent's productType is $(get productType), not com.apple.product-type.tool" ;;
+esac
+
+# THE ONE SETTING THE HELPER EXISTS FOR. Sandboxed, it cannot run hdiutil,
+# read pluginkit state, or drive osascript — which is the entire job.
+case "$(get sandbox)" in
+    NO) ok "and it is built UNSANDBOXED, which is the only reason it exists" ;;
+    *)  fail "ENABLE_APP_SANDBOX is $(get sandbox) for the agent; sandboxed it cannot run hdiutil or read extension state, which is its whole purpose" ;;
+esac
+
+# EVERY CONFIGURATION, because a setting present in Debug and absent in
+# Release ships a sandboxed helper from a release build only.
+cfg_report="$(printf '%s' "$target_json" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+cfgs = d.get("configs") or []
+if not cfgs:
+    print("none"); raise SystemExit
+bad = [c for c in cfgs if c.get("sandbox") != "NO" or not c.get("entitlements")]
+print("ok %d" % len(cfgs) if not bad else "bad %d of %d" % (len(bad), len(cfgs)))
+')"
+case "$cfg_report" in
+    "ok "*) ok "and ${cfg_report#ok } configurations all set ENABLE_APP_SANDBOX=NO with an entitlements file" ;;
+    none)   fail "could not read the agent's build configurations" ;;
+    *)      fail "the agent's build configurations disagree ($cfg_report): a setting present in Debug and absent in Release ships a sandboxed helper from a release build" ;;
+esac
+
+ents="$(get entitlements)"
+if [ -n "$ents" ] && [ "$ents" != "None" ] && [ -f "$REPO/$ents" ]; then
+    ok "and it signs with $ents"
+    if grep -A 1 'com.apple.security.app-sandbox' "$REPO/$ents" | grep -q '<false/>'; then
+        ok "whose app-sandbox key is false"
+    else
+        fail "$ents does not set com.apple.security.app-sandbox to false"
+    fi
+else
+    fail "the agent has no CODE_SIGN_ENTITLEMENTS pointing at a file that exists (got ${ents:-none})"
+fi
+
+# Every source in the directory must be compiled, for the same reason the
+# EXT4 extension's list is checked: this target has an explicit source list.
+compiled="$(printf '%s' "$target_json" | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin)['sources']))")"
+missing=""
+for f in "$AGENT_DIR"/*.swift; do
+    b="$(basename "$f")"
+    case " $compiled " in *" $b "*) ;; *) missing="$missing $b" ;; esac
+done
+if [ -z "$missing" ]; then
+    ok "and it compiles every .swift file in DiskJockeyAgent/"
+else
+    fail "DiskJockeyAgent/ has files the target does not compile:$missing"
+fi
+
+# --------------------------------------------------- where launchd looks
+# `scripts/install-agent-dev.sh` searches DerivedData for
+# .../DiskJockey.app/Contents/Library/LaunchAgents/DiskJockeyAgent and writes
+# a plist whose Program is that path. If the app stops embedding it there,
+# the installer finds nothing and says so — but only if somebody runs it.
+embed="$(get embedded_at)"
+case "$embed" in
+    Contents/Library/LaunchAgents) ok "the app embeds it at Contents/Library/LaunchAgents, where install-agent-dev.sh looks" ;;
+    None|"") fail "the app has no copy phase embedding DiskJockeyAgent: the binary is built and then left behind in the products directory" ;;
+    *) fail "the app embeds the agent at '$embed'; install-agent-dev.sh searches Contents/Library/LaunchAgents and will not find it" ;;
+esac
+if [ -n "$(grep -c 'Contents/Library/LaunchAgents' "$REPO/scripts/install-agent-dev.sh" 2>/dev/null || echo 0)" ] \
+   && grep -q 'LaunchAgents' "$REPO/scripts/install-agent-dev.sh" 2>/dev/null; then
+    ok "and the installer agrees on that path"
+else
+    fail "scripts/install-agent-dev.sh no longer references the LaunchAgents path the app embeds into"
+fi
+
+if [ "$(get app_depends)" = "True" ]; then
+    ok "and the app target depends on the agent, so it cannot be built without one"
+else
+    fail "the app does not depend on the agent target: a build can succeed while producing no helper, which is the state that caused diskjockey's silent attach failures"
+fi
+
+# --------------------------------- the facts duplicated by hand still agree
+# Both files say, in words, that changing one without the other breaks the
+# XPC and that neither side reports why.
+agent_team="$(grep -oE 'kTeamID = "[^"]+"' "$AGENT_DIR/main.swift" 2>/dev/null | head -1 | cut -d'"' -f2)"
+app_team="$(grep -oE 'teamID = "[^"]+"' "$REPO/DiskJockeyApplication/Services/DJAgentClient.swift" 2>/dev/null | head -1 | cut -d'"' -f2)"
+if [ -n "$agent_team" ] && [ "$agent_team" = "$app_team" ]; then
+    ok "both sides pin the same team identifier ($agent_team)"
+else
+    fail "team identifier mismatch: agent says '${agent_team:-none}', app says '${app_team:-none}' — the XPC connection is then invalidated with no error at either call site"
+fi
+
+if diff -q "$AGENT_DIR/DJAgentProtocol.swift" \
+           "$REPO/DiskJockeyApplication/Services/DJAgentProtocol.swift" >/dev/null 2>&1; then
+    ok "and the two copies of DJAgentProtocol.swift are identical"
+else
+    fail "the agent's and the app's DJAgentProtocol.swift differ: an @objc protocol mismatch fails the XPC call at runtime, not at compile time"
+fi
+
+# ------------------------------------------- and a failure leaves a trace
+# The attach flow used to report only into an in-memory array, so "nothing
+# happened" left nothing on disk to read. It writes through AppLog now, which
+# LogTailService feeds back into the same panel.
+MOUNTSVC="$REPO/DiskJockeyApplication/Services/FSKitMountService.swift"
+if grep -q 'AppLog.shared.event' "$MOUNTSVC" 2>/dev/null; then
+    ok "the attach flow's log lines are written through AppLog, so they survive the process"
+else
+    fail "FSKitMountService no longer logs through AppLog: its messages go only into LogRepository's in-memory array, which is why 'nothing happens' left no evidence anywhere"
+fi
+
+if [ "$fails" -eq 0 ]; then
+    echo "the-agent-is-a-target: all checks passed"
+else
+    echo "the-agent-is-a-target: $fails check(s) failed" >&2
+fi
+exit $(( fails > 0 ))


### PR DESCRIPTION
Mounting a disk image goes app → `DJAgentClient` → XPC → **DiskJockeyAgent** → `hdiutil attach` → DiskArbitration → FSKit extension. The agent is the only unsandboxed part: the sandboxed app can't shell out to `hdiutil`, and `diskarbitrationd` performs the privileged mount — so nothing on this path needs root.

**The agent was not a target.** It was compiled by hand, dropped into a DerivedData bundle, and installed as a user LaunchAgent whose plist pointed *into DerivedData*. Anything that cleared DerivedData deleted the binary and orphaned the plist; at the next login launchd had nothing to run.

## What that produced

The user picks a disk image and **nothing happens**. The XPC connect fails, the throw is caught, and the message goes into an in-memory array. Measured on 2026-09-10:

```
$ pgrep -lf DiskJockeyAgent                          → not running
$ ls ~/Library/LaunchAgents/…diskjockey.agent.plist  → No such file or directory
$ launchctl list | grep diskjockey.agent             → nothing
$ find ~/Library/Developer/Xcode/DerivedData -name DiskJockeyAgent -path '*LaunchAgents*'
                                                     → (nothing)
```

It cost an evening — the DriverKit fallback in `docs/driverkit-qcow2-architecture.md` and an untested `FSPathURLResource` path were both investigated before anyone noticed the helper was simply absent. Building and loading it by hand made the mount work immediately: `/dev/disk5 on /Volumes/testvolume (ext4, …, fskit, mounted by christhomas)`, with `test.txt`, a resolved symlink, `subdir/` and `lost+found/`.

## The change

`DiskJockeyAgent` is now a `com.apple.product-type.tool` target — unsandboxed via `ENABLE_APP_SANDBOX = NO` plus its own entitlements file, signed with the team identity, compiling all four sources. The app **depends** on it and copies it to `Contents/Library/LaunchAgents`, the path `scripts/install-agent-dev.sh` already searches. So a build can no longer succeed while producing no helper.

Verified locally: `BUILD SUCCEEDED` for the app and all six extensions, with a 163 KB `DiskJockeyAgent` in the bundle.

## And a failure now leaves a trace

`logFSKit` inserted straight into `LogRepository`'s published array:

```swift
public func addLogEntry(_ entry: LogEntry) {
    DispatchQueue.main.async { self?.logs.insert(entry, at: 0) }   // in-memory only
```

So every message the attach flow produced lived only inside the process — not in `app.ndjson`, not in the unified log, gone when the app quit. That's *why* "nothing happens" was undiagnosable. It writes through `AppLog` now, and `LogTailService` — which watches that directory and feeds every `*.ndjson` line back into the same repository — still surfaces it in the Logs panel. One path instead of two.

## The guard

`scripts/tests/the-agent-is-a-target.sh`, 13 checks. **11 arms, every one fails for its stated reason**, baseline green before and after:

| arm | caught by |
|---|---|
| `ENABLE_APP_SANDBOX = YES` | sandboxed, it can't run hdiutil — its whole purpose |
| same, **one configuration only** | per-config reading; a single-value read let this pass at first |
| entitlements removed from one config / both | ditto — Debug-only settings ship a sandboxed release helper |
| productType changed | must stay a tool |
| copy phase removed | binary built and left in the products directory |
| target dependency removed | build succeeds producing no helper |
| a source dropped from the phase | explicit source list, same drift as `DiskJockeyEXT4` |
| team identifier changed on one side | both files say in words that this breaks XPC with no error at either call site |
| `DJAgentProtocol.swift` copies diverge | `@objc` mismatch fails at runtime, not compile time |
| `AppLog` write removed | back to messages that never leave the process |

The per-configuration weakness is worth calling out: my first version read one value for `ENABLE_APP_SANDBOX` and `CODE_SIGN_ENTITLEMENTS`, so an arm that changed only the Release config passed. It now compares every configuration.

## Not in this PR

`mount -F` (Path A / `FSPathURLResource`) is still broken — `extensionKit error 2`, extension never launches, on two builds and four configurations, while the same bundle launches fine for a block device. It's **not** on the path to working disk-image mounts, since the agent route doesn't use it. Filing separately.

https://claude.ai/code/session_01ToCzPqyw5U88GLvua5yqEm